### PR TITLE
RevitOpeningPlacement: Корректировка получения точки вставки отверстий в перекрытиях

### DIFF
--- a/RevitOpeningPlacement/Models/Extensions/CeilingAndFloorExtension.cs
+++ b/RevitOpeningPlacement/Models/Extensions/CeilingAndFloorExtension.cs
@@ -29,7 +29,7 @@ namespace RevitOpeningPlacement.Models.Extensions {
 
         public static bool IsHorizontal(this CeilingAndFloor floor) {
             var normal = floor.GetTopFace().ComputeNormal(new UV(0, 0));
-            return normal.IsPapallel(new XYZ(0, 0, 1));
+            return normal.IsParallel(new XYZ(0, 0, 1));
         }
     }
 }

--- a/RevitOpeningPlacement/Models/Extensions/HostObjectExtension.cs
+++ b/RevitOpeningPlacement/Models/Extensions/HostObjectExtension.cs
@@ -51,6 +51,22 @@ namespace RevitOpeningPlacement.Models.Extensions {
         }
 
         /// <summary>
+        /// Возвращает нижнюю поверхность <paramref name="hostObject"/>, если он является "плитным" элементом: Перекрытие | Потолок | Крыша
+        /// </summary>
+        /// <param name="hostObject">Плитный элемент: Перекрытие | Потолок | Крыша</param>
+        /// <returns>Нижнюю поверхность Перекрытия | Потолка | Крыши</returns>
+        /// <exception cref="ArgumentException">Исключение, если <paramref name="hostObject"/> не является Перекрытием | Потолком | Крышей</exception>
+        public static Face GetBottomFace(this HostObject hostObject) {
+            if(!IsVerticallyCompound(hostObject)) {
+                var faceRefs = HostObjectUtils.GetBottomFaces(hostObject);
+                return (Face) hostObject.GetGeometryObjectFromReference(faceRefs[0]);
+            } else {
+                throw new ArgumentException($"Слои структуры элемента с Id {hostObject.Id} расположены вертикально. Нельзя определить нижнюю поверхность.");
+            }
+        }
+
+
+        /// <summary>
         /// Возвращает перечисление, состоящее из внутренней и внешней поверхности <paramref name="hostObject"/>, если он является Стеной
         /// </summary>
         /// <param name="hostObject">Стена</param>
@@ -235,21 +251,6 @@ namespace RevitOpeningPlacement.Models.Extensions {
         /// <returns>True, если <paramref name="hostObject"/> - стена, иначе False (перекрытия, крыши, потолки)</returns>
         private static bool IsVerticallyCompound(this HostObject hostObject) {
             return hostObject.GetElementType<HostObjAttributes>().GetCompoundStructure().IsVerticallyCompound;
-        }
-
-        /// <summary>
-        /// Возвращает нижнюю поверхность <paramref name="hostObject"/>, если он является "плитным" элементом: Перекрытие | Потолок | Крыша
-        /// </summary>
-        /// <param name="hostObject">Плитный элемент: Перекрытие | Потолок | Крыша</param>
-        /// <returns>Нижнюю поверхность Перекрытия | Потолка | Крыши</returns>
-        /// <exception cref="ArgumentException">Исключение, если <paramref name="hostObject"/> не является Перекрытием | Потолком | Крышей</exception>
-        private static Face GetBottomFace(this HostObject hostObject) {
-            if(!IsVerticallyCompound(hostObject)) {
-                var faceRefs = HostObjectUtils.GetBottomFaces(hostObject);
-                return (Face) hostObject.GetGeometryObjectFromReference(faceRefs[0]);
-            } else {
-                throw new ArgumentException($"Слои структуры элемента с Id {hostObject.Id} расположены вертикально. Нельзя определить нижнюю поверхность.");
-            }
         }
     }
 }

--- a/RevitOpeningPlacement/Models/Extensions/LineExtension.cs
+++ b/RevitOpeningPlacement/Models/Extensions/LineExtension.cs
@@ -21,7 +21,7 @@ namespace RevitOpeningPlacement.Models.Extensions {
         }
 
         public static bool IsParallel(this Line line, Line otherLine) {
-            return line.Direction.IsPapallel(otherLine.Direction);
+            return line.Direction.IsParallel(otherLine.Direction);
         }
 
         public static bool RunAlongWall(this Line line, Wall wall) {

--- a/RevitOpeningPlacement/Models/Extensions/XYZExtension.cs
+++ b/RevitOpeningPlacement/Models/Extensions/XYZExtension.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using Autodesk.Revit.DB;
 
@@ -22,7 +22,7 @@ namespace RevitOpeningPlacement.Models.Extensions {
 #endif
 
 
-        internal static bool IsPapallel(this XYZ vector1, XYZ vector2) {
+        internal static bool IsParallel(this XYZ vector1, XYZ vector2) {
             return Math.Abs(Math.Abs(Math.Cos(vector1.AngleTo(vector2))) - 1) < 0.0001;
         }
 
@@ -45,7 +45,7 @@ namespace RevitOpeningPlacement.Models.Extensions {
         public static bool RunAlongWall(this XYZ direction, Wall wall) {
             var plane = wall.GetHorizontalNormalPlane();
             var wallLine = wall.GetLine();
-            return plane.ProjectVector(direction).IsPapallel(plane.ProjectVector(wallLine.Direction));
+            return plane.ProjectVector(direction).IsParallel(plane.ProjectVector(wallLine.Direction));
         }
 
         /// <summary>

--- a/RevitOpeningPlacement/Models/OpeningPlacement/PointFinders/FloorPointFinder.cs
+++ b/RevitOpeningPlacement/Models/OpeningPlacement/PointFinders/FloorPointFinder.cs
@@ -1,4 +1,6 @@
-﻿using Autodesk.Revit.DB;
+using System;
+
+using Autodesk.Revit.DB;
 
 using RevitClashDetective.Models.Extensions;
 
@@ -14,14 +16,17 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PointFinders {
         private readonly Clash<T, CeilingAndFloor> _clash;
 
         public FloorPointFinder(Clash<T, CeilingAndFloor> clash) {
-            _clash = clash;
+            _clash = clash ?? throw new System.ArgumentNullException(nameof(clash));
         }
 
         public XYZ GetPoint() {
             var solid = _clash.GetIntersection();
-            var maxZ = _clash.Element2.IsHorizontal() ? GetMaxZ(_clash.Element2.GetTopFace()) : solid.GetOutline().MaximumPoint.Z;
-            var point = solid.ComputeCentroid();
-            return new XYZ(point.X, point.Y, maxZ);
+            var maxZ = _clash.Element2.IsHorizontal()
+                ? GetMaxZ(_clash.Element2.GetTopFace())
+                : solid.GetOutline().MaximumPoint.Z;
+            double transformedMaxZ = _clash.Element2Transform.OfPoint(new XYZ(0, 0, maxZ)).Z;
+            XYZ xyPoint = GetPointXY(_clash);
+            return new XYZ(xyPoint.X, xyPoint.Y, transformedMaxZ);
         }
 
         /// <summary>
@@ -32,6 +37,81 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PointFinders {
         /// <returns></returns>
         public double GetMaxZ(Face horizontalFace) {
             return horizontalFace.EdgeLoops.get_Item(0).get_Item(0).AsCurve().GetEndPoint(0).Z;
+        }
+
+        /// <summary>
+        /// Возвращает точку, X и Y координаты которой соответствуют центру пересечения оси инженерного элемента 
+        /// и срединной плоскости перекрытия. В остальных случаях возвращает центр солида пересечения.
+        /// Точность координаты Z не гарантируется.
+        /// </summary>
+        /// <param name="clash"></param>
+        /// <returns></returns>
+        private XYZ GetPointXY(Clash<T, CeilingAndFloor> clash) {
+            if(clash is null) {
+                throw new ArgumentNullException(nameof(clash));
+            }
+
+            if((clash.Element1 is MEPCurve mepCurve)
+                && (mepCurve.IsVertical()
+                    || !mepCurve.IsHorizontal() && clash.Element2.IsHorizontal())) {
+
+                if(mepCurve.IsVertical()) {
+                    return mepCurve.GetLine().GetEndPoint(0);
+                } else {
+                    //здесь инженерная система не вертикальна и не горизонтальна, а перекрытие горизонтально
+                    Line mepLine = mepCurve.GetLine();
+                    //удлинена осевая линия инженерной системы на 5 м в обе стороны
+                    var elongatedMepLine = Line.CreateBound(
+                        mepLine.GetEndPoint(0) - mepLine.Direction * 16.5,
+                        mepLine.GetEndPoint(1) + mepLine.Direction * 16.5);
+
+                    //получение верхней и нижней плоскостей перекрытия в координатах активного файла ВИС
+                    var topPlane = CreateTransformedPlaneByFace(clash, clash.Element2.GetTopFace());
+                    var topPoint = elongatedMepLine.GetIntersectionWithPlane(topPlane);
+                    var bottomPlane = CreateTransformedPlaneByFace(clash, clash.Element2.GetBottomFace());
+                    var bottomPoint = elongatedMepLine.GetIntersectionWithPlane(bottomPlane);
+
+                    return (topPoint + bottomPoint) / 2;
+                }
+            } else {
+                return clash.GetIntersection().ComputeCentroid();
+            }
+        }
+
+
+        /// <summary>
+        /// Возвращает точку, которая принадлежит заданной поверхности
+        /// </summary>
+        /// <param name="face"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        private XYZ GetPointFromFace(Face face) {
+            if(face is null) {
+                throw new ArgumentNullException(nameof(face));
+            }
+
+            return face.EdgeLoops.get_Item(0).get_Item(0).AsCurve().GetEndPoint(0);
+        }
+
+        /// <summary>
+        /// Возвращает горизонтальную плоскость, 
+        /// полученную из заданной поверхности и трансформированную по заданному пересечению
+        /// </summary>
+        /// <param name="clash"></param>
+        /// <param name="face"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        private Plane CreateTransformedPlaneByFace(Clash<T, CeilingAndFloor> clash, Face face) {
+            if(clash is null) {
+                throw new ArgumentNullException(nameof(clash));
+            }
+
+            if(face is null) {
+                throw new ArgumentNullException(nameof(face));
+            }
+
+            var floorTop = clash.Element2Transform.OfPoint(GetPointFromFace(face));
+            return Plane.CreateByNormalAndOrigin(XYZ.BasisZ, floorTop);
         }
     }
 }


### PR DESCRIPTION
Скорректирован алгоритм получения точки вставки для заданий на отверстия в перекрытиях.
Теперь точка вставки - это точка пересечения срединной плоскости перекрытия и оси элемента ВИС.

Было:
![image](https://github.com/Bim4Everyone/RevitPlugins/assets/87359016/a86a215b-0753-4e09-96e5-3166c8d73247)

Стало:
![image](https://github.com/Bim4Everyone/RevitPlugins/assets/87359016/6e52899f-a652-4c3f-bcf3-22dbbd43d487)

