### PR TITLE
RevitOpeningPlacement: Добавление функционала по работе с заданиями КР-ВИС

### DIFF
--- a/RevitOpeningPlacement/GetOpeningTasksCmd.cs
+++ b/RevitOpeningPlacement/GetOpeningTasksCmd.cs
@@ -104,7 +104,7 @@ namespace RevitOpeningPlacement {
 
             var incomingTasksViewModels = GetOpeningsMepIncomingTasksViewModels(
                 incomingTasks,
-                realOpenings,
+                realOpenings.ToArray<IOpeningReal>(),
                 constructureElementsIds);
             var openingsRealViewModels = GetOpeningsRealArViewModels(mepLinks, realOpenings);
 
@@ -191,7 +191,7 @@ namespace RevitOpeningPlacement {
         /// <returns></returns>
         private ICollection<OpeningMepTaskIncomingViewModel> GetOpeningsMepIncomingTasksViewModels(
             ICollection<OpeningMepTaskIncoming> incomingTasks,
-            ICollection<OpeningRealAr> realOpenings,
+            ICollection<IOpeningReal> realOpenings,
             ICollection<ElementId> constructureElementsIds) {
 
             var incomingTasksViewModels = new HashSet<OpeningMepTaskIncomingViewModel>();

--- a/RevitOpeningPlacement/GetOpeningTasksCmd.cs
+++ b/RevitOpeningPlacement/GetOpeningTasksCmd.cs
@@ -350,16 +350,16 @@ namespace RevitOpeningPlacement {
             var navigatorModeDialog = new TaskDialog("Навигатор по заданиям для КР") {
                 MainInstruction = "Режим навигатора:"
             };
-            navigatorModeDialog.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Задания от ВИС");
-            navigatorModeDialog.AddCommandLink(TaskDialogCommandLinkId.CommandLink2, "Задания от АР");
+            navigatorModeDialog.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Задания от АР");
+            navigatorModeDialog.AddCommandLink(TaskDialogCommandLinkId.CommandLink2, "Задания от ВИС");
             navigatorModeDialog.CommonButtons = TaskDialogCommonButtons.Close;
             navigatorModeDialog.DefaultButton = TaskDialogResult.Close;
             TaskDialogResult result = navigatorModeDialog.Show();
             switch(result) {
                 case TaskDialogResult.CommandLink1:
-                return KrNavigatorMode.IncomingMep;
-                case TaskDialogResult.CommandLink2:
                 return KrNavigatorMode.IncomingAr;
+                case TaskDialogResult.CommandLink2:
+                return KrNavigatorMode.IncomingMep;
                 default:
                 throw new OperationCanceledException();
             }

--- a/RevitOpeningPlacement/GetOpeningTasksCmd.cs
+++ b/RevitOpeningPlacement/GetOpeningTasksCmd.cs
@@ -172,7 +172,7 @@ namespace RevitOpeningPlacement {
             ICollection<ElementId> constructureElementsIds = revitRepository.GetConstructureElementsIds();
             ICollection<IConstructureLinkElementsProvider> arLinks = revitRepository
                 .GetArLinks()
-                .Select(link => new ConstructureLinkElementsProvider(link) as IConstructureLinkElementsProvider)
+                .Select(link => new ConstructureLinkElementsProvider(revitRepository, link) as IConstructureLinkElementsProvider)
                 .ToArray();
 
             var incomingTasksViewModels = GetOpeningsArIncomingTasksViewModels(
@@ -455,7 +455,7 @@ namespace RevitOpeningPlacement {
                 int i = 0;
                 foreach(var constructureLink in constructureLinks) {
                     ct.ThrowIfCancellationRequested();
-                    providers.Add(new ConstructureLinkElementsProvider(constructureLink));
+                    providers.Add(new ConstructureLinkElementsProvider(revitRepository, constructureLink));
                     progress.Report(i++);
                 }
             }

--- a/RevitOpeningPlacement/GetOpeningTasksCmd.cs
+++ b/RevitOpeningPlacement/GetOpeningTasksCmd.cs
@@ -100,7 +100,7 @@ namespace RevitOpeningPlacement {
             ICollection<IMepLinkElementsProvider> mepLinks = revitRepository
                 .GetMepLinks()
                 .Select(link => new MepLinkElementsProvider(link) as IMepLinkElementsProvider)
-                .ToHashSet();
+                .ToArray();
 
             var incomingTasksViewModels = GetOpeningsMepIncomingTasksViewModels(
                 incomingTasks,
@@ -119,7 +119,51 @@ namespace RevitOpeningPlacement {
             window.Show();
         }
 
-        private void GetIncomingTaskInDocKR(UIApplication uiApplication, RevitRepository revitRepository) {
+        /// <summary>
+        /// Просмотр входящих заданий на отверстия от ВИС в файле КР
+        /// </summary>
+        /// <param name="uiApplication"></param>
+        /// <param name="revitRepository"></param>
+        /// <exception cref="OperationCanceledException"></exception>
+        private void GetIncomingTasksFromMepInDocKR(UIApplication uiApplication, RevitRepository revitRepository) {
+            if(!revitRepository.ContinueIfNotAllLinksLoaded()) {
+                throw new OperationCanceledException();
+            }
+            ICollection<OpeningMepTaskIncoming> incomingTasks = revitRepository.GetOpeningsMepTasksIncoming();
+            ICollection<OpeningRealKr> realOpenings = revitRepository.GetRealOpeningsKr();
+            ICollection<ElementId> constructureElementsIds = revitRepository.GetConstructureElementsIds();
+            ICollection<IMepLinkElementsProvider> mepLinks = revitRepository
+                .GetMepLinks()
+                .Select(link => new MepLinkElementsProvider(link) as IMepLinkElementsProvider)
+                .ToArray();
+
+            var incomingTasksViewModels = GetOpeningsMepIncomingTasksViewModels(
+                incomingTasks,
+                realOpenings.ToArray<IOpeningReal>(),
+                constructureElementsIds)
+                .ToArray<IOpeningTaskIncomingForKrViewModel>();
+            var openingsRealViewModels = GetOpeningsRealKrViewModels(
+                realOpenings,
+                (OpeningRealKr opening) => { opening.UpdateStatus(mepLinks); });
+
+            var navigatorViewModel = new ConstructureNavigatorForIncomingTasksViewModel(
+                revitRepository,
+                incomingTasksViewModels,
+                openingsRealViewModels);
+
+            var window = new NavigatorArIncomingView() { Title = PluginName, DataContext = navigatorViewModel };
+            var helper = new WindowInteropHelper(window) { Owner = uiApplication.MainWindowHandle };
+
+            window.Show();
+        }
+
+        /// <summary>
+        /// Просмотр входящих заданий на отверстия от АР в файле КР
+        /// </summary>
+        /// <param name="uiApplication"></param>
+        /// <param name="revitRepository"></param>
+        /// <exception cref="OperationCanceledException"></exception>
+        private void GetIncomingTasksFromArInDocKR(UIApplication uiApplication, RevitRepository revitRepository) {
             if(!revitRepository.ContinueIfNotAllLinksLoaded()) {
                 throw new OperationCanceledException();
             }
@@ -129,13 +173,15 @@ namespace RevitOpeningPlacement {
             ICollection<IConstructureLinkElementsProvider> arLinks = revitRepository
                 .GetArLinks()
                 .Select(link => new ConstructureLinkElementsProvider(link) as IConstructureLinkElementsProvider)
-                .ToHashSet();
+                .ToArray();
 
             var incomingTasksViewModels = GetOpeningsArIncomingTasksViewModels(
                 incomingTasks,
                 realOpenings,
                 constructureElementsIds);
-            var openingsRealViewModels = GetOpeningsRealKrViewModels(arLinks, realOpenings);
+            var openingsRealViewModels = GetOpeningsRealKrViewModels(
+                realOpenings,
+                (OpeningRealKr opening) => { opening.UpdateStatus(arLinks); });
 
             var navigatorViewModel = new ConstructureNavigatorForIncomingTasksViewModel(
                 revitRepository,
@@ -155,12 +201,12 @@ namespace RevitOpeningPlacement {
         /// <param name="realOpenings">Чистовые отверстия из текущего документа</param>
         /// <param name="constructureElementsIds">Элементы конструкций из текущего документа</param>
         /// <returns></returns>
-        private ICollection<OpeningArTaskIncomingViewModel> GetOpeningsArIncomingTasksViewModels(
+        private ICollection<IOpeningTaskIncomingForKrViewModel> GetOpeningsArIncomingTasksViewModels(
             ICollection<OpeningArTaskIncoming> incomingTasks,
             ICollection<OpeningRealKr> realOpenings,
             ICollection<ElementId> constructureElementsIds) {
 
-            var incomintTasksViewModels = new HashSet<OpeningArTaskIncomingViewModel>();
+            var incomintTasksViewModels = new HashSet<IOpeningTaskIncomingForKrViewModel>();
 
             using(var pb = GetPlatformService<IProgressDialogService>()) {
                 pb.StepValue = _progressBarStepSmall;
@@ -222,14 +268,14 @@ namespace RevitOpeningPlacement {
         }
 
         /// <summary>
-        /// Возвращает коллекцию моделей представления чистовых отверстий, размещенных в активном документа КР
+        /// Возвращает коллекцию моделей представления чистовых отверстий, размещенных в активном документе КР
         /// </summary>
-        /// <param name="arLinks">Связи АР</param>
-        /// <param name="openingsReal">Чистовые отверстия, размещенные в активном документа КР</param>
+        /// <param name="mepLinks">Связи ВИС</param>
+        /// <param name="openingsReal">Чистовые отверстия, размещенные в активном документе КР</param>
         /// <returns></returns>
         private ICollection<OpeningRealKrViewModel> GetOpeningsRealKrViewModels(
-            ICollection<IConstructureLinkElementsProvider> arLinks,
-            ICollection<OpeningRealKr> openingsReal) {
+            ICollection<OpeningRealKr> openingsReal,
+            Action<OpeningRealKr> updateStatus) {
 
             var openingsRealViewModels = new HashSet<OpeningRealKrViewModel>();
 
@@ -245,7 +291,7 @@ namespace RevitOpeningPlacement {
                 foreach(var openingReal in openingsReal) {
                     ct.ThrowIfCancellationRequested();
                     progress.Report(i);
-                    openingReal.UpdateStatus(arLinks);
+                    updateStatus.Invoke(openingReal);
                     if(openingReal.Status != OpeningModels.Enums.OpeningRealStatus.Correct) {
                         openingsRealViewModels.Add(new OpeningRealKrViewModel(openingReal));
                     }
@@ -300,13 +346,42 @@ namespace RevitOpeningPlacement {
             return false;
         }
 
+        private KrNavigatorMode GetKrNavigatorMode() {
+            var navigatorModeDialog = new TaskDialog("Навигатор по заданиям для КР") {
+                MainInstruction = "Режим навигатора:"
+            };
+            navigatorModeDialog.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Задания от ВИС");
+            navigatorModeDialog.AddCommandLink(TaskDialogCommandLinkId.CommandLink2, "Задания от АР");
+            navigatorModeDialog.CommonButtons = TaskDialogCommonButtons.Close;
+            navigatorModeDialog.DefaultButton = TaskDialogResult.Close;
+            TaskDialogResult result = navigatorModeDialog.Show();
+            switch(result) {
+                case TaskDialogResult.CommandLink1:
+                return KrNavigatorMode.IncomingMep;
+                case TaskDialogResult.CommandLink2:
+                return KrNavigatorMode.IncomingAr;
+                default:
+                throw new OperationCanceledException();
+            }
+        }
+
         /// <summary>
         /// Логика вывода окна навигатора по заданиям на отверстия в файле несущих конструкций
         /// </summary>
         /// <param name="uiApplication"></param>
         /// <param name="revitRepository"></param>
         private void GetOpeningsTaskInDocumentKR(UIApplication uiApplication, RevitRepository revitRepository) {
-            GetIncomingTaskInDocKR(uiApplication, revitRepository);
+            var navigatorMode = GetKrNavigatorMode();
+            switch(navigatorMode) {
+                case KrNavigatorMode.IncomingAr:
+                GetIncomingTasksFromArInDocKR(uiApplication, revitRepository);
+                break;
+                case KrNavigatorMode.IncomingMep:
+                GetIncomingTasksFromMepInDocKR(uiApplication, revitRepository);
+                break;
+                default:
+                throw new OperationCanceledException();
+            }
         }
 
         /// <summary>
@@ -411,20 +486,16 @@ namespace RevitOpeningPlacement {
     }
 
     /// <summary>
-    /// Перечисление режимов навигатора по заданиям на отверстиям
+    /// Перечисление режимов навигатора по заданиям на отверстиям в файле КР
     /// </summary>
-    internal enum NavigatorMode {
+    internal enum KrNavigatorMode {
         /// <summary>
-        /// Просмотр исходящих заданий
+        /// Просмотр входящих заданий от АР
         /// </summary>
-        Outgoing,
+        IncomingAr,
         /// <summary>
-        /// Просмотр входящих заданий
+        /// Просмотр входящих заданий от ВИС
         /// </summary>
-        Incoming,
-        /// <summary>
-        /// Режим просмотра не задан
-        /// </summary>
-        NotDefined
+        IncomingMep
     }
 }

--- a/RevitOpeningPlacement/Models/Configs/OpeningRealKrPlacementType.cs
+++ b/RevitOpeningPlacement/Models/Configs/OpeningRealKrPlacementType.cs
@@ -1,0 +1,15 @@
+namespace RevitOpeningPlacement.Models.Configs {
+    /// <summary>
+    /// Типы расстановки чистовых отверстий КР
+    /// </summary>
+    internal enum OpeningRealKrPlacementType {
+        /// <summary>
+        /// Расстановка на основе входящих заданий от ВИС
+        /// </summary>
+        PlaceByMep,
+        /// <summary>
+        /// Расстановка на основе входящих заданий от АР
+        /// </summary>
+        PlaceByAr
+    }
+}

--- a/RevitOpeningPlacement/Models/Configs/OpeningRealsKrConfig.cs
+++ b/RevitOpeningPlacement/Models/Configs/OpeningRealsKrConfig.cs
@@ -1,3 +1,4 @@
+
 using System;
 
 using Autodesk.Revit.DB;
@@ -11,25 +12,25 @@ using RevitClashDetective.Models.FilterModel;
 
 namespace RevitOpeningPlacement.Models.Configs {
     /// <summary>
-    /// Настройки расстановки заданий на отверстия в файле ВИС
+    /// Настройки расстановки чистовых отверстий в файле КР
     /// </summary>
-    internal class OpeningConfig : ProjectConfig {
+    internal class OpeningRealsKrConfig : ProjectConfig {
         public string RevitVersion { get; set; }
         [JsonIgnore]
         public override string ProjectConfigPath { get; set; }
         [JsonIgnore]
         public override IConfigSerializer Serializer { get; set; }
-        public MepCategoryCollection Categories { get; set; } = new MepCategoryCollection();
+        public OpeningRealKrPlacementType PlacementType { get; set; } = OpeningRealKrPlacementType.PlaceByAr;
 
-        public static OpeningConfig GetOpeningConfig(Document document) {
+        public static OpeningRealsKrConfig GetOpeningConfig(Document document) {
             if(document is null) { throw new ArgumentNullException(nameof(document)); }
 
             return new ProjectConfigBuilder()
                 .SetSerializer(new RevitClashConfigSerializer(new OpeningSerializationBinder(), document))
                 .SetPluginName(nameof(RevitOpeningPlacement))
                 .SetRevitVersion(ModuleEnvironment.RevitVersion)
-                .SetProjectConfigName(nameof(OpeningConfig) + ".json")
-                .Build<OpeningConfig>();
+                .SetProjectConfigName(nameof(OpeningRealsKrConfig) + ".json")
+                .Build<OpeningRealsKrConfig>();
         }
     }
 }

--- a/RevitOpeningPlacement/Models/Interfaces/IOpeningReal.cs
+++ b/RevitOpeningPlacement/Models/Interfaces/IOpeningReal.cs
@@ -1,4 +1,4 @@
-﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.DB;
 
 namespace RevitOpeningPlacement.Models.Interfaces {
     /// <summary>
@@ -10,5 +10,10 @@ namespace RevitOpeningPlacement.Models.Interfaces {
         /// </summary>
         /// <returns></returns>
         Element GetHost();
+
+        /// <summary>
+        /// Id экземпляра семейства чистового проема
+        /// </summary>
+        ElementId Id { get; }
     }
 }

--- a/RevitOpeningPlacement/Models/Interfaces/IOpeningTaskIncoming.cs
+++ b/RevitOpeningPlacement/Models/Interfaces/IOpeningTaskIncoming.cs
@@ -1,4 +1,4 @@
-﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.DB;
 
 namespace RevitOpeningPlacement.Models.Interfaces {
     /// <summary>
@@ -24,5 +24,26 @@ namespace RevitOpeningPlacement.Models.Interfaces {
         /// Координата точки размещения задания на отверстие в координатах активного файла-получателя заданий
         /// </summary>
         XYZ Location { get; }
+
+        /// <summary>
+        /// Тип задания на отверстие
+        /// </summary>
+        OpeningType OpeningType { get; }
+
+        /// <summary>
+        /// Id экземпляра семейства задания на отверстие
+        /// </summary>
+        ElementId Id { get; }
+
+        /// <summary>
+        /// Путь к файлу, в котором создано задание на отверстие
+        /// </summary>
+        string FileName { get; }
+
+        /// <summary>
+        /// Угол поворота задания на отверстие в радианах в координатах активного файла, 
+        /// в который подгружена связь с заданием на отверстие
+        /// </summary>
+        double Rotation { get; }
     }
 }

--- a/RevitOpeningPlacement/Models/Interfaces/IOpeningTaskIncomingForKrViewModel.cs
+++ b/RevitOpeningPlacement/Models/Interfaces/IOpeningTaskIncomingForKrViewModel.cs
@@ -1,0 +1,44 @@
+using Autodesk.Revit.DB;
+
+namespace RevitOpeningPlacement.Models.Interfaces {
+    /// <summary>
+    /// Модель представления входящего задания на отверстие для КР.
+    /// Использовать для моделей представления входящих заданий из АР и из ВИС в КР.
+    /// </summary>
+    internal interface IOpeningTaskIncomingForKrViewModel : ISelectorAndHighlighter {
+        /// <summary>
+        /// Id входящего задания на отверстие
+        /// </summary>
+        ElementId OpeningId { get; }
+
+        /// <summary>
+        /// Название файла, в котором создано задание на отверстие
+        /// </summary>
+        string FileName { get; }
+
+        /// <summary>
+        /// Диаметр задания на отверстие, если есть
+        /// </summary>
+        string Diameter { get; }
+
+        /// <summary>
+        /// Высота задания на отверстие, если есть
+        /// </summary>
+        string Height { get; }
+
+        /// <summary>
+        /// Ширина задания на отверстие, если есть
+        /// </summary>
+        string Width { get; }
+
+        /// <summary>
+        /// Статус задания на отверстие
+        /// </summary>
+        string Status { get; }
+
+        /// <summary>
+        /// Комментарий задания на отверстие
+        /// </summary>
+        string Comment { get; }
+    }
+}

--- a/RevitOpeningPlacement/Models/RealOpeningKrPlacement/AngleFinders/SingleRectangleOpeningArTaskInFloorAngleFinder.cs
+++ b/RevitOpeningPlacement/Models/RealOpeningKrPlacement/AngleFinders/SingleRectangleOpeningArTaskInFloorAngleFinder.cs
@@ -1,24 +1,23 @@
-﻿using System;
+using System;
 
 using RevitOpeningPlacement.Models.Interfaces;
 using RevitOpeningPlacement.Models.OpeningPlacement.AngleFinders;
-using RevitOpeningPlacement.OpeningModels;
 
 namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.AngleFinders {
     /// <summary>
     /// Класс, предоставляющий угол поворота для размещаемого отверстия КР 
-    /// по одному прямоугольному входящему заданию от АР на отверстие в перекрытии в горизонтальной плоскости в единицах ревита
+    /// по одному прямоугольному входящему заданию на отверстие в перекрытии в горизонтальной плоскости в единицах ревита
     /// </summary>
     internal class SingleRectangleOpeningArTaskInFloorAngleFinder : IAngleFinder {
-        private readonly OpeningArTaskIncoming _incomingTask;
+        private readonly IOpeningTaskIncoming _incomingTask;
 
 
         /// <summary>
-        /// Конструктор класса, предоставляющего угол поворота для отверстия КР, размещаемого по заданию от АР на прямоугольное отверстие в перекрытии
+        /// Конструктор класса, предоставляющего угол поворота для отверстия КР, размещаемого по заданию на прямоугольное отверстие в перекрытии
         /// </summary>
         /// <param name="incomingTask"></param>
         /// <exception cref="ArgumentNullException"></exception>
-        public SingleRectangleOpeningArTaskInFloorAngleFinder(OpeningArTaskIncoming incomingTask) {
+        public SingleRectangleOpeningArTaskInFloorAngleFinder(IOpeningTaskIncoming incomingTask) {
             _incomingTask = incomingTask ?? throw new ArgumentNullException(nameof(incomingTask));
         }
 

--- a/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/ManyOpeningArTasksInFloorParameterGetter.cs
+++ b/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/ManyOpeningArTasksInFloorParameterGetter.cs
@@ -1,28 +1,26 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using RevitOpeningPlacement.Models.Interfaces;
 using RevitOpeningPlacement.Models.OpeningPlacement;
 using RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters;
 using RevitOpeningPlacement.Models.RealOpeningKrPlacement.ValueGetters;
 using RevitOpeningPlacement.Models.RealOpeningsGeometryValueGetters;
-using RevitOpeningPlacement.OpeningModels;
 
 namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
     /// <summary>
-    /// Класс, предоставляющий параметры отверстия КР, размещаемого в перекрытии по нескольким заданиям от АР
+    /// Класс, предоставляющий параметры отверстия КР, размещаемого в перекрытии по нескольким заданиям
     /// </summary>
     internal class ManyOpeningArTasksInFloorParameterGetter : IParametersGetter {
-        private readonly ICollection<OpeningArTaskIncoming> _incomingTasks;
+        private readonly ICollection<IOpeningTaskIncoming> _incomingTasks;
 
 
         /// <summary>
-        /// Конструктор класса, предоставляющего параметры отверстия КР, размещаемого в перекрытии по нескольким заданиям от АР
+        /// Конструктор класса, предоставляющего параметры отверстия КР, размещаемого в перекрытии по нескольким заданиям
         /// </summary>
-        /// <param name="incomingTasks">Входящие задания от АР</param>
+        /// <param name="incomingTasks">Входящие задания</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public ManyOpeningArTasksInFloorParameterGetter(ICollection<OpeningArTaskIncoming> incomingTasks) {
+        public ManyOpeningArTasksInFloorParameterGetter(ICollection<IOpeningTaskIncoming> incomingTasks) {
             _incomingTasks = incomingTasks ?? throw new ArgumentNullException(nameof(incomingTasks));
         }
 
@@ -31,10 +29,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
             // габариты отверстия
             yield return new DoubleParameterGetter(
                 RealOpeningKrPlacer.RealOpeningKrInFloorHeight,
-                new RectangleOpeningInFloorHeightValueGetter(_incomingTasks.Cast<IOpeningTaskIncoming>().ToArray())).GetParamValue();
+                new RectangleOpeningInFloorHeightValueGetter(_incomingTasks)).GetParamValue();
             yield return new DoubleParameterGetter(
                 RealOpeningKrPlacer.RealOpeningKrInFloorWidth,
-                new RectangleOpeningInFloorWidthValueGetter(_incomingTasks.Cast<IOpeningTaskIncoming>().ToArray())).GetParamValue();
+                new RectangleOpeningInFloorWidthValueGetter(_incomingTasks)).GetParamValue();
 
             // текстовые данные отверстия
             yield return new StringParameterGetter(

--- a/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/ManyOpeningArTasksInWallParameterGetter.cs
+++ b/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/ManyOpeningArTasksInWallParameterGetter.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using Autodesk.Revit.DB;
 
@@ -9,26 +8,25 @@ using RevitOpeningPlacement.Models.OpeningPlacement;
 using RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters;
 using RevitOpeningPlacement.Models.RealOpeningKrPlacement.ValueGetters;
 using RevitOpeningPlacement.Models.RealOpeningsGeometryValueGetters;
-using RevitOpeningPlacement.OpeningModels;
 
 namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
     /// <summary>
-    /// Класс, предоставляющий параметры отверстия КР, размещаемого в стене по нескольким заданиям от АР
+    /// Класс, предоставляющий параметры отверстия КР, размещаемого в стене по нескольким заданиям
     /// </summary>
     internal class ManyOpeningArTasksInWallParameterGetter : IParametersGetter {
-        private readonly ICollection<OpeningArTaskIncoming> _incomingTasks;
+        private readonly ICollection<IOpeningTaskIncoming> _incomingTasks;
         private readonly IPointFinder _pointFinder;
         private readonly Wall _wall;
 
 
         /// <summary>
-        /// Конструктор класса, предоставляющего параметры отверстия КР, размещаемого в стене по нескольким заданиям от АР
+        /// Конструктор класса, предоставляющего параметры отверстия КР, размещаемого в стене по нескольким заданиям
         /// </summary>
-        /// <param name="incomingTasks">Входящие задания от АР</param>
+        /// <param name="incomingTasks">Входящие задания</param>
         /// <param name="pointFinder">Провайдер точки вставки отверстия КР</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public ManyOpeningArTasksInWallParameterGetter(ICollection<OpeningArTaskIncoming> incomingTasks, IPointFinder pointFinder, Wall wall) {
+        public ManyOpeningArTasksInWallParameterGetter(ICollection<IOpeningTaskIncoming> incomingTasks, IPointFinder pointFinder, Wall wall) {
             _incomingTasks = incomingTasks ?? throw new ArgumentNullException(nameof(incomingTasks));
             if(_incomingTasks.Count < 1) { throw new ArgumentException(nameof(incomingTasks)); }
 
@@ -41,10 +39,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
             // габариты отверстия
             yield return new DoubleParameterGetter(
                 RealOpeningKrPlacer.RealOpeningKrInWallHeight,
-                new RectangleOpeningInWallHeightValueGetter(_incomingTasks.Cast<IOpeningTaskIncoming>().ToArray(), _pointFinder)).GetParamValue();
+                new RectangleOpeningInWallHeightValueGetter(_incomingTasks, _pointFinder)).GetParamValue();
             yield return new DoubleParameterGetter(
                 RealOpeningKrPlacer.RealOpeningKrInWallWidth,
-                new RectangleOpeningInWallWidthValueGetter(_incomingTasks.Cast<IOpeningTaskIncoming>().ToArray(), _wall)).GetParamValue();
+                new RectangleOpeningInWallWidthValueGetter(_incomingTasks, _wall)).GetParamValue();
 
             // текстовые данные отверстия
             yield return new StringParameterGetter(

--- a/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/SingleOpeningArTaskInFloorParameterGetter.cs
+++ b/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/SingleOpeningArTaskInFloorParameterGetter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using RevitOpeningPlacement.Models.Interfaces;
@@ -6,22 +6,21 @@ using RevitOpeningPlacement.Models.OpeningPlacement;
 using RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters;
 using RevitOpeningPlacement.Models.RealOpeningKrPlacement.ValueGetters;
 using RevitOpeningPlacement.Models.RealOpeningsGeometryValueGetters;
-using RevitOpeningPlacement.OpeningModels;
 
 namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
     /// <summary>
-    /// Класс, предоставляющий значения параметров для КР отверстия, размещаемого по одному заданию на отверстие от АР
+    /// Класс, предоставляющий значения параметров для КР отверстия, размещаемого по одному заданию на отверстие
     /// </summary>
     internal class SingleOpeningArTaskInFloorParameterGetter : IParametersGetter {
-        private readonly OpeningArTaskIncoming _incomingTask;
+        private readonly IOpeningTaskIncoming _incomingTask;
 
 
         /// <summary>
-        /// Конструктор класса, предоставляющего значения параметров для КР отверстия, размещаемого по одному заданию на отверстие от АР
+        /// Конструктор класса, предоставляющего значения параметров для КР отверстия, размещаемого по одному заданию на отверстие
         /// </summary>
-        /// <param name="incomingTask">Входящее задание на отверстие от АР</param>
+        /// <param name="incomingTask">Входящее задание на отверстие</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public SingleOpeningArTaskInFloorParameterGetter(OpeningArTaskIncoming incomingTask) {
+        public SingleOpeningArTaskInFloorParameterGetter(IOpeningTaskIncoming incomingTask) {
             _incomingTask = incomingTask ?? throw new ArgumentNullException(nameof(incomingTask));
         }
 

--- a/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/SingleRectangleOpeningArTaskInWallParameterGetter.cs
+++ b/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/SingleRectangleOpeningArTaskInWallParameterGetter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using RevitOpeningPlacement.Models.Interfaces;
@@ -6,24 +6,23 @@ using RevitOpeningPlacement.Models.OpeningPlacement;
 using RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters;
 using RevitOpeningPlacement.Models.RealOpeningKrPlacement.ValueGetters;
 using RevitOpeningPlacement.Models.RealOpeningsGeometryValueGetters;
-using RevitOpeningPlacement.OpeningModels;
 
 namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
     /// <summary>
-    /// Класс, предоставляющий параметры для чистового прямоугольного отверстия КР, размещаемого по одному входящему заданию от АР
+    /// Класс, предоставляющий параметры для чистового прямоугольного отверстия КР, размещаемого по одному входящему заданию
     /// </summary>
     internal class SingleRectangleOpeningArTaskInWallParameterGetter : IParametersGetter {
-        private readonly OpeningArTaskIncoming _incomingTask;
+        private readonly IOpeningTaskIncoming _incomingTask;
         private readonly IPointFinder _pointFinder;
 
 
         /// <summary>
-        /// Конструктор класса, предоставляющего параметры для чистового прямоугольного отверстия КР, размещаемого по одному входящему заданию от АР
+        /// Конструктор класса, предоставляющего параметры для чистового прямоугольного отверстия КР, размещаемого по одному входящему заданию
         /// </summary>
-        /// <param name="incomingTask">Входящее задание на отверстие от АР</param>
+        /// <param name="incomingTask">Входящее задание на отверстие</param>
         /// <param name="pointFinder">Провайдер точки вставки отверстия КР</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public SingleRectangleOpeningArTaskInWallParameterGetter(OpeningArTaskIncoming incomingTask, IPointFinder pointFinder) {
+        public SingleRectangleOpeningArTaskInWallParameterGetter(IOpeningTaskIncoming incomingTask, IPointFinder pointFinder) {
             _incomingTask = incomingTask ?? throw new ArgumentNullException(nameof(incomingTask));
             _pointFinder = pointFinder ?? throw new ArgumentNullException(nameof(pointFinder));
         }

--- a/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/SingleRoundOpeningArTaskInWallParameterGetter.cs
+++ b/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/SingleRoundOpeningArTaskInWallParameterGetter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using RevitOpeningPlacement.Models.Interfaces;
@@ -6,24 +6,23 @@ using RevitOpeningPlacement.Models.OpeningPlacement;
 using RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters;
 using RevitOpeningPlacement.Models.RealOpeningKrPlacement.ValueGetters;
 using RevitOpeningPlacement.Models.RealOpeningsGeometryValueGetters;
-using RevitOpeningPlacement.OpeningModels;
 
 namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
     /// <summary>
-    /// Класс, предоставляющий параметры для чистового круглого отверстия КР, размещаемого по одному входящему заданию от АР
+    /// Класс, предоставляющий параметры для чистового круглого отверстия КР, размещаемого по одному входящему заданию
     /// </summary>
     internal class SingleRoundOpeningArTaskInWallParameterGetter : IParametersGetter {
-        private readonly OpeningArTaskIncoming _incomingTask;
+        private readonly IOpeningTaskIncoming _incomingTask;
         private readonly IPointFinder _pointFinder;
 
 
         /// <summary>
-        /// Конструктор класса, предоставляющего параметры для чистового круглого отверстия КР, размещаемого по одному входящему заданию от АР
+        /// Конструктор класса, предоставляющего параметры для чистового круглого отверстия КР, размещаемого по одному входящему заданию
         /// </summary>
-        /// <param name="incomingTask">Входящее задание на отверстие от АР</param>
+        /// <param name="incomingTask">Входящее задание на отверстие</param>
         /// <param name="pointFinder">Провайдер точки вставки отверстия КР</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public SingleRoundOpeningArTaskInWallParameterGetter(OpeningArTaskIncoming incomingTask, IPointFinder pointFinder) {
+        public SingleRoundOpeningArTaskInWallParameterGetter(IOpeningTaskIncoming incomingTask, IPointFinder pointFinder) {
             _incomingTask = incomingTask ?? throw new ArgumentNullException(nameof(incomingTask));
             _pointFinder = pointFinder ?? throw new ArgumentNullException(nameof(pointFinder));
         }

--- a/RevitOpeningPlacement/Models/RealOpeningKrPlacement/PointFinders/SingleOpeningArTaskPointFinder.cs
+++ b/RevitOpeningPlacement/Models/RealOpeningKrPlacement/PointFinders/SingleOpeningArTaskPointFinder.cs
@@ -1,23 +1,22 @@
-﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.DB;
 
 using RevitOpeningPlacement.Models.Interfaces;
 using RevitOpeningPlacement.Models.OpeningPlacement.ValueGetters;
-using RevitOpeningPlacement.OpeningModels;
 
 namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.PointFinders {
     /// <summary>
     /// Класс, предоставляющий точку вставки для чистового отверстия КР
     /// </summary>
     internal class SingleOpeningArTaskPointFinder : RoundValueGetter, IPointFinder {
-        private readonly OpeningArTaskIncoming _openingArTaskIncoming;
+        private readonly IOpeningTaskIncoming _openingArTaskIncoming;
 
 
         /// <summary>
         /// Конструктор класса, предоставляющего точку вставки для чистового отверстия КР
         /// </summary>
-        /// <param name="incomingTask">Входящее задание на отверстие от АР</param>
+        /// <param name="incomingTask">Входящее задание на отверстие</param>
         /// <exception cref="System.ArgumentNullException"></exception>
-        public SingleOpeningArTaskPointFinder(OpeningArTaskIncoming incomingTask) {
+        public SingleOpeningArTaskPointFinder(IOpeningTaskIncoming incomingTask) {
             _openingArTaskIncoming = incomingTask ?? throw new System.ArgumentNullException(nameof(incomingTask));
         }
 

--- a/RevitOpeningPlacement/Models/RealOpeningKrPlacement/Providers/ManyOpeningArTasksParameterGettersProvider.cs
+++ b/RevitOpeningPlacement/Models/RealOpeningKrPlacement/Providers/ManyOpeningArTasksParameterGettersProvider.cs
@@ -1,11 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using Autodesk.Revit.DB;
 
 using RevitOpeningPlacement.Models.Interfaces;
 using RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters;
-using RevitOpeningPlacement.OpeningModels;
 
 namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
     /// <summary>
@@ -13,7 +12,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
     /// </summary>
     internal class ManyOpeningArTasksParameterGettersProvider {
         private readonly Element _host;
-        private readonly ICollection<OpeningArTaskIncoming> _incomingTasks;
+        private readonly ICollection<IOpeningTaskIncoming> _incomingTasks;
         private readonly IPointFinder _pointFinder;
 
 
@@ -21,11 +20,11 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
         /// Конструктор класса, предоставляющего провайдеров для параметров размещаемого отверстия КР
         /// </summary>
         /// <param name="host">Основа для отверстия КР</param>
-        /// <param name="incomingTasks">Входящие задания от АР</param>
+        /// <param name="incomingTasks">Входящие задания</param>
         /// <param name="pointFinder">Провайдер точки вставки отверстия КР</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public ManyOpeningArTasksParameterGettersProvider(Element host, ICollection<OpeningArTaskIncoming> incomingTasks, IPointFinder pointFinder) {
+        public ManyOpeningArTasksParameterGettersProvider(Element host, ICollection<IOpeningTaskIncoming> incomingTasks, IPointFinder pointFinder) {
             if(host is null) { throw new ArgumentNullException(nameof(host)); }
             if(!((host is Wall) || (host is Floor))) { throw new ArgumentException(nameof(host)); }
             if(incomingTasks is null) { throw new ArgumentNullException(nameof(incomingTasks)); }

--- a/RevitOpeningPlacement/Models/RealOpeningKrPlacement/Providers/ManyOpeningArTasksPointFinderProvider.cs
+++ b/RevitOpeningPlacement/Models/RealOpeningKrPlacement/Providers/ManyOpeningArTasksPointFinderProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -8,25 +8,24 @@ using dosymep.Revit.Geometry;
 
 using RevitOpeningPlacement.Models.Interfaces;
 using RevitOpeningPlacement.Models.RealOpeningArPlacement.PointFinders;
-using RevitOpeningPlacement.OpeningModels;
 
 namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
     /// <summary>
-    /// Класс, предоставляющий интерфейс для получения точки вставки отверстия КР, размещаемого по нескольким входящим заданиям от АР
+    /// Класс, предоставляющий интерфейс для получения точки вставки отверстия КР, размещаемого по нескольким входящим заданиям
     /// </summary>
     internal class ManyOpeningArTasksPointFinderProvider {
         private readonly Element _host;
-        private readonly ICollection<OpeningArTaskIncoming> _incomingTasks;
+        private readonly ICollection<IOpeningTaskIncoming> _incomingTasks;
 
 
         /// <summary>
-        /// Конструктор класса, предоставляющего интерфейс для получения точки вставки отверстия КР, размещаемого по нескольким входящим заданиям от АР
+        /// Конструктор класса, предоставляющего интерфейс для получения точки вставки отверстия КР, размещаемого по нескольким входящим заданиям
         /// </summary>
         /// <param name="host">Основа для размещаемого отверстия КР</param>
-        /// <param name="incomingTasks">Входящие задания на отверстия от АР</param>
+        /// <param name="incomingTasks">Входящие задания на отверстия</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public ManyOpeningArTasksPointFinderProvider(Element host, ICollection<OpeningArTaskIncoming> incomingTasks) {
+        public ManyOpeningArTasksPointFinderProvider(Element host, ICollection<IOpeningTaskIncoming> incomingTasks) {
             if(host is null) { throw new ArgumentNullException(nameof(host)); }
             if(!((host is Wall) || (host is Floor))) { throw new ArgumentException(nameof(host)); }
             if(incomingTasks is null) { throw new ArgumentNullException(nameof(incomingTasks)); }
@@ -50,7 +49,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
         }
 
 
-        private BoundingBoxXYZ GetUnitedBBox(ICollection<OpeningArTaskIncoming> incomingTasks) {
+        private BoundingBoxXYZ GetUnitedBBox(ICollection<IOpeningTaskIncoming> incomingTasks) {
             return incomingTasks.Select(task => task.GetTransformedBBoxXYZ()).ToList().CreateUnitedBoundingBox();
         }
     }

--- a/RevitOpeningPlacement/Models/RealOpeningKrPlacement/Providers/SingleOpeningArTaskAngleFinderProvider.cs
+++ b/RevitOpeningPlacement/Models/RealOpeningKrPlacement/Providers/SingleOpeningArTaskAngleFinderProvider.cs
@@ -1,24 +1,23 @@
-﻿using System;
+using System;
 
 using RevitOpeningPlacement.Models.Interfaces;
 using RevitOpeningPlacement.Models.OpeningPlacement.AngleFinders;
 using RevitOpeningPlacement.Models.RealOpeningKrPlacement.AngleFinders;
-using RevitOpeningPlacement.OpeningModels;
 
 namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
     /// <summary>
     /// Класс, предоставляющий интерфейс для определения угла поворота размещаемого отверстия КР
     /// </summary>
     internal class SingleOpeningArTaskAngleFinderProvider {
-        private readonly OpeningArTaskIncoming _incomingTask;
+        private readonly IOpeningTaskIncoming _incomingTask;
 
 
         /// <summary>
         /// Конструктор класса, предоставляющего интерфейс для определения угла поворота размещаемого отверстия КР
         /// </summary>
-        /// <param name="incomingTask">Входящее задание на отверсите от АР</param>
+        /// <param name="incomingTask">Входящее задание на отверстие от АР</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public SingleOpeningArTaskAngleFinderProvider(OpeningArTaskIncoming incomingTask) {
+        public SingleOpeningArTaskAngleFinderProvider(IOpeningTaskIncoming incomingTask) {
             _incomingTask = incomingTask ?? throw new ArgumentNullException(nameof(incomingTask));
         }
 

--- a/RevitOpeningPlacement/Models/RealOpeningKrPlacement/Providers/SingleOpeningArTaskFamilySymbolProvider.cs
+++ b/RevitOpeningPlacement/Models/RealOpeningKrPlacement/Providers/SingleOpeningArTaskFamilySymbolProvider.cs
@@ -1,28 +1,26 @@
-﻿using System;
+using System;
 
 using Autodesk.Revit.DB;
 
-using RevitOpeningPlacement.OpeningModels;
-
 namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
     /// <summary>
-    /// Класс, предоставляющий типоразмер семейства чистового отверстия КР по одному заданию на отверстие от АР
+    /// Класс, предоставляющий типоразмер семейства чистового отверстия КР по одному заданию на отверстие
     /// </summary>
     internal class SingleOpeningArTaskFamilySymbolProvider {
         private readonly RevitRepository _revitRepository;
         private readonly Element _host;
-        private readonly OpeningArTaskIncoming _incomingTask;
+        private readonly OpeningType _openingTaskType;
 
 
         /// <summary>
-        /// Конструктор класса, предоставляющего типоразмер семейства чистового отверстия КР по одному заданию на отверстие от АР
+        /// Конструктор класса, предоставляющего типоразмер семейства чистового отверстия КР по одному заданию на отверстие
         /// </summary>
         /// <param name="revitRepository">Репозиторий активного документа КР, в котором будет происходить размещение чистового семейства отверстия</param>
         /// <param name="host">Хост чистового отверстия - стена или перекрытие</param>
-        /// <param name="incomingTask">Входящее задание на отверстие от АР</param>
+        /// <param name="openingTaskType">Тип проема входящего задания на отверстие</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public SingleOpeningArTaskFamilySymbolProvider(RevitRepository revitRepository, Element host, OpeningArTaskIncoming incomingTask) {
+        public SingleOpeningArTaskFamilySymbolProvider(RevitRepository revitRepository, Element host, OpeningType openingTaskType) {
             _revitRepository = revitRepository ?? throw new ArgumentNullException(nameof(revitRepository));
             if(host is null) {
                 throw new ArgumentNullException(nameof(host));
@@ -31,14 +29,14 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
                 throw new ArgumentException(nameof(host));
             }
             _host = host;
-            _incomingTask = incomingTask ?? throw new ArgumentNullException(nameof(incomingTask));
+            _openingTaskType = openingTaskType;
         }
 
 
         /// <exception cref="ArgumentException"></exception>
         public FamilySymbol GetFamilySymbol() {
             if(_host is Wall) {
-                switch(_incomingTask.OpeningType) {
+                switch(_openingTaskType) {
                     case OpeningType.WallRound:
                     return _revitRepository.GetOpeningRealKrType(OpeningType.WallRound);
                     case OpeningType.WallRectangle:
@@ -46,7 +44,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
                     return _revitRepository.GetOpeningRealKrType(OpeningType.WallRectangle);
                 }
             } else if(_host is Floor) {
-                switch(_incomingTask.OpeningType) {
+                switch(_openingTaskType) {
                     default:
                     return _revitRepository.GetOpeningRealKrType(OpeningType.FloorRectangle);
                 }

--- a/RevitOpeningPlacement/Models/RealOpeningKrPlacement/Providers/SingleOpeningArTaskParameterGettersProvider.cs
+++ b/RevitOpeningPlacement/Models/RealOpeningKrPlacement/Providers/SingleOpeningArTaskParameterGettersProvider.cs
@@ -1,25 +1,24 @@
-﻿using System;
+using System;
 
 using RevitOpeningPlacement.Models.Interfaces;
 using RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters;
-using RevitOpeningPlacement.OpeningModels;
 
 namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
     /// <summary>
-    /// Класс, предоставляющий <see cref="IParametersGetter"/> для чистового отверстия КР, размещаемого по одному заданию на отверстие от АР
+    /// Класс, предоставляющий <see cref="IParametersGetter"/> для чистового отверстия КР, размещаемого по одному заданию на отверстие
     /// </summary>
     internal class SingleOpeningArTaskParameterGettersProvider {
-        private readonly OpeningArTaskIncoming _incomingTask;
+        private readonly IOpeningTaskIncoming _incomingTask;
         private readonly IPointFinder _pointFinder;
 
 
         /// <summary>
-        /// Конструктор класса, предоставляющего <see cref="IParametersGetter"/> для чистового отверстия КР, размещаемого по одному заданию на отверстие от АР
+        /// Конструктор класса, предоставляющего <see cref="IParametersGetter"/> для чистового отверстия КР, размещаемого по одному заданию на отверстие
         /// </summary>
-        /// <param name="incomingTask">Входящее задание на отверстие от АР</param>
+        /// <param name="incomingTask">Входящее задание на отверстие</param>
         /// <param name="pointFinder">Провайдер точки вставки отверстия КР</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public SingleOpeningArTaskParameterGettersProvider(OpeningArTaskIncoming incomingTask, IPointFinder pointFinder) {
+        public SingleOpeningArTaskParameterGettersProvider(IOpeningTaskIncoming incomingTask, IPointFinder pointFinder) {
             _incomingTask = incomingTask ?? throw new ArgumentNullException(nameof(incomingTask));
             _pointFinder = pointFinder ?? throw new ArgumentNullException(nameof(pointFinder));
         }

--- a/RevitOpeningPlacement/Models/RealOpeningKrPlacement/RealOpeningKrPlacer.cs
+++ b/RevitOpeningPlacement/Models/RealOpeningKrPlacement/RealOpeningKrPlacer.cs
@@ -15,11 +15,10 @@ using RevitOpeningPlacement.Models.Extensions;
 using RevitOpeningPlacement.Models.Interfaces;
 using RevitOpeningPlacement.Models.RealOpeningKrPlacement.PointFinders;
 using RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers;
-using RevitOpeningPlacement.OpeningModels;
 
 namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
     /// <summary>
-    /// Класс для размещения чистовых отверстий КР в активном документе в местах расположений заданий на отверстия из связанных файлов АР
+    /// Класс для размещения чистовых отверстий КР в активном документе в местах расположений заданий на отверстия из связанных файлов АР или ВИС
     /// </summary>
     internal class RealOpeningKrPlacer {
         private readonly RevitRepository _revitRepository;
@@ -36,10 +35,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
 
 
         /// <summary>
-        /// Конструктор класса для размещения чистовых отверстий КР в активном документе в местах расположений заданий на отверстия из связанных файлов АР
+        /// Конструктор класса для размещения чистовых отверстий КР в активном документе в местах расположений заданий на отверстия из связанных файлов АР или ВИС
         /// </summary>
         /// <param name="revitRepository">Репозиторий активного КР документа ревита, в котором будет происходить размещение чистовых отверстий</param>
-        /// <param name="config">Конфигурация расстановки заданий на отверстия в файле КР</param>
+        /// <param name="config">Конфигурация расстановки заданий на отверстия в файле КР, в которой задается обработка заданий ВИС или АР</param>
         /// <exception cref="System.ArgumentNullException"></exception>
         public RealOpeningKrPlacer(RevitRepository revitRepository, OpeningRealsKrConfig config) {
             _revitRepository = revitRepository ?? throw new ArgumentNullException(nameof(revitRepository));
@@ -48,43 +47,80 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
 
 
         public void PlaceSingleOpeningByOneTask() {
-            if(_config.PlacementType == OpeningRealKrPlacementType.PlaceByAr) {
-                PlaceSingleOpeningByOneArTask();
-            } else if(_config.PlacementType == OpeningRealKrPlacementType.PlaceByMep) {
-
-            } else {
-                _revitRepository.ShowErrorMessage(_configErrorMessage);
-                throw new OperationCanceledException();
-            }
+            Element host = _revitRepository.PickHostForRealOpening();
+            IOpeningTaskIncoming openingTask = PickOpeningTaskIncoming(_config);
+            PlaceSingleOpeningByOneIncomingTask(host, openingTask);
         }
 
         public void PlaceUnitedOpeningByManyTasks() {
-            if(_config.PlacementType == OpeningRealKrPlacementType.PlaceByAr) {
-                PlaceUnitedOpeningByManyArTasks();
-            } else if(_config.PlacementType == OpeningRealKrPlacementType.PlaceByMep) {
-
-            } else {
-                _revitRepository.ShowErrorMessage(_configErrorMessage);
-                throw new OperationCanceledException();
-            }
+            Element host = _revitRepository.PickHostForRealOpening();
+            ICollection<IOpeningTaskIncoming> openingTasks = PickOpeningsTaskIncoming(_config);
+            PlaceUnitedOpeningByManyIncomingTasks(
+                host,
+                openingTasks.Where(opening => opening.IntersectsSolid(host.GetSolid(), host.GetBoundingBox())).ToArray()
+                );
         }
 
         public void PlaceSingleOpeningsInOneHost() {
-            if(_config.PlacementType == OpeningRealKrPlacementType.PlaceByAr) {
-                PlaceSingleOpeningsInOneHostByArTasks();
-            } else if(_config.PlacementType == OpeningRealKrPlacementType.PlaceByMep) {
+            Element host = _revitRepository.PickHostForRealOpening();
+            ICollection<IOpeningTaskIncoming> openingTasks = PickOpeningsTaskIncoming(_config);
+            PlaceSingleOpeningsInOneHostByIncomingTasks(
+                host,
+                openingTasks.Where(opening => opening.IntersectsSolid(host.GetSolid(), host.GetBoundingBox())).ToArray()
+                );
+        }
 
+        public void PlaceSingleOpeningsInManyHosts() {
+            ICollection<Element> hosts = _revitRepository.PickHostsForRealOpenings();
+            ICollection<IOpeningTaskIncoming> allOpeningTasks = GetAllOpeningsTaskIncoming(_config);
+            PlaceSingleOpeningsInManyHostsByIncomingTasks(hosts, allOpeningTasks);
+        }
+
+        /// <summary>
+        /// Возвращает входящее задание на отверстие, выбранное пользователем в соответствии с настройками
+        /// </summary>
+        /// <param name="config"></param>
+        /// <returns></returns>
+        /// <exception cref="OperationCanceledException"></exception>
+        private IOpeningTaskIncoming PickOpeningTaskIncoming(OpeningRealsKrConfig config) {
+            if(config.PlacementType == OpeningRealKrPlacementType.PlaceByAr) {
+                return _revitRepository.PickSingleOpeningArTaskIncoming();
+            } else if(config.PlacementType == OpeningRealKrPlacementType.PlaceByMep) {
+                return _revitRepository.PickSingleOpeningMepTaskIncoming();
             } else {
                 _revitRepository.ShowErrorMessage(_configErrorMessage);
                 throw new OperationCanceledException();
             }
         }
 
-        public void PlaceSingleOpeningsInManyHosts() {
-            if(_config.PlacementType == OpeningRealKrPlacementType.PlaceByAr) {
-                PlaceSingleOpeningsInManyHostsByArTasks();
-            } else if(_config.PlacementType == OpeningRealKrPlacementType.PlaceByMep) {
+        /// <summary>
+        /// Возвращает входящие задания на отверстия, выбранные пользователем в соответствии с настройками
+        /// </summary>
+        /// <param name="config"></param>
+        /// <returns></returns>
+        /// <exception cref="OperationCanceledException"></exception>
+        private ICollection<IOpeningTaskIncoming> PickOpeningsTaskIncoming(OpeningRealsKrConfig config) {
+            if(config.PlacementType == OpeningRealKrPlacementType.PlaceByAr) {
+                return _revitRepository.PickManyOpeningArTasksIncoming().ToArray<IOpeningTaskIncoming>();
+            } else if(config.PlacementType == OpeningRealKrPlacementType.PlaceByMep) {
+                return _revitRepository.PickManyOpeningMepTasksIncoming().ToArray<IOpeningTaskIncoming>();
+            } else {
+                _revitRepository.ShowErrorMessage(_configErrorMessage);
+                throw new OperationCanceledException();
+            }
+        }
 
+        /// <summary>
+        /// Возвращает все входящие задания на отверстия в соответствии с заданными настройками
+        /// </summary>
+        /// <param name="config"></param>
+        /// <returns></returns>
+        /// <exception cref="OperationCanceledException"></exception>
+        private ICollection<IOpeningTaskIncoming> GetAllOpeningsTaskIncoming(OpeningRealsKrConfig config) {
+            if(config.PlacementType == OpeningRealKrPlacementType.PlaceByAr) {
+                return _revitRepository.GetOpeningsArTasksIncoming().ToArray<IOpeningTaskIncoming>();
+            } else if(config.PlacementType == OpeningRealKrPlacementType.PlaceByMep) {
+                return _revitRepository.GetOpeningsMepTasksIncoming().ToArray<IOpeningTaskIncoming>();
             } else {
                 _revitRepository.ShowErrorMessage(_configErrorMessage);
                 throw new OperationCanceledException();
@@ -93,12 +129,9 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
 
 
         /// <summary>
-        /// Размещение чистового отверстия КР по одному заданию на отверстие из связи АР в одном хосте
+        /// Размещение чистового отверстия КР по одному заданию на отверстие из связи в одном хосте
         /// </summary>
-        private void PlaceSingleOpeningByOneArTask() {
-            Element host = _revitRepository.PickHostForRealOpening();
-            OpeningArTaskIncoming openingTask = _revitRepository.PickSingleOpeningArTaskIncoming();
-
+        private void PlaceSingleOpeningByOneIncomingTask(Element host, IOpeningTaskIncoming openingTask) {
             using(var transaction = _revitRepository.GetTransaction("Размещение одиночного отверстия")) {
                 try {
                     if(openingTask.IntersectsSolid(host.GetSolid(), host.GetBoundingBox())) {
@@ -116,14 +149,9 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         }
 
         /// <summary>
-        /// Размещение объединенного чистового отверстия КР по одному или нескольким заданиям на отверстия из связи(ей) АР в одном хосте
+        /// Размещение объединенного чистового отверстия КР по одному или нескольким заданиям на отверстия из связи(ей) в одном хосте
         /// </summary>
-        private void PlaceUnitedOpeningByManyArTasks() {
-            Element host = _revitRepository.PickHostForRealOpening();
-            HashSet<OpeningArTaskIncoming> openingTasks = _revitRepository
-                .PickManyOpeningArTasksIncoming()
-                .Where(opening => opening.IntersectsSolid(host.GetSolid(), host.GetBoundingBox()))
-                .ToHashSet();
+        private void PlaceUnitedOpeningByManyIncomingTasks(Element host, ICollection<IOpeningTaskIncoming> openingTasks) {
             try {
                 if(openingTasks.Count > 0) {
                     using(var transaction = _revitRepository.GetTransaction("Размещение объединенного отверстия")) {
@@ -141,18 +169,12 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         }
 
         /// <summary>
-        /// Размещение нескольких одиночных чистовых отверстий КР по нескольким заданиям на отверстия из связи(ей) АР без их объединения
+        /// Размещение нескольких одиночных чистовых отверстий КР по нескольким заданиям на отверстия из связи(ей) без их объединения
         /// </summary>
-        private void PlaceSingleOpeningsInOneHostByArTasks() {
-            Element host = _revitRepository.PickHostForRealOpening();
-            HashSet<OpeningArTaskIncoming> openingTasks = _revitRepository
-                .PickManyOpeningArTasksIncoming()
-                .Where(opening => opening.IntersectsSolid(host.GetSolid(), host.GetBoundingBox()))
-                .ToHashSet();
-
+        private void PlaceSingleOpeningsInOneHostByIncomingTasks(Element host, ICollection<IOpeningTaskIncoming> openingTasks) {
             StringBuilder sb = new StringBuilder();
             using(var transaction = _revitRepository.GetTransaction("Одиночные отверстия в одном хосте")) {
-                foreach(OpeningArTaskIncoming openingTask in openingTasks) {
+                foreach(IOpeningTaskIncoming openingTask in openingTasks) {
                     try {
                         PlaceByOneTask(host, openingTask);
 
@@ -170,12 +192,9 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         }
 
         /// <summary>
-        /// Размещение нескольких одиночных чистовых отверстий КР в выбранных хостах по всем заданиям на отверстия из связи(ей) АР, которые пересекаются с этими хостами
+        /// Размещение нескольких одиночных чистовых отверстий КР в выбранных хостах по всем заданиям на отверстия из связи(ей), которые пересекаются с этими хостами
         /// </summary>
-        private void PlaceSingleOpeningsInManyHostsByArTasks() {
-            ICollection<Element> hosts = _revitRepository.PickHostsForRealOpenings();
-            ICollection<OpeningArTaskIncoming> allOpeningTasks = _revitRepository.GetOpeningsArTasksIncoming();
-
+        private void PlaceSingleOpeningsInManyHostsByIncomingTasks(ICollection<Element> hosts, ICollection<IOpeningTaskIncoming> allOpeningTasks) {
             StringBuilder sb = new StringBuilder();
             using(var transaction = _revitRepository.GetTransaction("Одиночные отверстия в нескольких хостах")) {
                 using(var progressBar = _revitRepository.GetProgressDialogService()) {
@@ -190,11 +209,11 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
                     foreach(Element host in hosts) {
                         ct.ThrowIfCancellationRequested();
 
-                        ICollection<OpeningArTaskIncoming> openingTasks = allOpeningTasks.Where(opening => opening.IntersectsSolid(host.GetSolid(), host.GetBoundingBox())).ToHashSet();
+                        ICollection<IOpeningTaskIncoming> openingTasks = allOpeningTasks.Where(opening => opening.IntersectsSolid(host.GetSolid(), host.GetBoundingBox())).ToHashSet();
                         if(openingTasks.Count == 0) {
                             sb.AppendLine($"Конструкция с ID: {host.Id} не пересекается ни с одним заданием");
                         }
-                        foreach(OpeningArTaskIncoming openingTask in openingTasks) {
+                        foreach(IOpeningTaskIncoming openingTask in openingTasks) {
                             try {
                                 PlaceByOneTask(host, openingTask);
                             } catch(OpeningNotPlacedException e) {
@@ -216,15 +235,15 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
 
 
         /// <summary>
-        /// Размещает экземпляр семейства чистового отверстия по одному заданию на отверстие из АР
+        /// Размещает экземпляр семейства чистового отверстия по одному заданию на отверстие
         /// <para>Транзакция внутри метода не запускается</para>
         /// </summary>
         /// <param name="host">Основа для чистового отверстия КР - стена или перекрытие</param>
-        /// <param name="openingTask">Входящее задание на отверстие из АР</param>
+        /// <param name="openingTask">Входящее задание на отверстие</param>
         /// <exception cref="OpeningNotPlacedException"></exception>
-        private void PlaceByOneTask(Element host, OpeningArTaskIncoming openingTask) {
+        private void PlaceByOneTask(Element host, IOpeningTaskIncoming openingTask) {
             try {
-                var symbol = GetFamilySymbol(host, openingTask);
+                var symbol = GetFamilySymbol(host, openingTask.OpeningType);
                 var pointFinder = GetPointFinder(openingTask);
                 var point = pointFinder.GetPoint();
 
@@ -250,13 +269,13 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         }
 
         /// <summary>
-        /// Размещает объединенное прямоугольное чистовое отверстие по одному или нескольким заданиям на отверстия АР из коллекции
+        /// Размещает объединенное прямоугольное чистовое отверстие по одному или нескольким заданиям на отверстия из коллекции
         /// <para>Транзакция внутри метода не запускается</para>
         /// </summary>
         /// <param name="host">Основа для чистового отверстия КР</param>
-        /// <param name="incomingTasks">Входящие задания на отверстия из АР</param>
+        /// <param name="incomingTasks">Входящие задания на отверстия</param>
         /// <exception cref="OpeningNotPlacedException"></exception>
-        private void PlaceUnitedByManyTasks(Element host, ICollection<OpeningArTaskIncoming> incomingTasks) {
+        private void PlaceUnitedByManyTasks(Element host, ICollection<IOpeningTaskIncoming> incomingTasks) {
             try {
                 var symbol = GetFamilySymbol(host);
                 var pointFinder = GetPointFinder(host, incomingTasks);
@@ -283,9 +302,9 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         /// <summary>
         /// Возвращает интерфейс, предоставляющий угол поворота размещаемого КР отверстия
         /// </summary>
-        /// <param name="incomingTask">Входящее задание на отверстие от АР</param>
+        /// <param name="incomingTask">Входящее задание на отверстие</param>
         /// <returns></returns>
-        private IAngleFinder GetAngleFinder(OpeningArTaskIncoming incomingTask) {
+        private IAngleFinder GetAngleFinder(IOpeningTaskIncoming incomingTask) {
             var provider = new SingleOpeningArTaskAngleFinderProvider(incomingTask);
             return provider.GetAngleFinder();
         }
@@ -311,19 +330,19 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         /// <param name="incomingTask"></param>
         /// <param name="pointFinder"></param>
         /// <returns></returns>
-        private IParametersGetter GetParameterGetter(OpeningArTaskIncoming incomingTask, IPointFinder pointFinder) {
+        private IParametersGetter GetParameterGetter(IOpeningTaskIncoming incomingTask, IPointFinder pointFinder) {
             var provider = new SingleOpeningArTaskParameterGettersProvider(incomingTask, pointFinder);
             return provider.GetParametersGetter();
         }
 
         /// <summary>
-        /// Возвращает интерфейс, предоставляющий точку вставки отверстия КР для размещения по нескольким заданиям от АР
+        /// Возвращает интерфейс, предоставляющий точку вставки отверстия КР для размещения по нескольким заданиям
         /// </summary>
         /// <param name="host">Основа для отверстия КР</param>
-        /// <param name="incomingTasks">Входящие задания на отверстия от АР</param>
+        /// <param name="incomingTasks">Входящие задания на отверстия</param>
         /// <param name="pointFinder"></param>
         /// <returns></returns>
-        private IParametersGetter GetParameterGetter(Element host, ICollection<OpeningArTaskIncoming> incomingTasks, IPointFinder pointFinder) {
+        private IParametersGetter GetParameterGetter(Element host, ICollection<IOpeningTaskIncoming> incomingTasks, IPointFinder pointFinder) {
             var provider = new ManyOpeningArTasksParameterGettersProvider(host, incomingTasks, pointFinder);
             return provider.GetParametersGetter();
         }
@@ -331,31 +350,31 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         /// <summary>
         /// Возвращает интерфейс, предоставляющий точку вставки отверстия КР
         /// </summary>
-        /// <param name="openingTask">Входящее задание на отверстие от АР</param>
+        /// <param name="openingTask">Входящее задание на отверстие</param>
         /// <returns></returns>
-        private IPointFinder GetPointFinder(OpeningArTaskIncoming openingTask) {
+        private IPointFinder GetPointFinder(IOpeningTaskIncoming openingTask) {
             return new SingleOpeningArTaskPointFinder(openingTask);
         }
 
         /// <summary>
-        /// Возвращает интерфейс, предоставляющий точку вставки отверстия КР по нескольким заданиям от АР
+        /// Возвращает интерфейс, предоставляющий точку вставки отверстия КР по нескольким заданиям
         /// </summary>
         /// <param name="host">Основа для отверстия КР</param>
-        /// <param name="incomingTasks">Входящие задания на отверстия от АР</param>
+        /// <param name="incomingTasks">Входящие задания на отверстия</param>
         /// <returns></returns>
-        private IPointFinder GetPointFinder(Element host, ICollection<OpeningArTaskIncoming> incomingTasks) {
+        private IPointFinder GetPointFinder(Element host, ICollection<IOpeningTaskIncoming> incomingTasks) {
             var provider = new ManyOpeningArTasksPointFinderProvider(host, incomingTasks);
             return provider.GetPointFinder();
         }
 
         /// <summary>
-        /// Возвращает типоразмер чистового отверстия КР на основе хоста и входящего задания на отверстие от АР
+        /// Возвращает типоразмер чистового отверстия КР на основе хоста и типа входящего задания на отверстие
         /// </summary>
         /// <param name="host"></param>
-        /// <param name="openingTask"></param>
+        /// <param name="openingTaskType"></param>
         /// <returns></returns>
-        private FamilySymbol GetFamilySymbol(Element host, OpeningArTaskIncoming openingTask) {
-            var provider = new SingleOpeningArTaskFamilySymbolProvider(_revitRepository, host, openingTask);
+        private FamilySymbol GetFamilySymbol(Element host, OpeningType openingTaskType) {
+            var provider = new SingleOpeningArTaskFamilySymbolProvider(_revitRepository, host, openingTaskType);
             return provider.GetFamilySymbol();
         }
 

--- a/RevitOpeningPlacement/Models/RealOpeningKrPlacement/RealOpeningKrPlacer.cs
+++ b/RevitOpeningPlacement/Models/RealOpeningKrPlacement/RealOpeningKrPlacer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,6 +9,7 @@ using dosymep.Revit;
 
 using RevitClashDetective.Models.Extensions;
 
+using RevitOpeningPlacement.Models.Configs;
 using RevitOpeningPlacement.Models.Exceptions;
 using RevitOpeningPlacement.Models.Extensions;
 using RevitOpeningPlacement.Models.Interfaces;
@@ -22,6 +23,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
     /// </summary>
     internal class RealOpeningKrPlacer {
         private readonly RevitRepository _revitRepository;
+        private readonly OpeningRealsKrConfig _config;
 
         public const string RealOpeningKrDiameter = "ФОП_РАЗМ_Диаметр";
         public const string RealOpeningKrInWallWidth = "ФОП_РАЗМ_Ширина";
@@ -35,9 +37,11 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         /// Конструктор класса для размещения чистовых отверстий КР в активном документе в местах расположений заданий на отверстия из связанных файлов АР
         /// </summary>
         /// <param name="revitRepository">Репозиторий активного КР документа ревита, в котором будет происходить размещение чистовых отверстий</param>
+        /// <param name="config">Конфигурация расстановки заданий на отверстия в файле КР</param>
         /// <exception cref="System.ArgumentNullException"></exception>
-        public RealOpeningKrPlacer(RevitRepository revitRepository) {
-            _revitRepository = revitRepository ?? throw new System.ArgumentNullException(nameof(revitRepository));
+        public RealOpeningKrPlacer(RevitRepository revitRepository, OpeningRealsKrConfig config) {
+            _revitRepository = revitRepository ?? throw new ArgumentNullException(nameof(revitRepository));
+            _config = config ?? throw new ArgumentNullException(nameof(config));
         }
 
 

--- a/RevitOpeningPlacement/Models/RealOpeningKrPlacement/RealOpeningKrPlacer.cs
+++ b/RevitOpeningPlacement/Models/RealOpeningKrPlacement/RealOpeningKrPlacer.cs
@@ -32,6 +32,8 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         public const string RealOpeningKrInFloorWidth = "мод_ФОП_Габарит Б";
         public const string RealOpeningTaskId = "ФОП_ID задания";
 
+        private const string _configErrorMessage = "Настройки расстановки отверстий КР некорректны. Пересохраните их.";
+
 
         /// <summary>
         /// Конструктор класса для размещения чистовых отверстий КР в активном документе в местах расположений заданий на отверстия из связанных файлов АР
@@ -45,10 +47,55 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         }
 
 
+        public void PlaceSingleOpeningByOneTask() {
+            if(_config.PlacementType == OpeningRealKrPlacementType.PlaceByAr) {
+                PlaceSingleOpeningByOneArTask();
+            } else if(_config.PlacementType == OpeningRealKrPlacementType.PlaceByMep) {
+
+            } else {
+                _revitRepository.ShowErrorMessage(_configErrorMessage);
+                throw new OperationCanceledException();
+            }
+        }
+
+        public void PlaceUnitedOpeningByManyTasks() {
+            if(_config.PlacementType == OpeningRealKrPlacementType.PlaceByAr) {
+                PlaceUnitedOpeningByManyArTasks();
+            } else if(_config.PlacementType == OpeningRealKrPlacementType.PlaceByMep) {
+
+            } else {
+                _revitRepository.ShowErrorMessage(_configErrorMessage);
+                throw new OperationCanceledException();
+            }
+        }
+
+        public void PlaceSingleOpeningsInOneHost() {
+            if(_config.PlacementType == OpeningRealKrPlacementType.PlaceByAr) {
+                PlaceSingleOpeningsInOneHostByArTasks();
+            } else if(_config.PlacementType == OpeningRealKrPlacementType.PlaceByMep) {
+
+            } else {
+                _revitRepository.ShowErrorMessage(_configErrorMessage);
+                throw new OperationCanceledException();
+            }
+        }
+
+        public void PlaceSingleOpeningsInManyHosts() {
+            if(_config.PlacementType == OpeningRealKrPlacementType.PlaceByAr) {
+                PlaceSingleOpeningsInManyHostsByArTasks();
+            } else if(_config.PlacementType == OpeningRealKrPlacementType.PlaceByMep) {
+
+            } else {
+                _revitRepository.ShowErrorMessage(_configErrorMessage);
+                throw new OperationCanceledException();
+            }
+        }
+
+
         /// <summary>
         /// Размещение чистового отверстия КР по одному заданию на отверстие из связи АР в одном хосте
         /// </summary>
-        public void PlaceSingleOpeningByOneTask() {
+        private void PlaceSingleOpeningByOneArTask() {
             Element host = _revitRepository.PickHostForRealOpening();
             OpeningArTaskIncoming openingTask = _revitRepository.PickSingleOpeningArTaskIncoming();
 
@@ -71,7 +118,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         /// <summary>
         /// Размещение объединенного чистового отверстия КР по одному или нескольким заданиям на отверстия из связи(ей) АР в одном хосте
         /// </summary>
-        public void PlaceUnitedOpeningByManyTasks() {
+        private void PlaceUnitedOpeningByManyArTasks() {
             Element host = _revitRepository.PickHostForRealOpening();
             HashSet<OpeningArTaskIncoming> openingTasks = _revitRepository
                 .PickManyOpeningArTasksIncoming()
@@ -96,7 +143,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         /// <summary>
         /// Размещение нескольких одиночных чистовых отверстий КР по нескольким заданиям на отверстия из связи(ей) АР без их объединения
         /// </summary>
-        public void PlaceSingleOpeningsInOneHost() {
+        private void PlaceSingleOpeningsInOneHostByArTasks() {
             Element host = _revitRepository.PickHostForRealOpening();
             HashSet<OpeningArTaskIncoming> openingTasks = _revitRepository
                 .PickManyOpeningArTasksIncoming()
@@ -125,7 +172,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         /// <summary>
         /// Размещение нескольких одиночных чистовых отверстий КР в выбранных хостах по всем заданиям на отверстия из связи(ей) АР, которые пересекаются с этими хостами
         /// </summary>
-        public void PlaceSingleOpeningsInManyHosts() {
+        private void PlaceSingleOpeningsInManyHostsByArTasks() {
             ICollection<Element> hosts = _revitRepository.PickHostsForRealOpenings();
             ICollection<OpeningArTaskIncoming> allOpeningTasks = _revitRepository.GetOpeningsArTasksIncoming();
 

--- a/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ValueGetters/KrTaskIdValueGetter.cs
+++ b/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ValueGetters/KrTaskIdValueGetter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,35 +6,34 @@ using System.Linq;
 using RevitClashDetective.Models.Value;
 
 using RevitOpeningPlacement.Models.Interfaces;
-using RevitOpeningPlacement.OpeningModels;
 
 namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ValueGetters {
     /// <summary>
     /// Класс, предоставляющий значение параметра <see cref="RealOpeningKrPlacer.RealOpeningTaskId"/> для отверстия КР
     /// </summary>
     internal class KrTaskIdValueGetter : IValueGetter<StringParamValue> {
-        private ICollection<OpeningArTaskIncoming> _incomingTasks;
+        private readonly ICollection<IOpeningTaskIncoming> _incomingTasks;
 
 
         /// <summary>
         /// Конструктор класса, предоставляющего значение параметра <see cref="RealOpeningKrPlacer.RealOpeningTaskId"/>
         /// </summary>
-        /// <param name="openingArTaskIncoming">Входящее задание на отверстие от АР</param>
+        /// <param name="openingArTaskIncoming">Входящее задание на отверстие</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public KrTaskIdValueGetter(OpeningArTaskIncoming openingArTaskIncoming) {
+        public KrTaskIdValueGetter(IOpeningTaskIncoming openingArTaskIncoming) {
             if(openingArTaskIncoming == null) { throw new ArgumentNullException(nameof(openingArTaskIncoming)); }
 
-            _incomingTasks = new OpeningArTaskIncoming[] { openingArTaskIncoming };
+            _incomingTasks = new IOpeningTaskIncoming[] { openingArTaskIncoming };
         }
 
 
         /// <summary>
         /// Конструктор класса, предоставляющего значение параметра <see cref="RealOpeningKrPlacer.RealOpeningTaskId"/>
         /// </summary>
-        /// <param name="openingArTaskIncoming">Входящие задания на отверстия от АР</param>
+        /// <param name="openingArTaskIncoming">Входящие задания на отверстия</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public KrTaskIdValueGetter(ICollection<OpeningArTaskIncoming> openingArTaskIncoming) {
+        public KrTaskIdValueGetter(ICollection<IOpeningTaskIncoming> openingArTaskIncoming) {
             if(openingArTaskIncoming == null) { throw new ArgumentNullException(nameof(openingArTaskIncoming)); }
             if(openingArTaskIncoming.Count < 1) { throw new ArgumentOutOfRangeException(nameof(openingArTaskIncoming)); }
 

--- a/RevitOpeningPlacement/Models/RevitRepository.cs
+++ b/RevitOpeningPlacement/Models/RevitRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -661,7 +661,15 @@ namespace RevitOpeningPlacement.Models {
         /// </summary>
         /// <returns></returns>
         public ICollection<OpeningRealAr> GetRealOpeningsAr() {
-            return GetOpeningsAr(_document)
+            return GetRealOpeningsAr(_document);
+        }
+
+        /// <summary>
+        /// Возвращает коллекцию чистовых экземпляров семейств отверстий из заданного АР документа Revit
+        /// </summary>
+        /// <returns></returns>
+        public ICollection<OpeningRealAr> GetRealOpeningsAr(Document document) {
+            return GetOpeningsAr(document)
                 .Select(famInst => new OpeningRealAr(famInst))
                 .ToHashSet();
         }
@@ -671,7 +679,15 @@ namespace RevitOpeningPlacement.Models {
         /// </summary>
         /// <returns></returns>
         public ICollection<OpeningRealKr> GetRealOpeningsKr() {
-            return new FilteredElementCollector(_document)
+            return GetRealOpeningsKr(_document);
+        }
+
+        /// <summary>
+        /// Возвращает коллекцию чистовых экземпляров семейств отверстий из заданного КР документа Revit
+        /// </summary>
+        /// <returns></returns>
+        public ICollection<OpeningRealKr> GetRealOpeningsKr(Document document) {
+            return new FilteredElementCollector(document)
                 .WhereElementIsNotElementType()
                 .WherePasses(FiltersInitializer.GetFilterByAllUsedOpeningsKrCategories())
                 .OfClass(typeof(FamilyInstance))
@@ -688,7 +704,16 @@ namespace RevitOpeningPlacement.Models {
         /// </summary>
         /// <returns></returns>
         public ICollection<ElementId> GetConstructureElementsIds() {
-            return new FilteredElementCollector(_document)
+            return GetConstructureElementsIds(_document);
+        }
+
+        /// <summary>
+        /// Возвращает коллекцию Id всех элементов конструкций из заданного документа ревита, 
+        /// для которых создаются задания на отверстия
+        /// </summary>
+        /// <returns></returns>
+        public ICollection<ElementId> GetConstructureElementsIds(Document document) {
+            return new FilteredElementCollector(document)
                 .WhereElementIsNotElementType()
                 .WherePasses(FiltersInitializer.GetFilterByAllUsedStructureCategories())
                 .ToElementIds();

--- a/RevitOpeningPlacement/OpeningModels/OpeningArTaskIncoming.cs
+++ b/RevitOpeningPlacement/OpeningModels/OpeningArTaskIncoming.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -36,7 +36,6 @@ namespace RevitOpeningPlacement.OpeningModels {
             : base(openingTask) {
             _revitRepository = revitRepository ?? throw new ArgumentNullException(nameof(revitRepository));
             FileName = _familyInstance.Document.PathName;
-            Id = _familyInstance.Id;
             Transform = transform;
             Location = Transform.OfPoint((_familyInstance.Location as LocationPoint).Point);
             // https://forums.autodesk.com/t5/revit-api-forum/get-angle-from-transform-basisx-basisy-and-basisz/td-p/5326059
@@ -61,7 +60,6 @@ namespace RevitOpeningPlacement.OpeningModels {
 
         public string FileName { get; }
 
-        public ElementId Id { get; }
 
         /// <summary>
         /// Трансформация связанного файла с заданием на отверстие относительно активного документа - получателя заданий

--- a/RevitOpeningPlacement/OpeningModels/OpeningMepTaskIncoming.cs
+++ b/RevitOpeningPlacement/OpeningModels/OpeningMepTaskIncoming.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -248,7 +248,7 @@ namespace RevitOpeningPlacement.OpeningModels {
         /// <param name="realOpenings">Коллекция чистовых отверстий, размещенных в активном документе-получателе заданий на отверстия</param>
         /// <param name="constructureElementsIds">Коллекция элементов конструкций в активном документе-получателе заданий на отверстия</param>
         /// <exception cref="ArgumentException"></exception>
-        public void UpdateStatusAndHostName(ICollection<OpeningRealAr> realOpenings, ICollection<ElementId> constructureElementsIds) {
+        public void UpdateStatusAndHostName(ICollection<IOpeningReal> realOpenings, ICollection<ElementId> constructureElementsIds) {
             var thisOpeningSolid = GetSolid();
             var thisOpeningBBox = GetTransformedBBoxXYZ();
 
@@ -344,7 +344,7 @@ namespace RevitOpeningPlacement.OpeningModels {
         /// <param name="thisOpeningSolid">Солид текущего задания на отверстие в координатах активного файла - получателя заданий</param>
         /// <param name="thisOpeningBBox">Бокс текущего задания на отверстие в координатах активного файла - получателя заданий</param>
         /// <returns></returns>
-        private ICollection<ElementId> GetIntersectingOpeningsIds(ICollection<OpeningRealAr> realOpenings, Solid thisOpeningSolid, BoundingBoxXYZ thisOpeningBBox) {
+        private ICollection<ElementId> GetIntersectingOpeningsIds(ICollection<IOpeningReal> realOpenings, Solid thisOpeningSolid, BoundingBoxXYZ thisOpeningBBox) {
             if((thisOpeningSolid is null) || (thisOpeningSolid.Volume <= 0)) {
                 return Array.Empty<ElementId>();
             } else {

--- a/RevitOpeningPlacement/OpeningModels/OpeningRealAr.cs
+++ b/RevitOpeningPlacement/OpeningModels/OpeningRealAr.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -26,7 +26,6 @@ namespace RevitOpeningPlacement.OpeningModels {
         /// </summary>
         /// <param name="openingReal">Экземпляр семейства чистового отверстия АР, идущего на чертежи</param>
         public OpeningRealAr(FamilyInstance openingReal) : base(openingReal) {
-            Id = _familyInstance.Id;
             Diameter = GetFamilyInstanceStringParamValueOrEmpty(RealOpeningArPlacer.RealOpeningArDiameter);
             Width = GetFamilyInstanceStringParamValueOrEmpty(RealOpeningArPlacer.RealOpeningArWidth);
             Height = GetFamilyInstanceStringParamValueOrEmpty(RealOpeningArPlacer.RealOpeningArHeight);
@@ -38,11 +37,6 @@ namespace RevitOpeningPlacement.OpeningModels {
                 string.Empty);
         }
 
-
-        /// <summary>
-        /// Id экземпляра семейства задания на отверстие
-        /// </summary>
-        public ElementId Id { get; }
 
         /// <summary>
         /// Диаметр в мм, если есть

--- a/RevitOpeningPlacement/OpeningModels/OpeningRealAr.cs
+++ b/RevitOpeningPlacement/OpeningModels/OpeningRealAr.cs
@@ -1,14 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using Autodesk.Revit.DB;
 
 using dosymep.Bim4Everyone;
 using dosymep.Bim4Everyone.SystemParams;
 using dosymep.Revit;
-
-using RevitClashDetective.Models.Extensions;
 
 using RevitOpeningPlacement.Models.Interfaces;
 using RevitOpeningPlacement.Models.RealOpeningArPlacement;
@@ -19,7 +16,7 @@ namespace RevitOpeningPlacement.OpeningModels {
     /// Класс, обозначающий чистовое отверстие АР, идущее на чертежи. 
     /// Использовать для обертки проемов из файла АР, когда активный файл - этот же АР или файл ВИС.
     /// </summary>
-    internal class OpeningRealAr : OpeningRealBase, IEquatable<OpeningRealAr> {
+    internal class OpeningRealAr : OpeningRealByMep, IEquatable<OpeningRealAr> {
         /// <summary>
         /// Создает экземпляр класса <see cref="OpeningRealAr"/>. 
         /// Использовать для обертки проемов из файла АР, когда активный файл - этот же АР или файл ВИС.
@@ -89,181 +86,7 @@ namespace RevitOpeningPlacement.OpeningModels {
         /// </summary>
         /// <param name="mepLinkElementsProviders">Коллекция связей с элементами ВИС и заданиями на отверстиями</param>
         public void UpdateStatus(ICollection<IMepLinkElementsProvider> mepLinkElementsProviders) {
-
-            Solid thisOpeningRealSolid = GetSolid();
-            Solid thisOpeningRealSolidAfterIntersection = thisOpeningRealSolid;
-
-            foreach(IMepLinkElementsProvider link in mepLinkElementsProviders) {
-                ICollection<ElementId> intersectingLinkElements = GetIntersectingLinkElements(link);
-                if(intersectingLinkElements.Count > 0) {
-                    if(LinkElementsIntersectHost(link, intersectingLinkElements)) {
-                        Status = OpeningRealStatus.NotActual;
-                        return;
-                    }
-
-                    ICollection<Solid> linkElementsSolids = GetLinkElementsSolids(link, intersectingLinkElements);
-                    thisOpeningRealSolidAfterIntersection = SubtractLinkSolids(
-                        thisOpeningRealSolidAfterIntersection,
-                        linkElementsSolids);
-                }
-            }
-            double volumeRatio = GetSolidsVolumesRatio(thisOpeningRealSolid, thisOpeningRealSolidAfterIntersection);
-            OpeningRealStatus status = GetStatusByVolumeRatio(volumeRatio);
-            Status = status;
-        }
-
-
-        /// <summary>
-        /// Возвращает статус текущего чистового отверстия по коэффициенту пересекаемого объема.
-        /// </summary>
-        /// <param name="volumeRatio">
-        /// Отношение объема солида текущего чистового отверстия, который пересекается с элементами из связей, 
-        /// к исходному объему этого солида.
-        /// <para>
-        /// 0 - элементы из связей на 100% пересекают солид текущего чистового отверстия, 
-        /// 1 - солид текущего чистового отверстия не пересекается ни с одним элементом из связи
-        /// </para>
-        /// </param>
-        /// <returns></returns>
-        private OpeningRealStatus GetStatusByVolumeRatio(double volumeRatio) {
-            if(volumeRatio < 0.01) {
-                return OpeningRealStatus.Empty;
-            } else if(volumeRatio < 0.2) {
-                return OpeningRealStatus.TooBig;
-            } else {
-                return OpeningRealStatus.Correct;
-            }
-        }
-
-        /// <summary>
-        /// Возвращает коэффициент, показывающий, какую часть исходного солида пересекают элементы из связей
-        /// </summary>
-        /// <param name="thisOpeningRealSolid">Исходный солид текущего чистового отверстия</param>
-        /// <param name="thisOpeningRealSolidAfterIntersection">
-        /// Солид текущего чистового отверстия, 
-        /// после вычтенных солидов элементов из связей, которые пересекают это отверстие
-        /// </param>
-        /// <returns>
-        /// 0 - элементы из связей на 100% пересекают солид текущего чистового отверстия, 
-        /// 1 - солид текущего чистового отверстия не пересекается ни с одним элементом из связи
-        /// </returns>
-        private double GetSolidsVolumesRatio(Solid thisOpeningRealSolid, Solid thisOpeningRealSolidAfterIntersection) {
-            if(thisOpeningRealSolid.Volume == 0) { return 1; }
-            return (1 - thisOpeningRealSolidAfterIntersection.Volume / thisOpeningRealSolid.Volume);
-        }
-
-        /// <summary>
-        /// Вычитает солиды связанных элементов из солида текущего отверстия и возвращает полученный новый солид
-        /// </summary>
-        /// <param name="thisOpeningRealSolid">Солид текущего чистового отверстия в координатах своего файла</param>
-        /// <param name="linkSolidsInThisCoordinates">
-        /// Коллекция солидов элементов из связи в координатах файла с чистовыми отверстиями</param>
-        /// <returns></returns>
-        private Solid SubtractLinkSolids(Solid thisOpeningRealSolid, ICollection<Solid> linkSolidsInThisCoordinates) {
-            var thisOpeningRealSolidAfterIntersection = thisOpeningRealSolid;
-            foreach(Solid linkSolid in linkSolidsInThisCoordinates) {
-                try {
-                    thisOpeningRealSolidAfterIntersection = BooleanOperationsUtils.ExecuteBooleanOperation(
-                        thisOpeningRealSolidAfterIntersection,
-                        linkSolid,
-                        BooleanOperationsType.Difference);
-                } catch(Autodesk.Revit.Exceptions.InvalidOperationException) {
-                    continue;
-                }
-            }
-            return thisOpeningRealSolidAfterIntersection;
-        }
-
-        /// <summary>
-        /// Возвращает коллекцию солидов заданных элементов из связанного файла 
-        /// в координатах активного файла c текущим чистовым отверстием
-        /// </summary>
-        /// <param name="mepLink">Связанный файл с элементами ВИС и заданиями на отверстия</param>
-        /// <param name="linkElementsIds">Id элементов из связанного файла, из которых надо получить солиды</param>
-        /// <returns></returns>
-        private ICollection<Solid> GetLinkElementsSolids(
-            IMepLinkElementsProvider mepLink,
-            ICollection<ElementId> linkElementsIds) {
-            var doc = mepLink.Document;
-            return linkElementsIds.Select(
-                id => SolidUtils.CreateTransformed(doc.GetElement(id).GetSolid(), mepLink.DocumentTransform))
-                .ToHashSet();
-        }
-
-        /// <summary>
-        /// Проверяет, пересекаются ли заданные элементы из связи с хостом текущего чистового отверстия
-        /// </summary>
-        /// <param name="mepLink">Связанный файл с элементами ВИС и заданиями на отверстия</param>
-        /// <param name="linkElementsForChecking">Элементы из связи для проверки на пересечение</param>
-        /// <returns>True, если хотя бы 1 элемент пересекается с хостом текущего чистового отверстия, иначе False</returns>
-        private bool LinkElementsIntersectHost(
-            IMepLinkElementsProvider mepLink,
-            ICollection<ElementId> linkElementsForChecking) {
-            if(!linkElementsForChecking.Any()) {
-                return false;
-            }
-            var hostSolidInLinkCoordinates = SolidUtils.CreateTransformed(
-                GetHost().GetSolid(), mepLink.DocumentTransform.Inverse);
-            return new FilteredElementCollector(mepLink.Document, linkElementsForChecking)
-                .WherePasses(new BoundingBoxIntersectsFilter(hostSolidInLinkCoordinates.GetOutline()))
-                .WherePasses(new ElementIntersectsSolidFilter(hostSolidInLinkCoordinates))
-                .Any();
-        }
-
-        /// <summary>
-        /// Возвращает коллекцию элементов ВИС и элементов заданий на отверстия из связанного файла
-        /// </summary>
-        /// <param name="mepLink">Связанный файл с элементами ВИС и заданиями на отверстия</param>
-        /// <returns></returns>
-        private ICollection<ElementId> GetIntersectingLinkElements(IMepLinkElementsProvider mepLink) {
-            Solid thisOpeningRealSolidInLinkCoordinates = SolidUtils.CreateTransformed(
-                GetSolid(), mepLink.DocumentTransform.Inverse);
-
-            var mepElements = GetIntersectingLinkMepElements(mepLink, thisOpeningRealSolidInLinkCoordinates)
-                .ToHashSet();
-            var openingTasks = GetIntersectingLinkOpeningTasks(mepLink, thisOpeningRealSolidInLinkCoordinates);
-            mepElements.UnionWith(openingTasks);
-
-            return mepElements;
-        }
-
-        /// <summary>
-        /// Возвращает коллекцию элементов ВИС из связи, которые пересекаются с солидом текущего чистового отверстия
-        /// </summary>
-        /// <param name="mepLink">Связанный файл с элементами ВИС и заданиями на отверстия</param>
-        /// <param name="thisOpeningRealSolidInLinkCoordinates">Солид текущего чистового отверстия в координатах связанного файла</param>
-        /// <returns></returns>
-        private ICollection<ElementId> GetIntersectingLinkMepElements(
-            IMepLinkElementsProvider mepLink,
-            Solid thisOpeningRealSolidInLinkCoordinates) {
-            var ids = mepLink.GetMepElementIds();
-            if(!ids.Any()) {
-                return Array.Empty<ElementId>();
-            }
-            return new FilteredElementCollector(mepLink.Document, ids)
-                .WherePasses(new BoundingBoxIntersectsFilter(thisOpeningRealSolidInLinkCoordinates.GetOutline()))
-                .WherePasses(new ElementIntersectsSolidFilter(thisOpeningRealSolidInLinkCoordinates))
-                .ToElementIds();
-        }
-
-        /// <summary>
-        /// Возвращает коллекцию экземпляров семейств заданий на отверстия из связи, которые пересекаются с солидом текущего чистового отверстия
-        /// </summary>
-        /// <param name="mepLink">Связанный файл с элементами ВИС и заданиями на отверстия</param>
-        /// <param name="thisOpeningRealSolidInLinkCoordinates">Солид текущего чистового отверстия в координатах связанного файла</param>
-        /// <returns></returns>
-        private ICollection<ElementId> GetIntersectingLinkOpeningTasks(
-            IMepLinkElementsProvider mepLink,
-            Solid thisOpeningRealSolidInLinkCoordinates) {
-
-            ICollection<ElementId> ids = mepLink.GetOpeningsTaskIds();
-            if(!ids.Any()) {
-                return Array.Empty<ElementId>();
-            }
-            return new FilteredElementCollector(mepLink.Document, ids)
-                .WherePasses(new BoundingBoxIntersectsFilter(thisOpeningRealSolidInLinkCoordinates.GetOutline()))
-                .WherePasses(new ElementIntersectsSolidFilter(thisOpeningRealSolidInLinkCoordinates))
-                .ToElementIds();
+            Status = DetermineStatus(mepLinkElementsProviders);
         }
     }
 }

--- a/RevitOpeningPlacement/OpeningModels/OpeningRealBase.cs
+++ b/RevitOpeningPlacement/OpeningModels/OpeningRealBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 
 using Autodesk.Revit.DB;
@@ -44,9 +44,15 @@ namespace RevitOpeningPlacement.OpeningModels {
                     $"{nameof(openingReal)} с Id {openingReal.Id} не содержит ссылки на хост элемент");
             }
             _familyInstance = openingReal;
+            Id = _familyInstance.Id;
 
             SetTransformedBBoxXYZ();
         }
+
+        /// <summary>
+        /// Id экземпляра семейства чистового проема
+        /// </summary>
+        public ElementId Id { get; }
 
 
         public abstract Solid GetSolid();

--- a/RevitOpeningPlacement/OpeningModels/OpeningRealByMep.cs
+++ b/RevitOpeningPlacement/OpeningModels/OpeningRealByMep.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Autodesk.Revit.DB;
+
+using RevitClashDetective.Models.Extensions;
+
+using RevitOpeningPlacement.Models.Interfaces;
+using RevitOpeningPlacement.OpeningModels.Enums;
+
+namespace RevitOpeningPlacement.OpeningModels {
+    /// <summary>
+    /// Класс, обозначающий чистовое отверстие, которое размещается по входящему заданию на отверстие от ВИС
+    /// </summary>
+    internal abstract class OpeningRealByMep : OpeningRealBase {
+        protected OpeningRealByMep(FamilyInstance openingReal) : base(openingReal) {
+        }
+
+
+        /// <summary>
+        /// Определяет статус для текущего чистового отверстия
+        /// </summary>
+        /// <param name="mepLinkElementsProviders">Коллекция связей с элементами ВИС и заданиями на отверстия</param>
+        /// <returns>Статус для текущего чистового отверстия относительно задания от ВИС</returns>
+        private protected OpeningRealStatus DetermineStatus(
+            ICollection<IMepLinkElementsProvider> mepLinkElementsProviders) {
+
+            Solid thisOpeningRealSolid = GetSolid();
+            Solid thisOpeningRealSolidAfterIntersection = thisOpeningRealSolid;
+
+            foreach(IMepLinkElementsProvider link in mepLinkElementsProviders) {
+                ICollection<ElementId> intersectingLinkElements = GetIntersectingLinkElements(link);
+                if(intersectingLinkElements.Count > 0) {
+                    if(LinkElementsIntersectHost(link, intersectingLinkElements)) {
+                        return OpeningRealStatus.NotActual;
+                    }
+
+                    ICollection<Solid> linkElementsSolids = GetLinkElementsSolids(link, intersectingLinkElements);
+                    thisOpeningRealSolidAfterIntersection = SubtractLinkSolids(
+                        thisOpeningRealSolidAfterIntersection,
+                        linkElementsSolids);
+                }
+            }
+            double volumeRatio = GetSolidsVolumesRatio(thisOpeningRealSolid, thisOpeningRealSolidAfterIntersection);
+            return GetStatusByVolumeRatio(volumeRatio);
+        }
+
+
+        /// <summary>
+        /// Возвращает коллекцию элементов ВИС и элементов заданий на отверстия из связанного файла
+        /// </summary>
+        /// <param name="mepLink">Связанный файл с элементами ВИС и заданиями на отверстия</param>
+        /// <returns></returns>
+        private ICollection<ElementId> GetIntersectingLinkElements(IMepLinkElementsProvider mepLink) {
+            Solid thisOpeningRealSolidInLinkCoordinates = SolidUtils.CreateTransformed(
+                GetSolid(), mepLink.DocumentTransform.Inverse);
+
+            var mepElements = GetIntersectingLinkMepElements(mepLink, thisOpeningRealSolidInLinkCoordinates)
+                .ToHashSet();
+            var openingTasks = GetIntersectingLinkOpeningTasks(mepLink, thisOpeningRealSolidInLinkCoordinates);
+            mepElements.UnionWith(openingTasks);
+
+            return mepElements;
+        }
+
+        /// <summary>
+        /// Возвращает коллекцию элементов ВИС из связи, которые пересекаются с солидом текущего чистового отверстия
+        /// </summary>
+        /// <param name="mepLink">Связанный файл с элементами ВИС и заданиями на отверстия</param>
+        /// <param name="thisOpeningRealSolidInLinkCoordinates">Солид текущего чистового отверстия в координатах связанного файла</param>
+        /// <returns></returns>
+        private ICollection<ElementId> GetIntersectingLinkMepElements(
+            IMepLinkElementsProvider mepLink,
+            Solid thisOpeningRealSolidInLinkCoordinates) {
+            var ids = mepLink.GetMepElementIds();
+            if(!ids.Any()) {
+                return Array.Empty<ElementId>();
+            }
+            return new FilteredElementCollector(mepLink.Document, ids)
+                .WherePasses(new BoundingBoxIntersectsFilter(thisOpeningRealSolidInLinkCoordinates.GetOutline()))
+                .WherePasses(new ElementIntersectsSolidFilter(thisOpeningRealSolidInLinkCoordinates))
+                .ToElementIds();
+        }
+
+        /// <summary>
+        /// Возвращает коллекцию экземпляров семейств заданий на отверстия из связи, которые пересекаются с солидом текущего чистового отверстия
+        /// </summary>
+        /// <param name="mepLink">Связанный файл с элементами ВИС и заданиями на отверстия</param>
+        /// <param name="thisOpeningRealSolidInLinkCoordinates">Солид текущего чистового отверстия в координатах связанного файла</param>
+        /// <returns></returns>
+        private ICollection<ElementId> GetIntersectingLinkOpeningTasks(
+            IMepLinkElementsProvider mepLink,
+            Solid thisOpeningRealSolidInLinkCoordinates) {
+
+            ICollection<ElementId> ids = mepLink.GetOpeningsTaskIds();
+            if(!ids.Any()) {
+                return Array.Empty<ElementId>();
+            }
+            return new FilteredElementCollector(mepLink.Document, ids)
+                .WherePasses(new BoundingBoxIntersectsFilter(thisOpeningRealSolidInLinkCoordinates.GetOutline()))
+                .WherePasses(new ElementIntersectsSolidFilter(thisOpeningRealSolidInLinkCoordinates))
+                .ToElementIds();
+        }
+
+        /// <summary>
+        /// Проверяет, пересекаются ли заданные элементы из связи с хостом текущего чистового отверстия
+        /// </summary>
+        /// <param name="mepLink">Связанный файл с элементами ВИС и заданиями на отверстия</param>
+        /// <param name="linkElementsForChecking">Элементы из связи для проверки на пересечение</param>
+        /// <returns>True, если хотя бы 1 элемент пересекается с хостом текущего чистового отверстия, иначе False</returns>
+        private bool LinkElementsIntersectHost(
+            IMepLinkElementsProvider mepLink,
+            ICollection<ElementId> linkElementsForChecking) {
+            if(!linkElementsForChecking.Any()) {
+                return false;
+            }
+            var hostSolidInLinkCoordinates = SolidUtils.CreateTransformed(
+                GetHost().GetSolid(), mepLink.DocumentTransform.Inverse);
+            return new FilteredElementCollector(mepLink.Document, linkElementsForChecking)
+                .WherePasses(new BoundingBoxIntersectsFilter(hostSolidInLinkCoordinates.GetOutline()))
+                .WherePasses(new ElementIntersectsSolidFilter(hostSolidInLinkCoordinates))
+                .Any();
+        }
+
+        /// <summary>
+        /// Возвращает коллекцию солидов заданных элементов из связанного файла 
+        /// в координатах активного файла c текущим чистовым отверстием
+        /// </summary>
+        /// <param name="mepLink">Связанный файл с элементами ВИС и заданиями на отверстия</param>
+        /// <param name="linkElementsIds">Id элементов из связанного файла, из которых надо получить солиды</param>
+        /// <returns></returns>
+        private ICollection<Solid> GetLinkElementsSolids(
+            IMepLinkElementsProvider mepLink,
+            ICollection<ElementId> linkElementsIds) {
+            var doc = mepLink.Document;
+            return linkElementsIds.Select(
+                id => SolidUtils.CreateTransformed(doc.GetElement(id).GetSolid(), mepLink.DocumentTransform))
+                .ToHashSet();
+        }
+
+        /// <summary>
+        /// Вычитает солиды связанных элементов из солида текущего отверстия и возвращает полученный новый солид
+        /// </summary>
+        /// <param name="thisOpeningRealSolid">Солид текущего чистового отверстия в координатах своего файла</param>
+        /// <param name="linkSolidsInThisCoordinates">
+        /// Коллекция солидов элементов из связи в координатах файла с чистовыми отверстиями</param>
+        /// <returns></returns>
+        private Solid SubtractLinkSolids(Solid thisOpeningRealSolid, ICollection<Solid> linkSolidsInThisCoordinates) {
+            var thisOpeningRealSolidAfterIntersection = thisOpeningRealSolid;
+            foreach(Solid linkSolid in linkSolidsInThisCoordinates) {
+                try {
+                    thisOpeningRealSolidAfterIntersection = BooleanOperationsUtils.ExecuteBooleanOperation(
+                        thisOpeningRealSolidAfterIntersection,
+                        linkSolid,
+                        BooleanOperationsType.Difference);
+                } catch(Autodesk.Revit.Exceptions.InvalidOperationException) {
+                    continue;
+                }
+            }
+            return thisOpeningRealSolidAfterIntersection;
+        }
+
+        /// <summary>
+        /// Возвращает коэффициент, показывающий, какую часть исходного солида пересекают элементы из связей
+        /// </summary>
+        /// <param name="thisOpeningRealSolid">Исходный солид текущего чистового отверстия</param>
+        /// <param name="thisOpeningRealSolidAfterIntersection">
+        /// Солид текущего чистового отверстия, 
+        /// после вычтенных солидов элементов из связей, которые пересекают это отверстие
+        /// </param>
+        /// <returns>
+        /// 0 - элементы из связей на 100% пересекают солид текущего чистового отверстия, 
+        /// 1 - солид текущего чистового отверстия не пересекается ни с одним элементом из связи
+        /// </returns>
+        private double GetSolidsVolumesRatio(Solid thisOpeningRealSolid, Solid thisOpeningRealSolidAfterIntersection) {
+            if(thisOpeningRealSolid.Volume == 0) { return 1; }
+            return (1 - thisOpeningRealSolidAfterIntersection.Volume / thisOpeningRealSolid.Volume);
+        }
+
+        /// <summary>
+        /// Возвращает статус текущего чистового отверстия по коэффициенту пересекаемого объема.
+        /// </summary>
+        /// <param name="volumeRatio">
+        /// Отношение объема солида текущего чистового отверстия, который пересекается с элементами из связей, 
+        /// к исходному объему этого солида.
+        /// <para>
+        /// 0 - элементы из связей на 100% пересекают солид текущего чистового отверстия, 
+        /// 1 - солид текущего чистового отверстия не пересекается ни с одним элементом из связи
+        /// </para>
+        /// </param>
+        /// <returns></returns>
+        private OpeningRealStatus GetStatusByVolumeRatio(double volumeRatio) {
+            if(volumeRatio < 0.01) {
+                return OpeningRealStatus.Empty;
+            } else if(volumeRatio < 0.2) {
+                return OpeningRealStatus.TooBig;
+            } else {
+                return OpeningRealStatus.Correct;
+            }
+        }
+    }
+}

--- a/RevitOpeningPlacement/OpeningModels/OpeningRealKr.cs
+++ b/RevitOpeningPlacement/OpeningModels/OpeningRealKr.cs
@@ -20,7 +20,7 @@ namespace RevitOpeningPlacement.OpeningModels {
     /// Класс, обозначающий чистовое отверстие КР, идущее на чертежи. 
     /// Использовать для обертки проемов из активного файла КР
     /// </summary>
-    internal class OpeningRealKr : OpeningRealBase, IEquatable<OpeningRealKr> {
+    internal class OpeningRealKr : OpeningRealByMep, IEquatable<OpeningRealKr> {
         public OpeningRealKr(FamilyInstance openingReal) : base(openingReal) {
             Diameter = GetFamilyInstanceStringParamValueOrEmpty(RealOpeningKrPlacer.RealOpeningKrDiameter);
             Width = GetFamilyInstanceStringParamValueOrEmpty(RealOpeningKrPlacer.RealOpeningKrInWallWidth);
@@ -78,6 +78,14 @@ namespace RevitOpeningPlacement.OpeningModels {
 
         public override BoundingBoxXYZ GetTransformedBBoxXYZ() {
             return _boundingBox;
+        }
+
+        /// <summary>
+        /// Обновляет свойство <see cref="Status"/>
+        /// </summary>
+        /// <param name="mepLinkElementsProviders">Коллекция связей с элементами ВИС и заданиями на отверстиями</param>
+        public void UpdateStatus(ICollection<IMepLinkElementsProvider> mepLinkElementsProviders) {
+            Status = DetermineStatus(mepLinkElementsProviders);
         }
 
         /// <summary>

--- a/RevitOpeningPlacement/OpeningModels/OpeningRealKr.cs
+++ b/RevitOpeningPlacement/OpeningModels/OpeningRealKr.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -22,7 +22,6 @@ namespace RevitOpeningPlacement.OpeningModels {
     /// </summary>
     internal class OpeningRealKr : OpeningRealBase, IEquatable<OpeningRealKr> {
         public OpeningRealKr(FamilyInstance openingReal) : base(openingReal) {
-            Id = _familyInstance.Id;
             Diameter = GetFamilyInstanceStringParamValueOrEmpty(RealOpeningKrPlacer.RealOpeningKrDiameter);
             Width = GetFamilyInstanceStringParamValueOrEmpty(RealOpeningKrPlacer.RealOpeningKrInWallWidth);
             Height = GetFamilyInstanceStringParamValueOrEmpty(RealOpeningKrPlacer.RealOpeningKrInWallHeight);
@@ -33,11 +32,6 @@ namespace RevitOpeningPlacement.OpeningModels {
                 string.Empty);
         }
 
-
-        /// <summary>
-        /// Id экземпляра семейства задания на отверстие
-        /// </summary>
-        public ElementId Id { get; }
 
         /// <summary>
         /// Диаметр в мм, если есть

--- a/RevitOpeningPlacement/PlaceManyOpeningRealsByManyTasksInManyHostsCmd.cs
+++ b/RevitOpeningPlacement/PlaceManyOpeningRealsByManyTasksInManyHostsCmd.cs
@@ -1,7 +1,8 @@
-﻿using Autodesk.Revit.Attributes;
+using Autodesk.Revit.Attributes;
 using Autodesk.Revit.UI;
 
 using RevitOpeningPlacement.Models;
+using RevitOpeningPlacement.Models.Configs;
 using RevitOpeningPlacement.Models.RealOpeningArPlacement;
 using RevitOpeningPlacement.Models.RealOpeningArPlacement.Checkers;
 using RevitOpeningPlacement.Models.RealOpeningKrPlacement;
@@ -39,7 +40,8 @@ namespace RevitOpeningPlacement {
                     if(!ModelCorrect(new RealOpeningsKrChecker(revitRepository))) {
                         return;
                     }
-                    var placer = new RealOpeningKrPlacer(revitRepository);
+                    var config = OpeningRealsKrConfig.GetOpeningConfig(revitRepository.Doc);
+                    var placer = new RealOpeningKrPlacer(revitRepository, config);
                     placer.PlaceSingleOpeningsInManyHosts();
                     break;
                 }

--- a/RevitOpeningPlacement/PlaceManyOpeningRealsByManyTasksInOneHostCmd.cs
+++ b/RevitOpeningPlacement/PlaceManyOpeningRealsByManyTasksInOneHostCmd.cs
@@ -2,6 +2,7 @@ using Autodesk.Revit.Attributes;
 using Autodesk.Revit.UI;
 
 using RevitOpeningPlacement.Models;
+using RevitOpeningPlacement.Models.Configs;
 using RevitOpeningPlacement.Models.RealOpeningArPlacement;
 using RevitOpeningPlacement.Models.RealOpeningArPlacement.Checkers;
 using RevitOpeningPlacement.Models.RealOpeningKrPlacement;
@@ -39,7 +40,8 @@ namespace RevitOpeningPlacement {
                     if(!ModelCorrect(new RealOpeningsKrChecker(revitRepository))) {
                         return;
                     }
-                    var placer = new RealOpeningKrPlacer(revitRepository);
+                    var config = OpeningRealsKrConfig.GetOpeningConfig(revitRepository.Doc);
+                    var placer = new RealOpeningKrPlacer(revitRepository, config);
                     placer.PlaceSingleOpeningsInOneHost();
                     break;
                 }

--- a/RevitOpeningPlacement/PlaceOneOpeningRealByManyTasksCmd.cs
+++ b/RevitOpeningPlacement/PlaceOneOpeningRealByManyTasksCmd.cs
@@ -2,6 +2,7 @@ using Autodesk.Revit.Attributes;
 using Autodesk.Revit.UI;
 
 using RevitOpeningPlacement.Models;
+using RevitOpeningPlacement.Models.Configs;
 using RevitOpeningPlacement.Models.RealOpeningArPlacement;
 using RevitOpeningPlacement.Models.RealOpeningArPlacement.Checkers;
 using RevitOpeningPlacement.Models.RealOpeningKrPlacement;
@@ -39,7 +40,8 @@ namespace RevitOpeningPlacement {
                     if(!ModelCorrect(new RealOpeningsKrChecker(revitRepository))) {
                         return;
                     }
-                    var placer = new RealOpeningKrPlacer(revitRepository);
+                    var config = OpeningRealsKrConfig.GetOpeningConfig(revitRepository.Doc);
+                    var placer = new RealOpeningKrPlacer(revitRepository, config);
                     placer.PlaceUnitedOpeningByManyTasks();
                     break;
                 }

--- a/RevitOpeningPlacement/PlaceOneOpeningRealByOneTaskCmd.cs
+++ b/RevitOpeningPlacement/PlaceOneOpeningRealByOneTaskCmd.cs
@@ -3,6 +3,7 @@ using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 
 using RevitOpeningPlacement.Models;
+using RevitOpeningPlacement.Models.Configs;
 using RevitOpeningPlacement.Models.RealOpeningArPlacement;
 using RevitOpeningPlacement.Models.RealOpeningArPlacement.Checkers;
 using RevitOpeningPlacement.Models.RealOpeningKrPlacement;
@@ -39,7 +40,8 @@ namespace RevitOpeningPlacement {
                     if(!ModelCorrect(new RealOpeningsKrChecker(revitRepository))) {
                         return;
                     }
-                    var placer = new RealOpeningKrPlacer(revitRepository);
+                    var config = OpeningRealsKrConfig.GetOpeningConfig(revitRepository.Doc);
+                    var placer = new RealOpeningKrPlacer(revitRepository, config);
                     placer.PlaceSingleOpeningByOneTask();
                     break;
                 }

--- a/RevitOpeningPlacement/SetOpeningRealsPlacementConfigCmd.cs
+++ b/RevitOpeningPlacement/SetOpeningRealsPlacementConfigCmd.cs
@@ -1,0 +1,40 @@
+using System.Windows.Interop;
+
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.UI;
+
+using dosymep.Bim4Everyone;
+
+using RevitOpeningPlacement.Models;
+using RevitOpeningPlacement.Models.Configs;
+using RevitOpeningPlacement.ViewModels.OpeningConfig;
+using RevitOpeningPlacement.Views;
+
+namespace RevitOpeningPlacement {
+    /// <summary>
+    /// Команда для задания настроек расстановки чистовых отверстий в файле КР
+    /// </summary>
+    [Transaction(TransactionMode.Manual)]
+    internal class SetOpeningRealsPlacementConfigCmd : BasePluginCommand {
+        public SetOpeningRealsPlacementConfigCmd() {
+            PluginName = "Настройки расстановки отверстий КР";
+        }
+
+
+        public void ExecuteCommand(UIApplication uiApplication) {
+            Execute(uiApplication);
+        }
+
+
+        protected override void Execute(UIApplication uiApplication) {
+            RevitRepository revitRepository = new RevitRepository(uiApplication.Application, uiApplication.ActiveUIDocument.Document);
+            var openingConfig = OpeningRealsKrConfig.GetOpeningConfig(revitRepository.Doc);
+            var viewModel = new OpeningRealsKrConfigViewModel(revitRepository, openingConfig);
+
+            var window = new OpeningRealsKrSettingsView() { Title = PluginName, DataContext = viewModel };
+            var helper = new WindowInteropHelper(window) { Owner = uiApplication.MainWindowHandle };
+
+            window.ShowDialog();
+        }
+    }
+}

--- a/RevitOpeningPlacement/ViewModels/Navigator/ConstructureNavigatorForIncomingTasksViewModel.cs
+++ b/RevitOpeningPlacement/ViewModels/Navigator/ConstructureNavigatorForIncomingTasksViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Windows.Data;
@@ -20,15 +20,15 @@ namespace RevitOpeningPlacement.ViewModels.Navigator {
 
         public ConstructureNavigatorForIncomingTasksViewModel(
             RevitRepository revitRepository,
-            ICollection<OpeningArTaskIncomingViewModel> openingsArTasksIncomingViewModels,
+            ICollection<IOpeningTaskIncomingForKrViewModel> openingsTasksIncomingViewModels,
             ICollection<OpeningRealKrViewModel> openingsRealViewModels) {
 
             _revitRepository = revitRepository ?? throw new ArgumentNullException(nameof(revitRepository));
-            if(openingsArTasksIncomingViewModels is null) { throw new ArgumentNullException(nameof(openingsArTasksIncomingViewModels)); }
+            if(openingsTasksIncomingViewModels is null) { throw new ArgumentNullException(nameof(openingsTasksIncomingViewModels)); }
             if(openingsRealViewModels is null) { throw new ArgumentNullException(nameof(openingsRealViewModels)); }
 
-            OpeningsArTasksIncoming = new ObservableCollection<OpeningArTaskIncomingViewModel>(openingsArTasksIncomingViewModels);
-            OpeningsArTasksIncomingViewSource = new CollectionViewSource() { Source = OpeningsArTasksIncoming };
+            OpeningsTasksIncoming = new ObservableCollection<IOpeningTaskIncomingForKrViewModel>(openingsTasksIncomingViewModels);
+            OpeningsTasksIncomingViewSource = new CollectionViewSource() { Source = OpeningsTasksIncoming };
 
             OpeningsReal = new ObservableCollection<OpeningRealKrViewModel>(openingsRealViewModels);
             OpeningsRealViewSource = new CollectionViewSource() { Source = OpeningsReal };
@@ -45,15 +45,15 @@ namespace RevitOpeningPlacement.ViewModels.Navigator {
 
 
         // Входящие задания на отверстия из АР
-        public ObservableCollection<OpeningArTaskIncomingViewModel> OpeningsArTasksIncoming { get; }
+        public ObservableCollection<IOpeningTaskIncomingForKrViewModel> OpeningsTasksIncoming { get; }
 
-        public CollectionViewSource OpeningsArTasksIncomingViewSource { get; private set; }
+        public CollectionViewSource OpeningsTasksIncomingViewSource { get; private set; }
 
-        private OpeningArTaskIncomingViewModel _selectedOpeningArTaskIncoming;
+        private IOpeningTaskIncomingForKrViewModel _selectedOpeningTaskIncoming;
 
-        public OpeningArTaskIncomingViewModel SelectedOpeningArTaskIncoming {
-            get => _selectedOpeningArTaskIncoming;
-            set => RaiseAndSetIfChanged(ref _selectedOpeningArTaskIncoming, value);
+        public IOpeningTaskIncomingForKrViewModel SelectedOpeningTaskIncoming {
+            get => _selectedOpeningTaskIncoming;
+            set => RaiseAndSetIfChanged(ref _selectedOpeningTaskIncoming, value);
         }
 
 
@@ -96,9 +96,9 @@ namespace RevitOpeningPlacement.ViewModels.Navigator {
         }
 
         private void IncomingTaskSelectionChanged(object p) {
-            if(OpeningsArTasksIncomingViewSource.View.CurrentPosition > -1
-                && OpeningsArTasksIncomingViewSource.View.CurrentPosition < OpeningsArTasksIncoming.Count) {
-                SelectElement((OpeningArTaskIncomingViewModel) p);
+            if(OpeningsTasksIncomingViewSource.View.CurrentPosition > -1
+                && OpeningsTasksIncomingViewSource.View.CurrentPosition < OpeningsTasksIncoming.Count) {
+                SelectElement((IOpeningTaskIncomingForKrViewModel) p);
             }
         }
 

--- a/RevitOpeningPlacement/ViewModels/Navigator/OpeningArTaskIncomingViewModel.cs
+++ b/RevitOpeningPlacement/ViewModels/Navigator/OpeningArTaskIncomingViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -17,7 +17,7 @@ namespace RevitOpeningPlacement.ViewModels.Navigator {
     /// <summary>
     /// Модель представления входящего задания на отверстие от архитектора в файле активном конструктора
     /// </summary>
-    internal class OpeningArTaskIncomingViewModel : BaseViewModel, ISelectorAndHighlighter, IEquatable<OpeningArTaskIncomingViewModel> {
+    internal class OpeningArTaskIncomingViewModel : BaseViewModel, IOpeningTaskIncomingForKrViewModel, IEquatable<OpeningArTaskIncomingViewModel> {
         /// <summary>
         /// Экземпляр семейства проема АР, являющегося входящим заданием на отверстие для КР
         /// </summary>

--- a/RevitOpeningPlacement/ViewModels/Navigator/OpeningMepTaskIncomingViewModel.cs
+++ b/RevitOpeningPlacement/ViewModels/Navigator/OpeningMepTaskIncomingViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -18,7 +18,7 @@ namespace RevitOpeningPlacement.ViewModels.Navigator {
     /// <summary>
     /// Модель представления окна для работы с конкретным входящим заданием на отверстие от инженера в файле архитектора или конструктора
     /// </summary>
-    internal class OpeningMepTaskIncomingViewModel : BaseViewModel, ISelectorAndHighlighter, IEquatable<OpeningMepTaskIncomingViewModel> {
+    internal class OpeningMepTaskIncomingViewModel : BaseViewModel, IOpeningTaskIncomingForKrViewModel, IEquatable<OpeningMepTaskIncomingViewModel> {
         /// <summary>
         /// Экземпляр семейства задания на отверстие
         /// </summary>

--- a/RevitOpeningPlacement/ViewModels/OpeningConfig/OpeningRealsKrConfigViewModel.cs
+++ b/RevitOpeningPlacement/ViewModels/OpeningConfig/OpeningRealsKrConfigViewModel.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Windows.Input;
+
+using dosymep.WPF.Commands;
+using dosymep.WPF.ViewModels;
+
+using RevitOpeningPlacement.Models;
+using RevitOpeningPlacement.Models.Configs;
+
+namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
+    internal class OpeningRealsKrConfigViewModel : BaseViewModel {
+        private readonly RevitRepository _revitRepository;
+
+        public OpeningRealsKrConfigViewModel(RevitRepository revitRepository, OpeningRealsKrConfig openingRealsKrConfig) {
+            _revitRepository = revitRepository ?? throw new ArgumentNullException(nameof(revitRepository));
+            if(openingRealsKrConfig is null) {
+                throw new ArgumentNullException(nameof(openingRealsKrConfig));
+            }
+
+            PlaceByMep = openingRealsKrConfig.PlacementType == OpeningRealKrPlacementType.PlaceByMep;
+            PlaceByAr = !PlaceByMep;
+
+            SaveConfigCommand = RelayCommand.Create(SaveConfig);
+        }
+
+
+        private bool _placeByMep;
+
+        public bool PlaceByMep {
+            get => _placeByMep;
+            set => RaiseAndSetIfChanged(ref _placeByMep, value);
+        }
+
+
+        private bool _placeByAr;
+
+        public bool PlaceByAr {
+            get => _placeByAr;
+            set => RaiseAndSetIfChanged(ref _placeByAr, value);
+        }
+
+
+        public ICommand SaveConfigCommand { get; }
+
+        private void SaveConfig() {
+            GetOpeningConfig().SaveProjectConfig();
+        }
+
+
+        private OpeningRealsKrConfig GetOpeningConfig() {
+            var config = OpeningRealsKrConfig.GetOpeningConfig(_revitRepository.Doc);
+            config.PlacementType = PlaceByAr
+                ? OpeningRealKrPlacementType.PlaceByAr
+                : OpeningRealKrPlacementType.PlaceByMep;
+            return config;
+        }
+    }
+}

--- a/RevitOpeningPlacement/Views/NavigatorArIncomingView.xaml
+++ b/RevitOpeningPlacement/Views/NavigatorArIncomingView.xaml
@@ -130,11 +130,11 @@
                                   ShowCloseButton="False">
                     <dxg:GridControl x:Name="_dgIncomingTasks"
                                      Grid.Row="0"
-                                     ItemsSource="{Binding OpeningsArTasksIncomingViewSource.View}"
+                                     ItemsSource="{Binding OpeningsTasksIncomingViewSource.View}"
                                      BorderThickness="0"
                                      SelectionMode="Row"
-                                     CurrentItem="RevitOpeningPlacement.ViewModels.Navigator.OpeningArTaskIncomingViewModel"
-                                     SelectedItem="{Binding SelectedOpeningArTaskIncoming}"
+                                     CurrentItem="RevitOpeningPlacement.Models.Interfaces.IOpeningTaskIncomingForKrViewModel"
+                                     SelectedItem="{Binding SelectedOpeningTaskIncoming}"
                                      MaxHeight="2000">
                         <dxg:GridControl.GroupSummary>
                             <dxg:GridSummaryItem SummaryType="Count" />

--- a/RevitOpeningPlacement/Views/OpeningRealsKrSettingsView.xaml
+++ b/RevitOpeningPlacement/Views/OpeningRealsKrSettingsView.xaml
@@ -1,0 +1,50 @@
+﻿<base:ThemedPlatformWindow x:Class="RevitOpeningPlacement.Views.OpeningRealsKrSettingsView"
+                           xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                           xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                           xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                           xmlns:base="clr-namespace:dosymep.WPF.Views"
+                           xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                           xmlns:local="clr-namespace:RevitOpeningPlacement.Views"
+                           xmlns:vms="clr-namespace:RevitOpeningPlacement.ViewModels.OpeningConfig"
+                           xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+                           xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+                           xmlns:dxdo="http://schemas.devexpress.com/winfx/2008/xaml/docking"
+                           WindowStartupLocation="CenterOwner"
+                           x:Name="_this"
+                           mc:Ignorable="d"
+                           Title="Настройки расстановки отверстий КР"
+                           MinHeight="140"
+                           MinWidth="350"
+                           MaxHeight="140"
+                           MaxWidth="350"
+                           ResizeMode="NoResize"
+                           d:DataContext="{d:DesignInstance vms:OpeningRealsKrConfigViewModel, IsDesignTimeCreatable=False}">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="45"/>
+        </Grid.RowDefinitions>
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+            <RadioButton GroupName="PlacementType"
+                         Content="Размещать отверстия по заданиям из АР"
+                         IsChecked="{Binding PlaceByAr}" />
+            <RadioButton GroupName="PlacementType"
+                         Content="Размещать отверстия по заданиям из ВИС"
+                         IsChecked="{Binding PlaceByMep}" />
+        </StackPanel>
+        <DockPanel Grid.Row="2" Margin="10 " HorizontalAlignment="Right" VerticalAlignment="Bottom">
+            <dx:SimpleButton Content="OK"
+                             Height="25"
+                             Width="80"
+                             Margin="0 0 10 0"
+                             IsDefault="True"
+                             Click="ButtonOk_Click"
+                             Command="{Binding SaveConfigCommand}" />
+            <dx:SimpleButton Content="Отмена"
+                             Height="25"
+                             Width="80"
+                             IsCancel="True"
+                             Click="ButtonCancel_Click" />
+        </DockPanel>
+    </Grid>
+</base:ThemedPlatformWindow>

--- a/RevitOpeningPlacement/Views/OpeningRealsKrSettingsView.xaml.cs
+++ b/RevitOpeningPlacement/Views/OpeningRealsKrSettingsView.xaml.cs
@@ -1,0 +1,20 @@
+using System.Windows;
+
+namespace RevitOpeningPlacement.Views {
+    public partial class OpeningRealsKrSettingsView {
+        public OpeningRealsKrSettingsView() {
+            InitializeComponent();
+        }
+
+        public override string PluginName => nameof(RevitOpeningPlacement);
+        public override string ProjectConfigName => nameof(MainWindow);
+
+        private void ButtonOk_Click(object sender, RoutedEventArgs e) {
+            DialogResult = true;
+        }
+
+        private void ButtonCancel_Click(object sender, RoutedEventArgs e) {
+            DialogResult = false;
+        }
+    }
+}


### PR DESCRIPTION
Реализован выбор режима Навигатора для просмотра заданий в связке КР-АР или КР-ВИС
![image](https://github.com/Bim4Everyone/RevitPlugins/assets/87359016/d8bde6da-32ea-4c8e-b45f-fd22c1dc80ec)

Реализован выбор типа расстановки и сама расстановка чистовых отверстий КР по заданиям от ВИС или от АР через отдельную кнопку на ленте.
![image](https://github.com/Bim4Everyone/RevitPlugins/assets/87359016/c08a6460-3d0f-4ac4-b9f3-a6ab4af5343f)
