### PR TITLE
RevitOpeningPlacement: Исправление бага с точкой вставки

### DIFF
--- a/RevitOpeningPlacement/GetOpeningTasksCmd.cs
+++ b/RevitOpeningPlacement/GetOpeningTasksCmd.cs
@@ -11,6 +11,7 @@ using dosymep.Bim4Everyone;
 using dosymep.SimpleServices;
 
 using RevitOpeningPlacement.Models;
+using RevitOpeningPlacement.Models.Configs;
 using RevitOpeningPlacement.Models.Interfaces;
 using RevitOpeningPlacement.Models.Navigator.Checkers;
 using RevitOpeningPlacement.OpeningModels;
@@ -372,13 +373,20 @@ namespace RevitOpeningPlacement {
         /// <param name="revitRepository"></param>
         private void GetOpeningsTaskInDocumentKR(UIApplication uiApplication, RevitRepository revitRepository) {
             var navigatorMode = GetKrNavigatorMode();
+            var config = OpeningRealsKrConfig.GetOpeningConfig(revitRepository.Doc);
             switch(navigatorMode) {
-                case KrNavigatorMode.IncomingAr:
-                GetIncomingTasksFromArInDocKR(uiApplication, revitRepository);
-                break;
-                case KrNavigatorMode.IncomingMep:
-                GetIncomingTasksFromMepInDocKR(uiApplication, revitRepository);
-                break;
+                case KrNavigatorMode.IncomingAr: {
+                    config.PlacementType = OpeningRealKrPlacementType.PlaceByAr;
+                    config.SaveProjectConfig();
+                    GetIncomingTasksFromArInDocKR(uiApplication, revitRepository);
+                    break;
+                }
+                case KrNavigatorMode.IncomingMep: {
+                    config.PlacementType = OpeningRealKrPlacementType.PlaceByMep;
+                    config.SaveProjectConfig();
+                    GetIncomingTasksFromMepInDocKR(uiApplication, revitRepository);
+                    break;
+                }
                 default:
                 throw new OperationCanceledException();
             }

--- a/RevitOpeningPlacement/Models/Extensions/WallExtension.cs
+++ b/RevitOpeningPlacement/Models/Extensions/WallExtension.cs
@@ -1,4 +1,6 @@
-﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.DB;
+
+using dosymep.Revit;
 
 namespace RevitOpeningPlacement.Models.Extensions {
     internal static class WallExtension {
@@ -28,8 +30,23 @@ namespace RevitOpeningPlacement.Models.Extensions {
         }
 
         private static XYZ GetCentralPoint(Wall wall) {
-            var bb = wall.get_BoundingBox(null);
-            return bb.Min + (bb.Max - bb.Min) / 2;
+            var bb = wall.GetBoundingBox();
+            XYZ bbCenter = bb.Min + (bb.Max - bb.Min) / 2;
+            //если стена соединена с другой стеной, то торец в месте соединения образует острый угол,
+            //из-за чего центр бокса - это не геометрический центр стены.
+
+            PlanarFace exteriorFace = wall.GetGeometryObjectFromReference(
+                HostObjectUtils.GetSideFaces(wall, ShellLayerType.Exterior)[0]) as PlanarFace;
+            Plane exteriorPlane = Plane.CreateByNormalAndOrigin(exteriorFace.FaceNormal, exteriorFace.Origin);
+
+            XYZ bbCenterProjection = exteriorPlane.ProjectPoint(bbCenter);
+            XYZ bbCenterToProjectionVector = bbCenterProjection - bbCenter;
+
+            //получение вектора, который надо прибавить к центру бокса, чтобы получившаяся точка была ровно посередине толщины стены
+            XYZ alignVector = bbCenterToProjectionVector.Normalize()
+                * (bbCenterToProjectionVector.GetLength() - wall.Width / 2);
+
+            return bbCenter + alignVector;
         }
     }
 }

--- a/RevitOpeningPlacement/Models/Extensions/WallExtension.cs
+++ b/RevitOpeningPlacement/Models/Extensions/WallExtension.cs
@@ -37,14 +37,20 @@ namespace RevitOpeningPlacement.Models.Extensions {
 
             PlanarFace exteriorFace = wall.GetGeometryObjectFromReference(
                 HostObjectUtils.GetSideFaces(wall, ShellLayerType.Exterior)[0]) as PlanarFace;
-            Plane exteriorPlane = Plane.CreateByNormalAndOrigin(exteriorFace.FaceNormal, exteriorFace.Origin);
+            XYZ alignVector;
+            if(exteriorFace != null) {
 
-            XYZ bbCenterProjection = exteriorPlane.ProjectPoint(bbCenter);
-            XYZ bbCenterToProjectionVector = bbCenterProjection - bbCenter;
+                Plane exteriorPlane = Plane.CreateByNormalAndOrigin(exteriorFace.FaceNormal, exteriorFace.Origin);
 
-            //получение вектора, который надо прибавить к центру бокса, чтобы получившаяся точка была ровно посередине толщины стены
-            XYZ alignVector = bbCenterToProjectionVector.Normalize()
-                * (bbCenterToProjectionVector.GetLength() - wall.Width / 2);
+                XYZ bbCenterProjection = exteriorPlane.ProjectPoint(bbCenter);
+                XYZ bbCenterToProjectionVector = bbCenterProjection - bbCenter;
+
+                //получение вектора, который надо прибавить к центру бокса, чтобы получившаяся точка была ровно посередине толщины стены
+                alignVector = bbCenterToProjectionVector.Normalize()
+                    * (bbCenterToProjectionVector.GetLength() - wall.Width / 2);
+            } else {
+                alignVector = XYZ.Zero;
+            }
 
             return bbCenter + alignVector;
         }


### PR DESCRIPTION
Изменения:

- **Исправлен баг с точкой вставки в стенах, имеющих соединения с другими стенами**
  Было:
![image](https://github.com/Bim4Everyone/RevitPlugins/assets/87359016/241eb9e5-8c85-4c52-aac3-e761c0a6219b)

  Стало:
![image](https://github.com/Bim4Everyone/RevitPlugins/assets/87359016/1a65581f-94a7-45fb-8c4e-3ac0949178db)


- **Добавлено автоназначение настроек расстановки отверстий КР в соответствии с выбором навигатора:**
  
![image](https://github.com/Bim4Everyone/RevitPlugins/assets/87359016/dc59101b-7c49-47d1-9fb5-636d1a759997)

