### PR TITLE
Обновлен стиль кода и добавлены ссылки на документацию в .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,135 +27,209 @@ insert_final_newline = true
 #### .NET Coding Conventions ####
 
 # Organize usings
+# Add new line between System using and others
 dotnet_separate_import_directive_groups = true
+# System usings go first
 dotnet_sort_system_directives_first = true
+# Comment message in header of file
 file_header_template = unset
 
 # this. and Me. preferences
+# Make "this." bright or not
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009
 dotnet_style_qualification_for_event = false
 dotnet_style_qualification_for_field = false
 dotnet_style_qualification_for_method = false
 dotnet_style_qualification_for_property = false
 
 # Language keywords vs BCL types preferences
+# Make by default "int" or "Int32" etc.
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0049
 dotnet_style_predefined_type_for_locals_parameters_members = true
 dotnet_style_predefined_type_for_member_access = true
 
 # Parentheses preferences
+# Make parentheses bright or not in complex operations
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0047-ide0048
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
 
 # Modifier preferences
-dotnet_style_require_accessibility_modifiers = for_non_interface_members
+# Underscore all members with missed accessibility modifiers like warning
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0040
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
 
 # Expression-level preferences
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0029-ide0030-ide0270
 dotnet_style_coalesce_expression = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0028?pivots=dotnet-8-0
 dotnet_style_collection_initializer = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0033
 dotnet_style_explicit_tuple_names = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0130
 dotnet_style_namespace_match_folder = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0031
 dotnet_style_null_propagation = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0017
 dotnet_style_object_initializer = true
+# https://learn.microsoft.com/en-us/visualstudio/ide/reference/code-styles-refactoring-options?view=vs-2022
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0032
 dotnet_style_prefer_auto_properties = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0054-ide0074
 dotnet_style_prefer_compound_assignment = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0045
 dotnet_style_prefer_conditional_expression_over_assignment = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0046
 dotnet_style_prefer_conditional_expression_over_return = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0037
 dotnet_style_prefer_inferred_anonymous_type_member_names = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0037
 dotnet_style_prefer_inferred_tuple_names = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0041
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0075
 dotnet_style_prefer_simplified_boolean_expressions = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0071
 dotnet_style_prefer_simplified_interpolation = true
 
 # Field preferences
-dotnet_style_readonly_field = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_style_readonly_field = true:warning
 
 # Parameter preferences
-dotnet_code_quality_unused_parameters = all
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0060
+dotnet_code_quality_unused_parameters = all:warning
 
 # Suppression preferences
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0079
 dotnet_remove_unnecessary_suppression_exclusions = none
 
 # New line preferences
-dotnet_style_allow_multiple_blank_lines_experimental = true
-dotnet_style_allow_statement_immediately_after_block_experimental = true
+# Experimental not documented properties
+# https://github.com/dotnet/roslyn/issues/60539
+# https://github.com/dotnet/roslyn/issues/65770
+# dotnet_style_allow_multiple_blank_lines_experimental = true
+# dotnet_style_allow_statement_immediately_after_block_experimental = true
 
 #### C# Coding Conventions ####
 
 # var preferences
+# Prefer explicit type over var
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0007-ide0008
 csharp_style_var_elsewhere = false
 csharp_style_var_for_built_in_types = false
 csharp_style_var_when_type_is_apparent = false
 
 # Expression-bodied members
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0027
 csharp_style_expression_bodied_accessors = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0021
 csharp_style_expression_bodied_constructors = false
-csharp_style_expression_bodied_indexers = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0026
+csharp_style_expression_bodied_indexers = false
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0053
 csharp_style_expression_bodied_lambdas = true
-csharp_style_expression_bodied_local_functions = false
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0061
+csharp_style_expression_bodied_local_functions = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0022
 csharp_style_expression_bodied_methods = false
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0023-ide0024
 csharp_style_expression_bodied_operators = false
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0025
 csharp_style_expression_bodied_properties = true
 
-# Pattern matching preferences
+# Pattern matching preferences. Applicable not in all C# versions
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0019
 csharp_style_pattern_matching_over_as_with_null_check = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0020-ide0038
 csharp_style_pattern_matching_over_is_with_cast_check = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0083
 csharp_style_prefer_not_pattern = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0078-ide0260
 csharp_style_prefer_pattern_matching = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0066
 csharp_style_prefer_switch_expression = true
 
 # Null-checking preferences
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide1005
 csharp_style_conditional_delegate_call = true
 
 # Modifier preferences
+# csharp_prefer_static_local_function is applicable in C# 8.0+ 
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0062
 csharp_prefer_static_local_function = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0036
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
 
 # Code-block preferences
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0011
 csharp_prefer_braces = true
-csharp_prefer_simple_using_statement = true
+# csharp_prefer_simple_using_statement is applicable in C# 8.0+
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0063
+csharp_prefer_simple_using_statement = false
 
 # Expression-level preferences
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0034
 csharp_prefer_simple_default_expression = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0042
 csharp_style_deconstructed_variable_declaration = true
+# csharp_style_implicit_object_creation_when_type_is_apparent is applicable in C# 9.0+
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0090
 csharp_style_implicit_object_creation_when_type_is_apparent = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0018
 csharp_style_inlined_variable_declaration = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0039
 csharp_style_pattern_local_over_anonymous_function = true
+# csharp_style_prefer_index_operator is applicable in C# 8.0+
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0056
 csharp_style_prefer_index_operator = true
+# csharp_style_prefer_range_operator is applicable in C# 8.0+
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0057
 csharp_style_prefer_range_operator = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0016
 csharp_style_throw_expression = true
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0059?pivots=lang-csharp-vb
 csharp_style_unused_value_assignment_preference = discard_variable
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0058
 csharp_style_unused_value_expression_statement_preference = discard_variable
 
 # 'using' directive preferences
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0065
 csharp_using_directive_placement = outside_namespace
 
-# New line preferences
-csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
-csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true
-csharp_style_allow_embedded_statements_on_same_line_experimental = true
+# New line preferences. Not documented experimental properties
+# https://github.com/dotnet/roslyn/issues/60539
+# https://github.com/dotnet/roslyn/issues/65770
+# csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
+# csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true
+# csharp_style_allow_embedded_statements_on_same_line_experimental = true
 
 #### C# Formatting Rules ####
 
 # New line preferences
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options#new-line-options
 csharp_new_line_before_catch = false
 csharp_new_line_before_else = false
 csharp_new_line_before_finally = false
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_open_brace = none
-csharp_new_line_between_query_expression_clauses = false
+csharp_new_line_between_query_expression_clauses = true
 
 # Indentation preferences
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options#indentation-options
 csharp_indent_block_contents = true
 csharp_indent_braces = false
-csharp_indent_case_contents = false
+csharp_indent_case_contents = true
 csharp_indent_case_contents_when_block = false
 csharp_indent_labels = one_less_than_current
 csharp_indent_switch_labels = true
 
 # Space preferences
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options#spacing-options
 csharp_space_after_cast = true
 csharp_space_after_colon_in_inheritance_clause = true
 csharp_space_after_comma = true
@@ -180,47 +254,41 @@ csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
 # Wrapping preferences
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options#wrap-options
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = false
 
 #### Naming styles ####
 
 # Naming rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/naming-rules
+# https://github.com/dotnet/roslyn/blob/main/.editorconfig#L63
 
-dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
-dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
-dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+# Private and private protected fields are camelCase and start with _
+dotnet_naming_rule.private_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.private_fields_should_be_camel_case.symbols = private_fields
+dotnet_naming_rule.private_fields_should_be_camel_case.style = private_field_style
 
-dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.types_should_be_pascal_case.symbols = types
-dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, private_protected
 
-dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
-dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+dotnet_naming_style.private_field_style.capitalization = camel_case
+dotnet_naming_style.private_field_style.required_prefix = _
 
-# Symbol specifications
+# Locals and parameters are camelCase
+dotnet_naming_rule.locals_should_be_camel_case.severity = warning
+dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
+dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
 
-dotnet_naming_symbols.interface.applicable_kinds = interface
-dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers = 
+dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
 
-dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
-dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers = 
+dotnet_naming_style.camel_case_style.capitalization = camel_case
 
-dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
-dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers = 
+# By default, name items with PascalCase
+dotnet_naming_rule.members_should_be_pascal_case.severity = warning
+dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
+dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
 
-# Naming styles
+dotnet_naming_symbols.all_members.applicable_kinds = *
 
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
-dotnet_naming_style.pascal_case.capitalization = pascal_case
-
-dotnet_naming_style.begins_with_i.required_prefix = I
-dotnet_naming_style.begins_with_i.required_suffix = 
-dotnet_naming_style.begins_with_i.word_separator = 
-dotnet_naming_style.begins_with_i.capitalization = pascal_case
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case

--- a/.editorconfig
+++ b/.editorconfig
@@ -121,7 +121,7 @@ dotnet_remove_unnecessary_suppression_exclusions = none
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0007-ide0008
 csharp_style_var_elsewhere = false
 csharp_style_var_for_built_in_types = false
-csharp_style_var_when_type_is_apparent = false
+csharp_style_var_when_type_is_apparent = true
 
 # Expression-bodied members
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0027

--- a/.editorconfig
+++ b/.editorconfig
@@ -162,7 +162,7 @@ csharp_style_conditional_delegate_call = true
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0062
 csharp_prefer_static_local_function = true
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0036
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+csharp_preferred_modifier_order = public,private,protected,internal,file,new,static,abstract,virtual,sealed,readonly,override,extern,unsafe,volatile,async,required:warning
 
 # Code-block preferences
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0011

--- a/.editorconfig
+++ b/.editorconfig
@@ -284,6 +284,16 @@ dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
 
 dotnet_naming_style.camel_case_style.capitalization = camel_case
 
+# Interfaces in PascalCase and start with I
+dotnet_naming_rule.interfaces_should_be_pascal_case.severity = warning
+dotnet_naming_rule.interfaces_should_be_pascal_case.symbols = interfaces
+dotnet_naming_rule.interfaces_should_be_pascal_case.style = interfaces_style
+
+dotnet_naming_symbols.interfaces.applicable_kinds = interface
+
+dotnet_naming_style.interfaces_style.capitalization = pascal_case
+dotnet_naming_style.interfaces_style.required_prefix = I
+
 # By default, name items with PascalCase
 dotnet_naming_rule.members_should_be_pascal_case.severity = warning
 dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members


### PR DESCRIPTION
- Добавлены ссылки на документацию по свойствам .editorconfig
- Экспериментальные незадокументированные свойства выключены
- Для некоторых стилей добавлена строгость 'warning', таких как:
  - требование явного указания модификаторов доступа для всех членов, кроме публичных методов интерфейсов
  - требование отсутствия неиспользуемых параметров методов
  - требование модификатора readonly для полей, которые устанавливаются в конструкторе или имеют значение по умолчанию, и потом не меняются
  - требование стиля именования camelCase для локальных переменных и входных параметров методов
  - требование стиля именования _camelCase для приватных полей
  - требование стиля именования PascalCase для остальных членов
  - требование стиля именования IPascalCase для интерфейсов
- Теперь предпочтительны using выражения в "старом стиле" с использованием фигурных скобок
- Теперь предпочтительно составляющие сложных выражений запросов переносить построчно
- Теперь предпочтительно делать отступ для блоков case в switch
- Теперь предпочтительно определять тело индексаторов с использованием фигурных скобок
- Теперь предпочтительно определять тело локальных функций внутри фигурных скобок
- Теперь порядок ключевых слов следующий: public, private, protected, internal, file, new, static, abstract, virtual, sealed, readonly, override, extern, unsafe, volatile, async, required
- Теперь предпочтительно использовать var для очевидных типов, которые не являются встроенными