### PR TITLE
Отверстия: Исправлена ошибка определения солида станы - витража

### DIFF
--- a/src/RevitOpeningPlacement/Models/Extensions/HostObjectExtension.cs
+++ b/src/RevitOpeningPlacement/Models/Extensions/HostObjectExtension.cs
@@ -250,7 +250,7 @@ namespace RevitOpeningPlacement.Models.Extensions {
         /// <param name="hostObject"></param>
         /// <returns>True, если <paramref name="hostObject"/> - стена, иначе False (перекрытия, крыши, потолки)</returns>
         private static bool IsVerticallyCompound(this HostObject hostObject) {
-            return hostObject.GetElementType<HostObjAttributes>().GetCompoundStructure().IsVerticallyCompound;
+            return hostObject.GetElementType<HostObjAttributes>().GetCompoundStructure()?.IsVerticallyCompound ?? false;
         }
     }
 }

--- a/src/RevitOpeningPlacement/OpeningModels/OpeningRealBase.cs
+++ b/src/RevitOpeningPlacement/OpeningModels/OpeningRealBase.cs
@@ -184,6 +184,8 @@ namespace RevitOpeningPlacement.OpeningModels {
                 return CreateRawSolid(box);
             } catch(Autodesk.Revit.Exceptions.ArgumentOutOfRangeException) {
                 return CreateRawSolid(box);
+            } catch(Autodesk.Revit.Exceptions.ArgumentException) {
+                return CreateRawSolid(box);
             } catch(InvalidOperationException) {
                 return CreateRawSolid(box);
             } catch(ArgumentException) {


### PR DESCRIPTION
Исправлена ошибка, возникающая при определении солида хоста отверстия (АР/КР), когда хост - стена, сделанная семейством "Витраж".