### PR TITLE
RevitFinishingWalls: Настроен CI-CD запуска публикации плагина

### DIFF
--- a/.github/workflows/publish.RevitFinishingWalls.yml
+++ b/.github/workflows/publish.RevitFinishingWalls.yml
@@ -6,6 +6,7 @@ on:
     types: [ closed, synchronize, review_requested ]
     branches: [ main, master ]
     paths:
+      - '**RevitClashes**.cs'
       - '**RevitFinishingWalls**.cs'
       - '**RevitFinishingWalls**.xaml'
 


### PR DESCRIPTION
Т.к. плагин RevitFinishingWalls использует RevitClashes, добавил триггер на изменение файлов '**RevitClashes**.cs'