### PR TITLE
RevitClashDetective: Добавлена возможность изолировать элементы выбранной коллизии

### DIFF
--- a/RevitPlugins.sln
+++ b/RevitPlugins.sln
@@ -202,6 +202,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Handlers", "Handlers", "{7D
 		RevitClashes\Models\Handlers\RevitEventHandler.cs = RevitClashes\Models\Handlers\RevitEventHandler.cs
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GraphicView", "GraphicView", "{E41C8530-D08A-4320-BA0D-D604D85E23D2}"
+	ProjectSection(SolutionItems) = preProject
+		src\RevitClashes\Models\GraphicView\ParameterFilterProvider.cs = src\RevitClashes\Models\GraphicView\ParameterFilterProvider.cs
+	EndProjectSection
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RevitGenLookupTables", "src\RevitGenLookupTables\RevitGenLookupTables.csproj", "{65795232-ECD1-4811-A473-B718AE74E4E1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RevitFamilyExplorer", "src\RevitFamilyExplorer\RevitFamilyExplorer.csproj", "{0D3A89D6-19AA-44BA-A854-D5C63542CC60}"
@@ -286,11 +291,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RevitSectionsConstructor", "src\RevitSectionsConstructor\RevitSectionsConstructor.csproj", "{ED097443-BBE0-488F-BECC-7C7FDA188D74}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RevitFinishingWalls", "src\RevitFinishingWalls\RevitFinishingWalls.csproj", "{6EDA98F4-285F-47A1-BEBA-6EAE9323D9DF}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GraphicView", "GraphicView", "{E41C8530-D08A-4320-BA0D-D604D85E23D2}"
-	ProjectSection(SolutionItems) = preProject
-		src\RevitClashes\Models\GraphicView\ParameterFilterProvider.cs = src\RevitClashes\Models\GraphicView\ParameterFilterProvider.cs
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/RevitPlugins.sln
+++ b/RevitPlugins.sln
@@ -287,6 +287,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RevitSectionsConstructor", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RevitFinishingWalls", "src\RevitFinishingWalls\RevitFinishingWalls.csproj", "{6EDA98F4-285F-47A1-BEBA-6EAE9323D9DF}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GraphicView", "GraphicView", "{E41C8530-D08A-4320-BA0D-D604D85E23D2}"
+	ProjectSection(SolutionItems) = preProject
+		src\RevitClashes\Models\GraphicView\ParameterFilterProvider.cs = src\RevitClashes\Models\GraphicView\ParameterFilterProvider.cs
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		D2020|x64 = D2020|x64
@@ -803,6 +808,7 @@ Global
 		{D9661EB6-ECF7-4E7F-B055-65A6313EDF8B} = {968DE2B9-F390-4B99-A796-A797FBB7847A}
 		{74DD9D4A-AEAD-4C5E-ACBD-B5447AA791DA} = {968DE2B9-F390-4B99-A796-A797FBB7847A}
 		{7D8627B7-D98F-4D86-A10F-7C9DA00EEA7B} = {968DE2B9-F390-4B99-A796-A797FBB7847A}
+		{E41C8530-D08A-4320-BA0D-D604D85E23D2} = {968DE2B9-F390-4B99-A796-A797FBB7847A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2332A0ED-46BB-427C-AAD9-EFA10FA76316}

--- a/src/RevitClashDetective/ViewModels/Navigator/ReportViewModel.cs
+++ b/src/RevitClashDetective/ViewModels/Navigator/ReportViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Input;
@@ -49,7 +49,6 @@ namespace RevitClashDetective.ViewModels.Navigator {
             set => this.RaiseAndSetIfChanged(ref _clashes, value);
         }
 
-        public ICommand SelectClashCommand { get; set; }
 
         public ICommand SaveCommand { get; set; }
 
@@ -74,7 +73,6 @@ namespace RevitClashDetective.ViewModels.Navigator {
 
             InitializeTimer();
 
-            SelectClashCommand = new RelayCommand(SelectClash, CanSelectClash);
             SaveCommand = new RelayCommand(Save);
             SaveAsCommand = new RelayCommand(SaveAs);
         }
@@ -110,20 +108,6 @@ namespace RevitClashDetective.ViewModels.Navigator {
 
         private bool IsValid(List<string> documentNames, ClashViewModel clash) {
             return clash.Clash.IsValid(documentNames);
-        }
-
-        private void SelectClash(object p) {
-            var clash = (ClashViewModel) p;
-
-            var elements = new[] {
-                clash.Clash.MainElement,
-                clash.Clash.OtherElement
-            };
-            _revitRepository.SelectAndShowElement(elements.Where(item => item != null));
-        }
-
-        private bool CanSelectClash(object p) {
-            return p != null && p is ClashViewModel;
         }
 
         private void InitializeTimer() {

--- a/src/RevitClashDetective/ViewModels/Navigator/ReportsViewModel.cs
+++ b/src/RevitClashDetective/ViewModels/Navigator/ReportsViewModel.cs
@@ -136,11 +136,7 @@ namespace RevitClashDetective.ViewModels.Navigator {
         private bool CanDelete() => SelectedReport != null;
 
         private void SelectClash(ClashViewModel clash) {
-            var elements = new[] {
-                clash.Clash.MainElement,
-                clash.Clash.OtherElement
-            };
-            _revitRepository.SelectAndShowElement(elements);
+            _revitRepository.SelectAndShowElement(clash.Clash, IsolateSelectedElements);
         }
 
         private bool CanSelectClash(ClashViewModel p) {

--- a/src/RevitClashDetective/ViewModels/Navigator/ReportsViewModel.cs
+++ b/src/RevitClashDetective/ViewModels/Navigator/ReportsViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
@@ -19,6 +19,7 @@ namespace RevitClashDetective.ViewModels.Navigator {
     internal class ReportsViewModel : BaseViewModel {
         private readonly RevitRepository _revitRepository;
 
+        private bool _isolateSelectedElements;
         private bool _openFromClashDetector;
         private ReportViewModel _selectedFile;
         private ObservableCollection<ReportViewModel> _reports;
@@ -33,30 +34,38 @@ namespace RevitClashDetective.ViewModels.Navigator {
                 InitializeFiles(selectedFile);
             }
 
-            OpenClashDetectorCommand = new RelayCommand(OpenClashDetector, p => OpenFromClashDetector);
-            LoadCommand = new RelayCommand(Load);
-            DeleteCommand = new RelayCommand(Delete, CanDelete);
+            OpenClashDetectorCommand = RelayCommand.Create(OpenClashDetector, () => OpenFromClashDetector);
+            LoadCommand = RelayCommand.Create(Load);
+            DeleteCommand = RelayCommand.Create(Delete, CanDelete);
+            SelectClashCommand = RelayCommand.Create<ClashViewModel>(SelectClash, CanSelectClash);
         }
 
+
+        public ICommand SelectClashCommand { get; }
         public ICommand OpenClashDetectorCommand { get; }
         public ICommand LoadCommand { get; }
         public ICommand DeleteCommand { get; }
 
         public ObservableCollection<ReportViewModel> Reports {
             get => _reports;
-            set => this.RaiseAndSetIfChanged(ref _reports, value);
+            set => RaiseAndSetIfChanged(ref _reports, value);
         }
 
         public bool IsColumnVisible => Reports != null;
 
         public bool OpenFromClashDetector {
             get => _openFromClashDetector;
-            set => this.RaiseAndSetIfChanged(ref _openFromClashDetector, value);
+            set => RaiseAndSetIfChanged(ref _openFromClashDetector, value);
         }
 
         public ReportViewModel SelectedReport {
             get => _selectedFile;
-            set => this.RaiseAndSetIfChanged(ref _selectedFile, value);
+            set => RaiseAndSetIfChanged(ref _selectedFile, value);
+        }
+
+        public bool IsolateSelectedElements {
+            get => _isolateSelectedElements;
+            set => RaiseAndSetIfChanged(ref _isolateSelectedElements, value);
         }
 
 
@@ -78,16 +87,15 @@ namespace RevitClashDetective.ViewModels.Navigator {
             }
         }
 
-        private void OpenClashDetector(object p) {
-            void action() {
+        private void OpenClashDetector() {
+            _revitRepository.DoAction(() => {
                 var command = new DetectiveClashesCommand();
                 command.ExecuteCommand(_revitRepository.UiApplication);
-            }
-            _revitRepository.DoAction(action);
+            });
         }
 
 
-        private void Load(object p) {
+        private void Load() {
             var openWindow = GetPlatformService<IOpenFileDialogService>();
             openWindow.Filter = "AutodeskClashReport (*.html)|*.html|PluginClashReport (*.json)|*.json";
 
@@ -110,7 +118,7 @@ namespace RevitClashDetective.ViewModels.Navigator {
             SelectedReport = report;
         }
 
-        private void Delete(object p) {
+        private void Delete() {
             var mb = GetPlatformService<IMessageBoxService>();
             if(mb.Show("Вы уверены, что хотите удалить файл?", "BIM", MessageBoxButton.YesNo, MessageBoxImage.Warning, MessageBoxResult.Cancel) == MessageBoxResult.Yes) {
                 DeleteConfig(SelectedReport.GetUpdatedConfig());
@@ -125,6 +133,21 @@ namespace RevitClashDetective.ViewModels.Navigator {
             }
         }
 
-        private bool CanDelete(object p) => SelectedReport != null;
+        private bool CanDelete() => SelectedReport != null;
+
+        private void SelectClash(ClashViewModel clash) {
+            var elements = new[] {
+                clash.Clash.MainElement,
+                clash.Clash.OtherElement
+            };
+            _revitRepository.SelectAndShowElement(elements);
+        }
+
+        private bool CanSelectClash(ClashViewModel p) {
+            return p != null
+                && p.Clash != null
+                && p.Clash.MainElement != null
+                && p.Clash.OtherElement != null;
+        }
     }
 }

--- a/src/RevitClashDetective/ViewModels/Navigator/ReportsViewModel.cs
+++ b/src/RevitClashDetective/ViewModels/Navigator/ReportsViewModel.cs
@@ -19,7 +19,7 @@ namespace RevitClashDetective.ViewModels.Navigator {
     internal class ReportsViewModel : BaseViewModel {
         private readonly RevitRepository _revitRepository;
 
-        private bool _isolateSelectedElements = true;
+        private bool _elementsIsolationEnabled = true;
         private bool _openFromClashDetector;
         private ReportViewModel _selectedFile;
         private ObservableCollection<ReportViewModel> _reports;
@@ -63,9 +63,9 @@ namespace RevitClashDetective.ViewModels.Navigator {
             set => RaiseAndSetIfChanged(ref _selectedFile, value);
         }
 
-        public bool IsolateSelectedElements {
-            get => _isolateSelectedElements;
-            set => RaiseAndSetIfChanged(ref _isolateSelectedElements, value);
+        public bool ElementsIsolationEnabled {
+            get => _elementsIsolationEnabled;
+            set => RaiseAndSetIfChanged(ref _elementsIsolationEnabled, value);
         }
 
 
@@ -136,7 +136,7 @@ namespace RevitClashDetective.ViewModels.Navigator {
         private bool CanDelete() => SelectedReport != null;
 
         private void SelectClash(ClashViewModel clash) {
-            _revitRepository.SelectAndShowElement(clash.Clash, IsolateSelectedElements);
+            _revitRepository.SelectAndShowElement(clash.Clash, ElementsIsolationEnabled);
         }
 
         private bool CanSelectClash(ClashViewModel p) {

--- a/src/RevitClashDetective/ViewModels/Navigator/ReportsViewModel.cs
+++ b/src/RevitClashDetective/ViewModels/Navigator/ReportsViewModel.cs
@@ -19,7 +19,7 @@ namespace RevitClashDetective.ViewModels.Navigator {
     internal class ReportsViewModel : BaseViewModel {
         private readonly RevitRepository _revitRepository;
 
-        private bool _isolateSelectedElements;
+        private bool _isolateSelectedElements = true;
         private bool _openFromClashDetector;
         private ReportViewModel _selectedFile;
         private ObservableCollection<ReportViewModel> _reports;

--- a/src/RevitClashDetective/Views/NavigatorView.xaml
+++ b/src/RevitClashDetective/Views/NavigatorView.xaml
@@ -149,7 +149,7 @@
         <DockPanel Grid.Row="2"
                    Margin="0 10 0 0">
             <DockPanel>
-                <dxe:CheckEdit EditValue="{Binding IsolateSelectedElements}"
+                <dxe:CheckEdit EditValue="{Binding ElementsIsolationEnabled}"
                                Content="Изолировать выделенные элементы" />
             </DockPanel>
 

--- a/src/RevitClashDetective/Views/NavigatorView.xaml
+++ b/src/RevitClashDetective/Views/NavigatorView.xaml
@@ -81,12 +81,6 @@
                 <dxg:GridSummaryItem SummaryType="Count" />
             </dxg:GridControl.GroupSummary>
 
-            <!--<mvvm:Interaction.Behaviors>
-                <mvvm:EventToCommand EventName="SelectedItemChanged"
-                                     Command="{Binding SelectClashCommand}"
-                                     CommandParameter="{Binding ElementName=_dg, Path=CurrentItem}" />
-            </mvvm:Interaction.Behaviors>-->
-
             <dxg:GridControl.View>
                 <dxg:TableView Name="_gridView"
                                AutoWidth="True"

--- a/src/RevitClashDetective/Views/NavigatorView.xaml
+++ b/src/RevitClashDetective/Views/NavigatorView.xaml
@@ -1,23 +1,23 @@
-﻿<base:ThemedPlatformWindow
-    x:Class="RevitClashDetective.Views.NavigatorView"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:vm="clr-namespace:RevitClashDetective.ViewModels.Navigator"
-    xmlns:m="clr-namespace:RevitClashDetective.Models.Clashes"
-    xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-    xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
-    xmlns:mvvm="http://schemas.devexpress.com/winfx/2008/xaml/mvvm"
-    xmlns:dxg="http://schemas.devexpress.com/winfx/2008/xaml/grid"
-    xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
-    xmlns:base="clr-namespace:dosymep.WPF.Views"
-    xmlns:converters="clr-namespace:dosymep.WPF.Converters"
-    xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
-
-    mc:Ignorable="d"
-    Title="Навигатор" Height="450" Width="800"
-    d:DataContext="{d:DesignInstance vm:ReportsViewModel, IsDesignTimeCreatable=False}">
+﻿<base:ThemedPlatformWindow x:Class="RevitClashDetective.Views.NavigatorView"
+                           xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                           xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                           xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                           xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                           xmlns:vm="clr-namespace:RevitClashDetective.ViewModels.Navigator"
+                           xmlns:m="clr-namespace:RevitClashDetective.Models.Clashes"
+                           xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+                           xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+                           xmlns:mvvm="http://schemas.devexpress.com/winfx/2008/xaml/mvvm"
+                           xmlns:dxg="http://schemas.devexpress.com/winfx/2008/xaml/grid"
+                           xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+                           xmlns:base="clr-namespace:dosymep.WPF.Views"
+                           xmlns:converters="clr-namespace:dosymep.WPF.Converters"
+                           xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
+                           mc:Ignorable="d"
+                           Title="Навигатор"
+                           Height="450"
+                           Width="800"
+                           d:DataContext="{d:DesignInstance vm:ReportsViewModel, IsDesignTimeCreatable=False}">
     <b:Interaction.Triggers>
         <b:EventTrigger EventName="Closing">
             <b:InvokeCommandAction Command="{Binding OpenClashDetectorCommand}" />
@@ -25,9 +25,16 @@
     </b:Interaction.Triggers>
     <base:ThemedPlatformWindow.Resources>
         <converters:IndexConverter x:Key="IndexConverter" />
+        <Style TargetType="dxg:GridColumn"
+               x:Key="ReadOnlyColumn">
+            <Setter Property="ReadOnly"
+                    Value="True" />
+            <Setter Property="AllowEditing"
+                    Value="False" />
+        </Style>
     </base:ThemedPlatformWindow.Resources>
     <Grid Margin="10">
-        
+
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
@@ -37,11 +44,11 @@
 
         <DockPanel LastChildFill="True">
 
-            <dx:SimpleButton DockPanel.Dock="Left" 
+            <dx:SimpleButton DockPanel.Dock="Left"
                              ToolTip="Загрузить"
                              Command="{Binding LoadCommand}"
                              Glyph="{dx:DXImage 'Office2013/Actions/Download_32x32.png'}" />
-            <dx:SimpleButton DockPanel.Dock="Left" 
+            <dx:SimpleButton DockPanel.Dock="Left"
                              Margin="5 0 0 0"
                              ToolTip="Сохранить"
                              Command="{Binding SelectedReport.SaveCommand }"
@@ -56,89 +63,116 @@
                              ToolTip="Удалить"
                              Command="{Binding DeleteCommand}"
                              Glyph="{dx:DXImage 'Office2013/Reports/DeleteGroupHeader_32x32.png'}" />
-            <dxe:ComboBoxEdit IsTextEditable="False" 
+            <dxe:ComboBoxEdit IsTextEditable="False"
                               Margin="5 0 0 0"
                               ItemsSource="{Binding Reports}"
                               DisplayMember="Name"
                               SelectedItem="{Binding SelectedReport}">
             </dxe:ComboBoxEdit>
-            
+
         </DockPanel>
 
         <dxg:GridControl Name="_dg"
                          Grid.Row="1"
                          AllowCollectionView="False"
                          ItemsSource="{Binding SelectedReport.Clashes}">
-            
+
             <dxg:GridControl.GroupSummary>
                 <dxg:GridSummaryItem SummaryType="Count" />
             </dxg:GridControl.GroupSummary>
-            
-            <mvvm:Interaction.Behaviors>
-                <mvvm:EventToCommand EventName="SelectedItemChanged" Command="{Binding SelectedReport.SelectClashCommand}" 
+
+            <!--<mvvm:Interaction.Behaviors>
+                <mvvm:EventToCommand EventName="SelectedItemChanged"
+                                     Command="{Binding SelectClashCommand}"
                                      CommandParameter="{Binding ElementName=_dg, Path=CurrentItem}" />
-            </mvvm:Interaction.Behaviors>
-            
+            </mvvm:Interaction.Behaviors>-->
+
             <dxg:GridControl.View>
-                <dxg:TableView Name="_gridView" 
-                               AutoWidth="True" 
+                <dxg:TableView Name="_gridView"
+                               AutoWidth="True"
                                DataNavigatorButtons="Navigation"
                                AllowMergedGrouping="True"
                                ShowDataNavigator="True">
                 </dxg:TableView>
             </dxg:GridControl.View>
-            
+
             <dxg:GridControl.Columns>
-                
-                <dxg:GridColumn ReadOnly="True" Width="70" Header="">
+
+                <dxg:GridColumn ReadOnly="True"
+                                Width="70"
+                                MinWidth="70"
+                                AllowResizing="False"
+                                Header="">
                     <dxg:GridColumn.CellTemplate>
                         <DataTemplate>
                             <dx:SimpleButton Content="Выбрать"
-                                             Command="{Binding ElementName=_dg, Path=DataContext.SelectedReport.SelectClashCommand}"
+                                             Command="{Binding ElementName=_dg, Path=DataContext.SelectClashCommand}"
                                              CommandParameter="{Binding Row}" />
                         </DataTemplate>
                     </dxg:GridColumn.CellTemplate>
                 </dxg:GridColumn>
-                
+
                 <dxg:GridColumn Header="Статус">
                     <dxg:GridColumn.CellTemplate>
                         <DataTemplate>
                             <dxe:ComboBoxEdit ApplyItemTemplateToSelectedItem="True"
-                                              IsTextEditable="False" 
-                                              EditMode="InplaceActive" 
-                                              EditValue="{Binding Row.ClashStatus}" 
+                                              IsTextEditable="False"
+                                              EditMode="InplaceActive"
+                                              EditValue="{Binding Row.ClashStatus}"
                                               ItemsSource="{dxe:EnumItemsSource EnumType={x:Type m:ClashStatus}}" />
                         </DataTemplate>
                     </dxg:GridColumn.CellTemplate>
                 </dxg:GridColumn>
 
-                <dxg:GridColumn ReadOnly="True" Header="Уровень 1" FieldName="FirstLevel"/>
-                <dxg:GridColumn ReadOnly="True" Header="Категория 1" FieldName="FirstCategory" />
-                <dxg:GridColumn ReadOnly="True" Header="Имя типа 1" FieldName="FirstName" />
-                <dxg:GridColumn ReadOnly="True" Header="Имя файла 1" FieldName="FirstDocumentName" />
-                <dxg:GridColumn ReadOnly="True" Header="Уровень 2" FieldName="SecondLevel" />
-                <dxg:GridColumn ReadOnly="True" Header="Категория 2" FieldName="SecondCategory" />
-                <dxg:GridColumn ReadOnly="True" Header="Имя типа 2" FieldName="SecondName" />
-                <dxg:GridColumn ReadOnly="True" Header="Имя файла 2" FieldName="SecondDocumentName" />
-                
+                <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
+                                Header="Уровень 1"
+                                FieldName="FirstLevel" />
+                <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
+                                Header="Категория 1"
+                                FieldName="FirstCategory" />
+                <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
+                                Header="Имя типа 1"
+                                FieldName="FirstName" />
+                <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
+                                Header="Имя файла 1"
+                                FieldName="FirstDocumentName" />
+                <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
+                                Header="Уровень 2"
+                                FieldName="SecondLevel" />
+                <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
+                                Header="Категория 2"
+                                FieldName="SecondCategory" />
+                <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
+                                Header="Имя типа 2"
+                                FieldName="SecondName" />
+                <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
+                                Header="Имя файла 2"
+                                FieldName="SecondDocumentName" />
+
             </dxg:GridControl.Columns>
         </dxg:GridControl>
 
-        <StackPanel Grid.Row="2" Margin="0 10 0 0" Orientation="Horizontal"
-                    HorizontalAlignment="Right">
-            
-            <dxe:TextEdit Margin="10 0" 
-                          IsReadOnly="True" 
-                          EditMode="InplaceActive" 
-                          EditValue="{Binding SelectedReport.Message}"
-                          Foreground="Green" />
-            <dx:SimpleButton Content="Отмена" 
-                             Height="25" 
-                             Width="80" 
-                             IsCancel="true"
-                             Click="ButtonCancel_Click" />
-            
-        </StackPanel>
+        <DockPanel Grid.Row="2"
+                   Margin="0 10 0 0">
+            <DockPanel>
+                <dxe:CheckEdit EditValue="{Binding IsolateSelectedElements}"
+                               Content="Изолировать выделенные элементы" />
+            </DockPanel>
+
+            <DockPanel HorizontalAlignment="Right">
+                <dxe:TextEdit Margin="10 0"
+                              IsReadOnly="True"
+                              EditMode="InplaceActive"
+                              EditValue="{Binding SelectedReport.Message}"
+                              Foreground="Green" />
+                <dx:SimpleButton Content="Отмена"
+                                 Height="25"
+                                 Width="80"
+                                 IsCancel="true"
+                                 Click="ButtonCancel_Click" />
+            </DockPanel>
+
+        </DockPanel>
 
     </Grid>
 </base:ThemedPlatformWindow>

--- a/src/RevitClashes/Models/GraphicView/ParameterFilterProvider.cs
+++ b/src/RevitClashes/Models/GraphicView/ParameterFilterProvider.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Autodesk.Revit.DB;
+
+using dosymep.Revit;
+
+using RevitClashDetective.Models.Visiter;
+
+namespace RevitClashDetective.Models.GraphicView {
+    internal class ParameterFilterProvider {
+        private readonly NotEqualsVisister _notEqualsVisister;
+
+        public ParameterFilterProvider() {
+            _notEqualsVisister = new NotEqualsVisister();
+        }
+
+
+        public ParameterFilterElement GetHighlightFilter(Document document, Element element, string filterName) {
+            if(document is null) { throw new ArgumentNullException(nameof(document)); }
+            if(element is null) { throw new ArgumentNullException(nameof(element)); }
+            if(string.IsNullOrWhiteSpace(filterName)) { throw new ArgumentException(nameof(filterName)); }
+
+            var elementFilter = GetOrCreateFilter(document, filterName, element.Category.GetBuiltInCategory());
+            return UpdateHighlightFilter(document, elementFilter, element);
+        }
+
+
+        private ParameterFilterElement GetOrCreateFilter(
+            Document document,
+            string filterName,
+            BuiltInCategory category) {
+
+            return GetOrCreateFilter(document, filterName, new BuiltInCategory[] { category });
+        }
+
+        /// <summary>
+        /// Возвращает существующий или создает новый фильтр для настроек графики на виде
+        /// </summary>
+        /// <param name="document">Документ, в котором нужно получить фильтр</param>
+        /// <param name="filterName">Название фильтра</param>
+        /// <param name="categories">Категории элементов для фильтра</param>
+        /// <returns></returns>
+        private ParameterFilterElement GetOrCreateFilter(
+            Document document,
+            string filterName,
+            ICollection<BuiltInCategory> categories) {
+
+            ParameterFilterElement filter = new FilteredElementCollector(document)
+                .OfClass(typeof(ParameterFilterElement))
+                .OfType<ParameterFilterElement>()
+                .FirstOrDefault(item => item.Name.Equals(filterName));
+            if(filter == null) {
+                using(Transaction t = document.StartTransaction("Создание фильтра")) {
+                    filter = ParameterFilterElement.Create(
+                        document,
+                        filterName,
+                        categories
+                            .Select(item => new ElementId(item))
+                            .ToArray());
+
+                    t.Commit();
+                }
+            }
+
+            return filter;
+        }
+
+        private ParameterFilterElement UpdateHighlightFilter(
+            Document document,
+            ParameterFilterElement filter,
+            Element element) {
+
+            using(Transaction t = document.StartTransaction("Обновление фильтра")) {
+                //переназначить категории элементов, если пользователь изменил их
+                filter.SetCategories(new ElementId[] { new ElementId(element.Category.GetBuiltInCategory()) });
+                //сбросить все критерии фильтрации
+                filter.ClearRules();
+                //установить критерии фильтрации
+                filter.SetElementFilter(GetGighlightElementFilter(element));
+                t.Commit();
+            }
+            return filter;
+        }
+
+        /// <summary>
+        /// Возвращает фильтр, в который попадают все элементы, 
+        /// значение типоразмера и значение double параметров которых отличаются 
+        /// от соответствующих значений параметров заданного элемента
+        /// </summary>
+        /// <param name="element"></param>
+        /// <returns>Фильтр вида: Имя типа != "имя типа" ИЛИ Размер != ХХХ ИЛИ Высота != ХХХ и т.д.</returns>
+        private ElementFilter GetGighlightElementFilter(Element element) {
+            //имя типа элемента
+            BuiltInParameter typeName = BuiltInParameter.ALL_MODEL_TYPE_NAME;
+            string elType = element.GetParamValue<string>(typeName);
+
+            //отсеиваем все элементы, у которых название типа не равно названию типа заданного элемента
+            FilterRule typeNameNotEqualsRule = _notEqualsVisister.Create(new ElementId(typeName), elType);
+            ElementParameterFilter typeNameNotEqualsFilter = new ElementParameterFilter(typeNameNotEqualsRule);
+            List<ElementFilter> filters = new List<ElementFilter> {
+                typeNameNotEqualsFilter
+            };
+
+            var doubleParameters = GetParameters(element).Where(p => p.HasValue && p.StorageType == StorageType.Double);
+            foreach(var param in doubleParameters) {
+                FilterRule rule = _notEqualsVisister.Create(param.Id, param.AsDouble());
+                ElementParameterFilter paramFilter = new ElementParameterFilter(rule);
+                filters.Add(paramFilter);
+            }
+            return new LogicalOrFilter(filters);
+        }
+
+        private ICollection<Parameter> GetParameters(Element element) {
+            List<Parameter> parameters = new List<Parameter>();
+            foreach(Parameter parameter in element.Parameters) {
+                parameters.Add(parameter);
+            }
+            return parameters;
+        }
+    }
+}

--- a/src/RevitClashes/Models/GraphicView/ParameterFilterProvider.cs
+++ b/src/RevitClashes/Models/GraphicView/ParameterFilterProvider.cs
@@ -36,6 +36,37 @@ namespace RevitClashDetective.Models.GraphicView {
         }
 
         /// <summary>
+        /// Возвращает фильтр по параметрам элементов на виде, выключив видимость элементов которого,
+        /// скроются все элементы той же категории, что и заданные элементы, кроме самих заданных элементов.
+        /// При этом заданные элементы должны быть строго одной и той же категории
+        /// </summary>
+        /// <param name="document"></param>
+        /// <param name="firstEl">Первый элемент</param>
+        /// <param name="secondEl">Второй элемент с такой же категорией как у первого</param>
+        /// <param name="filterName">Название фильтра</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        /// <exception cref="InvalidOperationException"></exception>
+        public ParameterFilterElement GetHighlightFilter(
+            Document document,
+            Element firstEl,
+            Element secondEl,
+            string filterName) {
+
+            if(document is null) { throw new ArgumentNullException(nameof(document)); }
+            if(firstEl is null) { throw new ArgumentNullException(nameof(firstEl)); }
+            if(secondEl is null) { throw new ArgumentNullException(nameof(secondEl)); }
+            if(string.IsNullOrWhiteSpace(filterName)) { throw new ArgumentException(nameof(filterName)); }
+            if(firstEl.Category.GetBuiltInCategory() != secondEl.Category.GetBuiltInCategory()) {
+                throw new InvalidOperationException($"У элементов разные категории");
+            }
+
+            var filter = GetOrCreateFilter(document, filterName, firstEl.Category.GetBuiltInCategory());
+            return UpdateHighlightFilter(filter, firstEl, secondEl);
+        }
+
+        /// <summary>
         /// Возвращает фильтр с заданным названием по всем категориям элементов модели, кроме заданных категорий
         /// </summary>
         /// <param name="document">Документ, в котором должен быть получен фильтр</param>
@@ -122,9 +153,9 @@ namespace RevitClashDetective.Models.GraphicView {
         }
 
         /// <summary>
-        /// Обновляет фильтр по параметрам элементов на виде, который нужен для скрытия элементов той же категории, что и заданный элемент, но отличных от него
+        /// Обновляет фильтр по параметрам элементов на виде, который нужен для скрытия элементов той же категории, 
+        /// что и заданный элемент, но отличных от него
         /// </summary>
-        /// <param name="document">Документ, в котором создан фильтр</param>
         /// <param name="filter">Фильтр по параметрам элементов на виде, который надо обновить</param>
         /// <param name="element">Элемент, который выделяется фильтром. То есть элемент, который не попадает в фильтр.</param>
         /// <returns></returns>
@@ -134,21 +165,45 @@ namespace RevitClashDetective.Models.GraphicView {
 
             //переназначить категории элементов, если пользователь изменил их
             filter.SetCategories(new ElementId[] { new ElementId(element.Category.GetBuiltInCategory()) });
-            //сбросить все критерии фильтрации
-            filter.ClearRules();
-            //установить критерии фильтрации
-            filter.SetElementFilter(GetGighlightElementFilter(element, filter));
+            //переназначить критерии фильтрации
+            filter.SetElementFilter(GetHighlightElementFilter(element, filter));
             return filter;
         }
 
         /// <summary>
-        /// Возвращает фильтр, в который попадают все элементы, 
+        /// Обновляет фильтр по параметрам элементов на виде, который нужен для скрытия элементов той же категории, 
+        /// что и заданные элементы, но отличные от них.
+        /// При этом заданные элементы должны быть строго одной и той же категории
+        /// </summary>
+        /// <param name="filter">Фильтр по параметрам элементов на виде, который надо обновить</param>
+        /// <param name="firstEl">Первый элемент</param>
+        /// <param name="secondEl">Второй элемент</param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        private ParameterFilterElement UpdateHighlightFilter(
+            ParameterFilterElement filter,
+            Element firstEl,
+            Element secondEl) {
+            if(firstEl.Category.GetBuiltInCategory() != secondEl.Category.GetBuiltInCategory()) {
+                throw new InvalidOperationException("У элементов разные категории");
+            }
+
+            //переназначить категории элементов, если пользователь изменил их
+            filter.SetCategories(new ElementId[] { new ElementId(firstEl.Category.GetBuiltInCategory()) });
+            //переназначить критерии фильтрации
+            filter.SetElementFilter(GetHighlightElementFilter(firstEl, secondEl, filter));
+            return filter;
+        }
+
+        /// <summary>
+        /// Возвращает фильтр, в который попадают все элементы категории заданного элемента, 
         /// значение типоразмера и значение double параметров которых отличаются 
         /// от соответствующих значений параметров заданного элемента
         /// </summary>
         /// <param name="element"></param>
+        /// <param name="checker">Экземпляр класса для проверки возможности установить фильтры на параметры</param>
         /// <returns>Фильтр вида: Имя типа != "имя типа" ИЛИ Размер != ХХХ ИЛИ Высота != ХХХ и т.д.</returns>
-        private ElementFilter GetGighlightElementFilter(Element element, ParameterFilterElement checker) {
+        private ElementFilter GetHighlightElementFilter(Element element, ParameterFilterElement checker) {
             List<ElementFilter> filters = new List<ElementFilter> { };
             //проверяем наличие типа у элемента
             if(element.HasElementType()) {
@@ -175,7 +230,33 @@ namespace RevitClashDetective.Models.GraphicView {
         }
 
         /// <summary>
-        /// Проверяет, что заданный фильтр может быть использован внутри фильтра по параметрам для фильтрации элементов на виде
+        /// Возвращает фильтр, в который попадают все элементы категории заданных элементов,
+        /// значения типоразмеров и значения double параметров которых отличаются 
+        /// от соответствующих значений параметров заданных элементов.
+        /// При этом заданные элементы должны быть строго одной и той же категории.
+        /// </summary>
+        /// <param name="firstEl">Первый элемент</param>
+        /// <param name="secondEl">Второй элемент с такой же категорией как у первого</param>
+        /// <param name="checker">Экземпляр класса для проверки возможности установить фильтры на параметры</param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        private ElementFilter GetHighlightElementFilter(
+            Element firstEl,
+            Element secondEl,
+            ParameterFilterElement checker) {
+            if(firstEl.Category.GetBuiltInCategory() != secondEl.Category.GetBuiltInCategory()) {
+                throw new InvalidOperationException("У элементов разные категории");
+            }
+
+            var firstOrFilter = GetHighlightElementFilter(firstEl, checker);
+            var secondOrFilter = GetHighlightElementFilter(secondEl, checker);
+
+            return new LogicalAndFilter(firstOrFilter, secondOrFilter);
+        }
+
+        /// <summary>
+        /// Проверяет, что заданный фильтр может быть использован 
+        /// внутри фильтра по параметрам для фильтрации элементов на виде
         /// </summary>
         /// <param name="checker">Фильтр по параметрам на виде</param>
         /// <param name="elementFilter">Фильтр, который надо проверить</param>

--- a/src/RevitClashes/Models/GraphicView/ParameterFilterProvider.cs
+++ b/src/RevitClashes/Models/GraphicView/ParameterFilterProvider.cs
@@ -184,12 +184,12 @@ namespace RevitClashDetective.Models.GraphicView {
             ParameterFilterElement filter,
             Element firstEl,
             Element secondEl) {
-            if(firstEl.Category.GetBuiltInCategory() != secondEl.Category.GetBuiltInCategory()) {
+            if(firstEl.Category.Id != secondEl.Category.Id) {
                 throw new InvalidOperationException("У элементов разные категории");
             }
 
             //переназначить категории элементов, если пользователь изменил их
-            filter.SetCategories(new ElementId[] { new ElementId(firstEl.Category.GetBuiltInCategory()) });
+            filter.SetCategories(new ElementId[] { firstEl.Category.Id });
             //переназначить критерии фильтрации
             filter.SetElementFilter(GetHighlightElementFilter(firstEl, secondEl, filter));
             return filter;
@@ -204,7 +204,7 @@ namespace RevitClashDetective.Models.GraphicView {
         /// <param name="checker">Экземпляр класса для проверки возможности установить фильтры на параметры</param>
         /// <returns>Фильтр вида: Имя типа != "имя типа" ИЛИ Размер != ХХХ ИЛИ Высота != ХХХ и т.д.</returns>
         private ElementFilter GetHighlightElementFilter(Element element, ParameterFilterElement checker) {
-            List<ElementFilter> filters = new List<ElementFilter> { };
+            List<ElementFilter> filters = new List<ElementFilter>();
             //проверяем наличие типа у элемента
             if(element.HasElementType()) {
                 BuiltInParameter typeName = BuiltInParameter.ALL_MODEL_TYPE_NAME;
@@ -244,7 +244,7 @@ namespace RevitClashDetective.Models.GraphicView {
             Element firstEl,
             Element secondEl,
             ParameterFilterElement checker) {
-            if(firstEl.Category.GetBuiltInCategory() != secondEl.Category.GetBuiltInCategory()) {
+            if(firstEl.Category.Id != secondEl.Category.Id) {
                 throw new InvalidOperationException("У элементов разные категории");
             }
 
@@ -266,12 +266,8 @@ namespace RevitClashDetective.Models.GraphicView {
                 && checker.AllRuleParametersApplicable(elementFilter);
         }
 
-        private ICollection<Parameter> GetParameters(Element element) {
-            List<Parameter> parameters = new List<Parameter>();
-            foreach(Parameter parameter in element.Parameters) {
-                parameters.Add(parameter);
-            }
-            return parameters;
+        private IEnumerable<Parameter> GetParameters(Element element) {
+            return element.Parameters.OfType<Parameter>();
         }
     }
 }

--- a/src/RevitClashes/Models/RevitRepository.cs
+++ b/src/RevitClashes/Models/RevitRepository.cs
@@ -496,19 +496,32 @@ namespace RevitClashDetective.Models {
         private ICollection<ParameterFilterElement> GetHighlightFilters(ClashModel clash) {
             string username = _document.Application.Username;
             var filters = new List<ParameterFilterElement>() {
-                _parameterFilterProvider.GetHighlightFilter(
-                    _document,
-                    clash.MainElement.GetElement(DocInfos),
-                    $"{_filtersNamePrefix}не_первый_элемент_{username}"),
-                _parameterFilterProvider.GetHighlightFilter(
-                    _document,
-                    clash.OtherElement.GetElement(DocInfos),
-                    $"{_filtersNamePrefix}не_второй_элемент_{username}"),
                 _parameterFilterProvider.GetExceptCategoriesFilter(
                     _document,
                     GetClashCategories(clash),
                     $"{_filtersNamePrefix}не_категории_элементов_коллизии_{username}")
             };
+            var firstEl = clash.MainElement.GetElement(DocInfos);
+            var secondEl = clash.OtherElement.GetElement(DocInfos);
+            if(firstEl.Category.GetBuiltInCategory() == secondEl.Category.GetBuiltInCategory()) {
+                filters.Add(
+                    _parameterFilterProvider.GetHighlightFilter(
+                        _document,
+                        firstEl,
+                        secondEl,
+                        $"{_filtersNamePrefix}не_элементы_категории_коллизии_{username}"));
+            } else {
+                filters.Add(
+                    _parameterFilterProvider.GetHighlightFilter(
+                        _document,
+                        firstEl,
+                        $"{_filtersNamePrefix}не_первый_элемент_{username}"));
+                filters.Add(
+                    _parameterFilterProvider.GetHighlightFilter(
+                        _document,
+                        secondEl,
+                        $"{_filtersNamePrefix}не_второй_элемент_{username}"));
+            }
             return filters;
         }
 

--- a/src/RevitClashes/Models/RevitRepository.cs
+++ b/src/RevitClashes/Models/RevitRepository.cs
@@ -493,20 +493,23 @@ namespace RevitClashDetective.Models {
             }
         }
 
-        private IEnumerable<ParameterFilterElement> GetHighlightFilters(ClashModel clash) {
+        private ICollection<ParameterFilterElement> GetHighlightFilters(ClashModel clash) {
             string username = _document.Application.Username;
-            yield return _parameterFilterProvider.GetHighlightFilter(
-                _document,
-                clash.MainElement.GetElement(DocInfos),
-                $"{_filtersNamePrefix}не_первый_элемент_{username}");
-            yield return _parameterFilterProvider.GetHighlightFilter(
-                _document,
-                clash.OtherElement.GetElement(DocInfos),
-                $"{_filtersNamePrefix}не_второй_элемент_{username}");
-            yield return _parameterFilterProvider.GetExceptCategoriesFilter(
-                _document,
-                GetClashCategories(clash),
-                $"{_filtersNamePrefix}не_категории_элементов_коллизии_{username}");
+            var filters = new List<ParameterFilterElement>() {
+                _parameterFilterProvider.GetHighlightFilter(
+                    _document,
+                    clash.MainElement.GetElement(DocInfos),
+                    $"{_filtersNamePrefix}не_первый_элемент_{username}"),
+                _parameterFilterProvider.GetHighlightFilter(
+                    _document,
+                    clash.OtherElement.GetElement(DocInfos),
+                    $"{_filtersNamePrefix}не_второй_элемент_{username}"),
+                _parameterFilterProvider.GetExceptCategoriesFilter(
+                    _document,
+                    GetClashCategories(clash),
+                    $"{_filtersNamePrefix}не_категории_элементов_коллизии_{username}")
+            };
+            return filters;
         }
 
         private ICollection<BuiltInCategory> GetClashCategories(ClashModel clash) {


### PR DESCRIPTION
Изолирование реализовано через генерацию фильтров по параметрам элементов и последующее отключение видимости элементов.

![image](https://github.com/Bim4Everyone/RevitPlugins/assets/87359016/e15cd9a5-d8e0-4e00-85e5-8916966d5cee)

При нажатой галочке "Изолировать выделенные элементы" элементы изолируются, при отжатой - все фильтры сбрасываются