### PR TITLE
RevitOpeningPlacement: Категория "Воздухораспределители" полностью убрана из обработки плагином

### DIFF
--- a/src/RevitOpeningPlacement/Models/RevitRepository.cs
+++ b/src/RevitOpeningPlacement/Models/RevitRepository.cs
@@ -194,17 +194,16 @@ namespace RevitOpeningPlacement.Models {
         public static BuiltInCategory MepDuctLinearCategory { get; } = BuiltInCategory.OST_DuctCurves;
 
         /// <summary>
-        /// Используемые в плагине нелинейные категории для воздуховодов: Соединители детали воздуховодов, Арматура воздуховодов, Воздухораспределители
+        /// Используемые в плагине нелинейные категории для воздуховодов: Соединители детали воздуховодов, Арматура воздуховодов
         /// </summary>
         public static IReadOnlyCollection<BuiltInCategory> MepDuctFittingCategories { get; } =
             new ReadOnlyCollection<BuiltInCategory>(new BuiltInCategory[] {
                 BuiltInCategory.OST_DuctFitting,
-                BuiltInCategory.OST_DuctAccessory,
-                BuiltInCategory.OST_DuctTerminal
+                BuiltInCategory.OST_DuctAccessory
             });
 
         /// <summary>
-        /// Все используемые в плагине категории для воздуховодов: Воздуховоды, Соединители детали воздуховодов, Арматура воздуховодов, Воздухораспределители
+        /// Все используемые в плагине категории для воздуховодов: Воздуховоды, Соединители детали воздуховодов, Арматура воздуховодов
         /// </summary>
         public static IReadOnlyCollection<BuiltInCategory> MepDuctCategories { get; } =
            new ReadOnlyCollection<BuiltInCategory>(


### PR DESCRIPTION
Из категорий инженерных элементов ВИС, с которыми работает плагин убрана категория "Воздухораспределители".
Все текущие категории ВИС, с которыми работает плагин:
- Воздуховоды, Соединительные детали воздуховодов, Арматура воздуховодов
- Трубы, Соединительные детали трубопроводов
- Короба, Соединительные телати коробов
- Кабельные лотки, Соединительные детали кабельных лотков