### PR TITLE
RevitOpeningPlacement: Скорректировано создание настроек расстановки заданий от ВИС по умолчанию

### DIFF
--- a/src/RevitOpeningPlacement/Models/Configs/MepCategory.cs
+++ b/src/RevitOpeningPlacement/Models/Configs/MepCategory.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 using pyRevitLabs.Json;
 
+using RevitClashDetective.Models.Evaluators;
 using RevitClashDetective.Models.FilterModel;
 
 namespace RevitOpeningPlacement.Models.Configs {
@@ -11,6 +12,17 @@ namespace RevitOpeningPlacement.Models.Configs {
     /// Класс для обертки настроек расстановки заданий на отверстия для элементов категории инженерных систем
     /// </summary>
     internal class MepCategory : IEquatable<MepCategory> {
+        public const int DefaultRoundingMm = 50;
+        public const int DefaultMinSizeMm = 0;
+        public const int DefaultMaxSizeMm = 10000;
+        public const int DefaultOffsetMm = 50;
+        public const string PipeImageSource = "../Resources/pipe.png";
+        public const string RectDuctImageSource = "../Resources/rectangleDuct.png";
+        public const string RoundDuctImageSource = "../Resources/roundDuct.png";
+        public const string CableTrayImageSource = "../Resources/tray.png";
+        public const string ConduitImageSource = "../Resources/conduit.png";
+
+
         /// <summary>
         /// Конструктор настроек расстановки заданий на отверстия для дисциплины инженерных систем
         /// </summary>
@@ -46,7 +58,7 @@ namespace RevitOpeningPlacement.Models.Configs {
         /// <summary>
         /// Выбрана ли данная категория для поиска пересечений и последующей расстановки отверстий
         /// </summary>
-        public bool IsSelected { get; set; }
+        public bool IsSelected { get; set; } = true;
 
         /// <summary>
         /// Название категории
@@ -66,22 +78,40 @@ namespace RevitOpeningPlacement.Models.Configs {
         /// <summary>
         /// Значения отступов от габаритов сечения
         /// </summary>
-        public List<Offset> Offsets { get; set; } = new List<Offset>();
+        public List<Offset> Offsets { get; set; } = new List<Offset>() {
+                new Offset() {
+                    From = DefaultMinSizeMm,
+                    To = DefaultMaxSizeMm,
+                    OffsetValue = DefaultOffsetMm,
+                    OpeningTypeName = RevitRepository.OpeningTaskTypeName[OpeningType.WallRectangle]
+                }
+            };
 
         /// <summary>
         /// Категории конструкций (стены, перекрытия и т.п.), с которыми нужно выполнять проверку на пересечения и расстановку отверстий
         /// </summary>
-        public List<StructureCategory> Intersections { get; set; } = new List<StructureCategory>();
+        public List<StructureCategory> Intersections { get; set; } = new List<StructureCategory>(){
+                new StructureCategory(){
+                    Name = RevitRepository.StructureCategoryNames[StructureCategoryEnum.Wall],
+                    IsSelected = true },
+                new StructureCategory(){
+                    Name = RevitRepository.StructureCategoryNames[StructureCategoryEnum.Floor],
+                    IsSelected = true
+                }
+            };
 
         /// <summary>
         /// Значение округления габаритов итогового размещенного задания на отверстие в месте пересечения элемента данной категории и конструктивного элемента
         /// </summary>
-        public int Rounding { get; set; }
+        public int Rounding { get; set; } = DefaultRoundingMm;
 
         /// <summary>
         /// Правила фильтрации элементов данной категории
         /// </summary>
-        public Set Set { get; set; } = new Set();
+        public Set Set { get; set; } = new Set() {
+            SetEvaluator = SetEvaluatorUtils.GetEvaluators().First(),
+            Criteria = new List<Criterion>()
+        };
 
 
         /// <summary>

--- a/src/RevitOpeningPlacement/Models/Configs/MepCategoryCollection.cs
+++ b/src/RevitOpeningPlacement/Models/Configs/MepCategoryCollection.cs
@@ -1,18 +1,30 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace RevitOpeningPlacement.Models.Configs {
     internal class MepCategoryCollection : IEnumerable<MepCategory> {
         public MepCategoryCollection() {
-            Categories = new List<MepCategory>();
+            Categories = new List<MepCategory>() {
+                GetDefaultPipeCategory(),
+                GetDefaultRectDuctCategory(),
+                GetDefaultRoundDuctCategory(),
+                GetDefaultCableTrayCategory(),
+                GetDefaultConduitCategory()
+            };
         }
+
         public MepCategoryCollection(IEnumerable<MepCategory> categories) {
             Categories = new List<MepCategory>(categories);
         }
-        public List<MepCategory> Categories { get; set; } = new List<MepCategory>();
+
+
+        public List<MepCategory> Categories { get; set; }
         public int Count => Categories.Count;
-        public MepCategory this[MepCategoryEnum category] => Categories.FirstOrDefault(item => item.Name.Equals(RevitRepository.MepCategoryNames[category]));
+        public MepCategory this[MepCategoryEnum category] => Categories
+            .FirstOrDefault(item => item.Name.Equals(RevitRepository.MepCategoryNames[category]));
+
+
         public IEnumerator<MepCategory> GetEnumerator() => Categories.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
 
@@ -36,6 +48,74 @@ namespace RevitOpeningPlacement.Models.Configs {
                     break;
                 }
             }
+        }
+
+
+        public MepCategory GetDefaultPipeCategory() {
+            return new MepCategory(
+                    RevitRepository.MepCategoryNames[MepCategoryEnum.Pipe],
+                    MepCategory.PipeImageSource,
+                    true) {
+                MinSizes = GetDefaultRoundSizes()
+            };
+        }
+
+        public MepCategory GetDefaultRectDuctCategory() {
+            return new MepCategory(
+                    RevitRepository.MepCategoryNames[MepCategoryEnum.RectangleDuct],
+                    MepCategory.RectDuctImageSource,
+                    false) {
+                MinSizes = GetDefaultRectSizes()
+            };
+        }
+
+        public MepCategory GetDefaultRoundDuctCategory() {
+            return new MepCategory(
+                    RevitRepository.MepCategoryNames[MepCategoryEnum.RoundDuct],
+                    MepCategory.RoundDuctImageSource,
+                    true) {
+                MinSizes = GetDefaultRoundSizes()
+            };
+        }
+
+        public MepCategory GetDefaultConduitCategory() {
+            return new MepCategory(
+                    RevitRepository.MepCategoryNames[MepCategoryEnum.Conduit],
+                    MepCategory.ConduitImageSource,
+                    true) {
+                MinSizes = GetDefaultRoundSizes()
+            };
+        }
+
+        public MepCategory GetDefaultCableTrayCategory() {
+            return new MepCategory(
+                    RevitRepository.MepCategoryNames[MepCategoryEnum.CableTray],
+                    MepCategory.CableTrayImageSource,
+                    false) {
+                MinSizes = GetDefaultRectSizes()
+            };
+        }
+
+        private SizeCollection GetDefaultRectSizes() {
+            return new SizeCollection(new List<Size>{
+                new Size() {
+                    Name = RevitRepository.ParameterNames[Parameters.Width],
+                    Value = MepCategory.DefaultMinSizeMm
+                },
+                new Size() {
+                    Name = RevitRepository.ParameterNames[Parameters.Height],
+                    Value = MepCategory.DefaultMinSizeMm
+                }
+            });
+        }
+
+        private SizeCollection GetDefaultRoundSizes() {
+            return new SizeCollection(new List<Size>{
+                new Size() {
+                    Name = RevitRepository.ParameterNames[Parameters.Diameter],
+                    Value = MepCategory.DefaultMinSizeMm
+                }
+            });
         }
     }
 }

--- a/src/RevitOpeningPlacement/ViewModels/OpeningConfig/MainViewModel.cs
+++ b/src/RevitOpeningPlacement/ViewModels/OpeningConfig/MainViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
@@ -92,7 +92,7 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
             name: RevitRepository.MepCategoryNames[MepCategoryEnum.Pipe],
             minSizesParameters: new Parameters[] { Parameters.Diameter },
             isRound: true,
-            imageSource: "../Resources/pipe.png"
+            imageSource: MepCategory.PipeImageSource
             );
 
 
@@ -101,7 +101,7 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
             name: RevitRepository.MepCategoryNames[MepCategoryEnum.RectangleDuct],
             minSizesParameters: new Parameters[] { Parameters.Width, Parameters.Height },
             isRound: false,
-            imageSource: "../Resources/rectangleDuct.png"
+            imageSource: MepCategory.RectDuctImageSource
             );
 
 
@@ -110,7 +110,7 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
             name: RevitRepository.MepCategoryNames[MepCategoryEnum.RoundDuct],
             minSizesParameters: new Parameters[] { Parameters.Diameter },
             isRound: true,
-            imageSource: "../Resources/roundDuct.png"
+            imageSource: MepCategory.RoundDuctImageSource
             );
 
         private MepCategoryViewModel GetCableTray() => new MepCategoryViewModel(
@@ -118,7 +118,7 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
             name: RevitRepository.MepCategoryNames[MepCategoryEnum.CableTray],
             minSizesParameters: new Parameters[] { Parameters.Width, Parameters.Height },
             isRound: false,
-            imageSource: "../Resources/tray.png"
+            imageSource: MepCategory.CableTrayImageSource
             );
 
         private MepCategoryViewModel GetConduit() => new MepCategoryViewModel(
@@ -126,7 +126,7 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
             name: RevitRepository.MepCategoryNames[MepCategoryEnum.Conduit],
             minSizesParameters: new Parameters[] { Parameters.Diameter },
             isRound: true,
-            imageSource: "../Resources/conduit.png"
+            imageSource: MepCategory.ConduitImageSource
             );
 
         private void AddMissingCategories() {
@@ -159,17 +159,17 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
         private MepCategoryViewModel GetMissingCategory(MepCategoryEnum missingCategory) {
             switch(missingCategory) {
                 case MepCategoryEnum.Pipe:
-                return GetPipe();
+                    return GetPipe();
                 case MepCategoryEnum.RectangleDuct:
-                return GetRectangleDuct();
+                    return GetRectangleDuct();
                 case MepCategoryEnum.RoundDuct:
-                return GetRoundDuct();
+                    return GetRoundDuct();
                 case MepCategoryEnum.CableTray:
-                return GetCableTray();
+                    return GetCableTray();
                 case MepCategoryEnum.Conduit:
-                return GetConduit();
+                    return GetConduit();
                 default:
-                throw new ArgumentException($"Не найдена категория \"{missingCategory}\".", nameof(missingCategory));
+                    throw new ArgumentException($"Не найдена категория \"{missingCategory}\".", nameof(missingCategory));
             }
         }
         private void InitializeTimer() {

--- a/src/RevitOpeningPlacement/ViewModels/OpeningConfig/MepCategoryViewModel.cs
+++ b/src/RevitOpeningPlacement/ViewModels/OpeningConfig/MepCategoryViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -55,9 +55,9 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
             IsSelected = true; // категория выбрана для создания заданий на отверстия
             SelectedRounding = Roundings.Last(); // округление 50 мм
             var firstOffset = Offsets.First();
-            firstOffset.To = 10000; // максимальный габарит сечения элемента для зазора в мм
+            firstOffset.To = MepCategory.DefaultMaxSizeMm; // максимальный габарит сечения элемента для зазора в мм
             firstOffset.SelectedOpeningType = firstOffset.OpeningTypeNames.Last(); // тип задания на  отверстие по умолчанию прямоугольный
-            firstOffset.Offset = 50; // зазор 50 мм для прямоугольных заданий на отверстия
+            firstOffset.Offset = MepCategory.DefaultOffsetMm; // зазор 50 мм для прямоугольных заданий на отверстия
             foreach(var structureCategory in StructureCategories) {
                 structureCategory.IsSelected = true; // все категории конструкций выбраны для создания заданий на отверстия
             }


### PR DESCRIPTION
Скорректирована инициализация значений по умолчанию, если файл конфига для настроек расстановки заданий на отврестия от ВИС отсутствует. Раньше инициализация настроек по умолчанию происходила только в MainViewModel и нужно было при отсутствии конфига всегда открывать это окно настроек расстановки ВИС и сохранять их.
Сами значения настроек по умолчанию никак не изменились.

![image](https://github.com/user-attachments/assets/acd8828e-946b-4471-91aa-dfd39144628f)

![image](https://github.com/user-attachments/assets/9b9f894b-1e18-4c74-b161-8a6e01ef023c)

![image](https://github.com/user-attachments/assets/d470e838-3d15-4f2b-87d5-0f4be0607c4c)

![image](https://github.com/user-attachments/assets/5f9f8379-150a-48e1-9500-498aa2028a8d)

![image](https://github.com/user-attachments/assets/a9eed17c-612c-40ec-98ad-12e9e2816100)
