### PR TITLE
RevitClashDetective: В навигатор коллизий добавлен вывод % пересечения и объема коллизии

### DIFF
--- a/RevitPlugins.sln
+++ b/RevitPlugins.sln
@@ -78,6 +78,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ClashDetection", "ClashDete
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Clashes", "Clashes", "{4526DA81-105F-41F7-8EA9-EBC495EEEBD6}"
 	ProjectSection(SolutionItems) = preProject
+		src\RevitClashes\Models\Clashes\ClashData.cs = src\RevitClashes\Models\Clashes\ClashData.cs
 		src\RevitClashes\Models\Clashes\ClashesConfig.cs = src\RevitClashes\Models\Clashes\ClashesConfig.cs
 		src\RevitClashes\Models\Clashes\ClashModel.cs = src\RevitClashes\Models\Clashes\ClashModel.cs
 		src\RevitClashes\Models\Clashes\ElementModel.cs = src\RevitClashes\Models\Clashes\ElementModel.cs

--- a/src/RevitClashDetective/ViewModels/Navigator/ClashViewModel.cs
+++ b/src/RevitClashDetective/ViewModels/Navigator/ClashViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using Autodesk.Revit.DB;
@@ -7,6 +7,7 @@ using dosymep.WPF.ViewModels;
 
 using RevitClashDetective.Models;
 using RevitClashDetective.Models.Clashes;
+using RevitClashDetective.Models.Extensions;
 
 namespace RevitClashDetective.ViewModels.Navigator {
     internal class ClashViewModel : BaseViewModel, IEquatable<ClashViewModel> {
@@ -25,6 +26,8 @@ namespace RevitClashDetective.ViewModels.Navigator {
             SecondName = clash.OtherElement.Name;
             SecondLevel = clash.OtherElement.Level;
             SecondDocumentName = clash.OtherElement.DocumentName;
+
+            (IntersectionPercentage, IntersectionVolume) = GetIntersectionData(clash);
 
             ClashStatus = clash.ClashStatus;
             Clash = clash;
@@ -51,7 +54,18 @@ namespace RevitClashDetective.ViewModels.Navigator {
 
         public string SecondDocumentName { get; }
 
-        public string SecondCategory { get; set; }
+        public string SecondCategory { get; }
+
+        /// <summary>
+        /// Процент пересечения относительно объема меньшего элемента коллизии
+        /// </summary>
+        public double IntersectionPercentage { get; }
+
+        /// <summary>
+        /// Объем пересечения в м3
+        /// </summary>
+        public double IntersectionVolume { get; }
+
         public ClashModel Clash { get; }
 
         public IEnumerable<ElementId> GetElementIds(string docTitle) {
@@ -101,6 +115,78 @@ namespace RevitClashDetective.ViewModels.Navigator {
                 && SecondLevel == other.SecondLevel
                 && SecondDocumentName == other.SecondDocumentName
                 && SecondCategory == other.SecondCategory;
+        }
+
+
+        private (double Percentage, double Volume) GetIntersectionData(ClashModel clashModel) {
+            if(clashModel is null) {
+                throw new ArgumentNullException(nameof(clashModel));
+            }
+
+            try {
+                Solid firstSolid = GetFirstSolid(clashModel);
+                Solid secondSolid = GetSecondSolid(clashModel);
+
+                Solid intersection = BooleanOperationsUtils.ExecuteBooleanOperation(
+                    firstSolid,
+                    secondSolid,
+                    BooleanOperationsType.Intersect);
+
+                double minVolume = firstSolid.Volume < secondSolid.Volume
+                    ? firstSolid.Volume
+                    : secondSolid.Volume;
+                double intersectionVolume = intersection.Volume;
+                return (Math.Round(intersectionVolume / minVolume * 100, 2),
+                    Math.Round(ConvertToM3(intersection.Volume), 6));
+            } catch(NullReferenceException) {
+                return (0, 0);
+            } catch(Autodesk.Revit.Exceptions.ApplicationException) {
+                return (0, 0);
+            }
+        }
+
+        private Solid GetFirstSolid(ClashModel clashModel) {
+            return clashModel.MainElement.GetElement(_revitRepository.DocInfos).GetSolid();
+        }
+
+        private Solid GetSecondSolid(ClashModel clashModel) {
+            return SolidUtils.CreateTransformed(
+                clashModel.OtherElement
+                    .GetElement(_revitRepository.DocInfos)
+                    .GetSolid(),
+                GetFirstTransform(clashModel)
+                    .GetTransitionMatrix(GetSecondTransform(clashModel))
+                );
+        }
+
+        private Transform GetFirstTransform(ClashModel clashModel) {
+            return GetTransform(clashModel.MainElement.TransformModel);
+        }
+
+        private Transform GetSecondTransform(ClashModel clashModel) {
+            return GetTransform(clashModel.OtherElement.TransformModel);
+        }
+
+        private Transform GetTransform(TransformModel transformModel) {
+            Transform transform = Transform.Identity;
+            transform.Origin = transformModel.Origin.GetXYZ();
+            transform.BasisX = transformModel.BasisX.GetXYZ();
+            transform.BasisY = transformModel.BasisY.GetXYZ();
+            transform.BasisZ = transformModel.BasisZ.GetXYZ();
+            return transform;
+        }
+
+        /// <summary>
+        /// Конвертирует кубические футы в кубические метры
+        /// </summary>
+        /// <param name="cubeFeet">Кубические футы</param>
+        /// <returns>Кубические метры</returns>
+        public double ConvertToM3(double cubeFeet) {
+#if REVIT_2020_OR_LESS
+            return UnitUtils.ConvertFromInternalUnits(cubeFeet, DisplayUnitType.DUT_CUBIC_METERS);
+#else
+            return UnitUtils.ConvertFromInternalUnits(cubeFeet, UnitTypeId.CubicMeters);
+#endif
         }
     }
 }

--- a/src/RevitClashDetective/ViewModels/Navigator/ReportViewModel.cs
+++ b/src/RevitClashDetective/ViewModels/Navigator/ReportViewModel.cs
@@ -50,9 +50,9 @@ namespace RevitClashDetective.ViewModels.Navigator {
         }
 
 
-        public ICommand SaveCommand { get; set; }
+        public ICommand SaveCommand { get; private set; }
 
-        public ICommand SaveAsCommand { get; set; }
+        public ICommand SaveAsCommand { get; private set; }
 
         public ClashesConfig GetUpdatedConfig() {
             var config = ClashesConfig.GetClashesConfig(_revitRepository.GetObjectName(), Name);

--- a/src/RevitClashDetective/Views/NavigatorView.xaml
+++ b/src/RevitClashDetective/Views/NavigatorView.xaml
@@ -142,7 +142,20 @@
                 <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
                                 Header="Имя файла 2"
                                 FieldName="SecondDocumentName" />
-
+                <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
+                                Header="% пересечения"
+                                FieldName="IntersectionPercentage">
+                    <dxg:GridColumn.EditSettings>
+                        <dxe:TextEditSettings HorizontalContentAlignment="Left" />
+                    </dxg:GridColumn.EditSettings>
+                </dxg:GridColumn>
+                <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
+                                Header="V пересечения, м³"
+                                FieldName="IntersectionVolume">
+                    <dxg:GridColumn.EditSettings>
+                        <dxe:TextEditSettings HorizontalContentAlignment="Left" />
+                    </dxg:GridColumn.EditSettings>
+                </dxg:GridColumn>
             </dxg:GridControl.Columns>
         </dxg:GridControl>
 

--- a/src/RevitClashes/Models/Clashes/ClashData.cs
+++ b/src/RevitClashes/Models/Clashes/ClashData.cs
@@ -7,6 +7,12 @@ namespace RevitClashDetective.Models.Clashes {
     /// </summary>
     internal class ClashData : IEquatable<ClashData> {
         /// <summary>
+        /// Точность сравнения объемов в кубических футах ~0.028 мм3
+        /// </summary>
+        private const double _precision = 0.000001;
+
+
+        /// <summary>
         /// Конструирует объект информации о коллизии с заданными параметрами
         /// </summary>
         /// <param name="mainElementVolume">Объем первого элемента коллизии в единицах ревита (кубических футах)</param>
@@ -58,9 +64,9 @@ namespace RevitClashDetective.Models.Clashes {
             if(ReferenceEquals(null, other)) { return false; }
             if(ReferenceEquals(this, other)) { return true; }
 
-            return MainElementVolume == other.MainElementVolume
-                && OtherElementVolume == other.OtherElementVolume
-                && ClashVolume == other.ClashVolume;
+            return Math.Abs(MainElementVolume - other.MainElementVolume) < _precision
+                && Math.Abs(OtherElementVolume - other.OtherElementVolume) < _precision
+                && Math.Abs(ClashVolume - other.ClashVolume) < _precision;
         }
     }
 }

--- a/src/RevitClashes/Models/Clashes/ClashData.cs
+++ b/src/RevitClashes/Models/Clashes/ClashData.cs
@@ -1,0 +1,66 @@
+using System;
+
+
+namespace RevitClashDetective.Models.Clashes {
+    /// <summary>
+    /// Данные о коллизии <see cref="ClashModel"/>
+    /// </summary>
+    internal class ClashData : IEquatable<ClashData> {
+        /// <summary>
+        /// Конструирует объект информации о коллизии с заданными параметрами
+        /// </summary>
+        /// <param name="mainElementVolume">Объем первого элемента коллизии в единицах ревита (кубических футах)</param>
+        /// <param name="otherElementVolume">Объем второго элемента коллизии в единицах ревита (кубических футах)</param>
+        /// <param name="clashVolume">Объем пересечения элементов коллизии в единицах ревита (кубических футах)</param>
+        public ClashData(double mainElementVolume, double otherElementVolume, double clashVolume) {
+            MainElementVolume = mainElementVolume;
+            OtherElementVolume = otherElementVolume;
+            ClashVolume = clashVolume;
+        }
+
+        /// <summary>
+        /// Конструирует объект информации о коллизии с параметрами по умолчанию
+        /// </summary>
+        public ClashData() : this(0, 0, 0) {
+        }
+
+
+        /// <summary>
+        /// Объем пересечения <see cref="ClashModel.MainElement"/> c <see cref="ClashModel.OtherElement"/> 
+        /// в единицах ревита (кубических футах)
+        /// </summary>
+        public double ClashVolume { get; }
+
+        /// <summary>
+        /// Объем <see cref="ClashModel.MainElement"/> в единицах ревита (кубических футах)
+        /// </summary>
+        public double MainElementVolume { get; }
+
+        /// <summary>
+        /// Объем <see cref="ClashModel.OtherElement"/> в единицах ревита (кубических футах)
+        /// </summary>
+        public double OtherElementVolume { get; }
+
+
+        public override bool Equals(object obj) {
+            return Equals(obj as ClashData);
+        }
+
+        public override int GetHashCode() {
+            int hashCode = -1962954641;
+            hashCode = hashCode * -1521134295 + ClashVolume.GetHashCode();
+            hashCode = hashCode * -1521134295 + MainElementVolume.GetHashCode();
+            hashCode = hashCode * -1521134295 + OtherElementVolume.GetHashCode();
+            return hashCode;
+        }
+
+        public bool Equals(ClashData other) {
+            if(ReferenceEquals(null, other)) { return false; }
+            if(ReferenceEquals(this, other)) { return true; }
+
+            return MainElementVolume == other.MainElementVolume
+                && OtherElementVolume == other.OtherElementVolume
+                && ClashVolume == other.ClashVolume;
+        }
+    }
+}

--- a/src/RevitClashes/Models/Clashes/ClashModel.cs
+++ b/src/RevitClashes/Models/Clashes/ClashModel.cs
@@ -88,12 +88,11 @@ namespace RevitClashDetective.Models.Clashes {
         /// Назначить это поле можно через метод <see cref="SetRevitRepository(RevitRepository)"/>
         /// </summary>
         /// <returns>Объект с данными о коллизии</returns>
-        /// <exception cref="ArgumentNullException">Исключение, если <see cref="_revitRepository"/> null</exception>
+        /// <exception cref="InvalidOperationException">Исключение, если <see cref="_revitRepository"/> null</exception>
         public ClashData GetClashData() {
             if(_revitRepository is null) {
-                throw new ArgumentNullException(
-                    "Для получения данных о коллизии необходимо назначить репозиторий активного документа Ревита",
-                    nameof(_revitRepository));
+                throw new InvalidOperationException(
+                    "Для получения данных о коллизии необходимо назначить репозиторий активного документа Ревита");
             }
 
             try {
@@ -108,6 +107,8 @@ namespace RevitClashDetective.Models.Clashes {
             } catch(ArgumentNullException) {
                 return new ClashData();
             } catch(NullReferenceException) {
+                return new ClashData();
+            } catch(ArgumentException) {
                 return new ClashData();
             } catch(Autodesk.Revit.Exceptions.ApplicationException) {
                 return new ClashData();

--- a/src/RevitClashes/Models/Clashes/ElementModel.cs
+++ b/src/RevitClashes/Models/Clashes/ElementModel.cs
@@ -80,9 +80,7 @@ namespace RevitClashDetective.Models.Clashes {
 
         public IList<Solid> GetSolids(IEnumerable<DocInfo> documents) {
             return GetElement(documents)?.GetSolids()
-                ?? throw new ArgumentNullException(
-                    nameof(documents),
-                    $"Элемент с Id={Id} не найден в заданных документах");
+                ?? throw new ArgumentException($"Элемент с Id={Id} не найден в заданных документах");
         }
 
         public override bool Equals(object obj) {

--- a/src/RevitClashes/Models/Clashes/ElementModel.cs
+++ b/src/RevitClashes/Models/Clashes/ElementModel.cs
@@ -1,10 +1,12 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 using Autodesk.Revit.DB;
 
 using pyRevitLabs.Json;
+
+using RevitClashDetective.Models.Extensions;
 
 namespace RevitClashDetective.Models.Clashes {
     internal class ElementModel : IEquatable<ElementModel> {
@@ -70,6 +72,17 @@ namespace RevitClashDetective.Models.Clashes {
                     .FirstOrDefault(item => TransformModel.IsAlmostEqualTo(item.Transform))
                     ?? docsWithTheSameTitle.FirstOrDefault();
             }
+        }
+
+        public Transform GetTransform() {
+            return TransformModel.GetTransform();
+        }
+
+        public IList<Solid> GetSolids(IEnumerable<DocInfo> documents) {
+            return GetElement(documents)?.GetSolids()
+                ?? throw new ArgumentNullException(
+                    nameof(documents),
+                    $"Элемент с Id={Id} не найден в заданных документах");
         }
 
         public override bool Equals(object obj) {

--- a/src/RevitClashes/Models/Clashes/TransformModel.cs
+++ b/src/RevitClashes/Models/Clashes/TransformModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using Autodesk.Revit.DB;
@@ -61,6 +61,15 @@ namespace RevitClashDetective.Models.Clashes {
                 && BasisX.GetXYZ().IsAlmostEqualTo(transform.BasisX)
                 && BasisY.GetXYZ().IsAlmostEqualTo(transform.BasisY)
                 && BasisZ.GetXYZ().IsAlmostEqualTo(transform.BasisZ);
+        }
+
+        public Transform GetTransform() {
+            Transform transform = Transform.Identity;
+            transform.Origin = Origin.GetXYZ();
+            transform.BasisX = BasisX.GetXYZ();
+            transform.BasisY = BasisY.GetXYZ();
+            transform.BasisZ = BasisZ.GetXYZ();
+            return transform;
         }
     }
 }

--- a/src/RevitClashes/Models/RevitRepository.cs
+++ b/src/RevitClashes/Models/RevitRepository.cs
@@ -355,6 +355,19 @@ namespace RevitClashDetective.Models {
             }
         }
 
+        /// <summary>
+        /// Конвертирует кубические футы в кубические метры
+        /// </summary>
+        /// <param name="cubeFeet">Кубические футы</param>
+        /// <returns>Кубические метры</returns>
+        public double ConvertToM3(double cubeFeet) {
+#if REVIT_2020_OR_LESS
+            return UnitUtils.ConvertFromInternalUnits(cubeFeet, DisplayUnitType.DUT_CUBIC_METERS);
+#else
+            return UnitUtils.ConvertFromInternalUnits(cubeFeet, UnitTypeId.CubicMeters);
+#endif
+        }
+
 
         /// <summary>
         /// Возвращает коллекцию фильтров по параметрам элементов, в которые попадают элементы, попадающие в фильтр по элементам,
@@ -565,6 +578,9 @@ namespace RevitClashDetective.Models {
                 foreach(var filter in filtersToHide) {
                     view.AddFilter(filter.Id);
                     view.SetFilterVisibility(filter.Id, false);
+                }
+                foreach(var category in GetLineCategoriesToHide()) {
+                    view.SetCategoryHidden(category, true);
                 }
                 t.Commit();
             }


### PR DESCRIPTION
В GUI просмотра коллизий добавлены столбцы:
- % пересечения относительно меньшего элемента
- объем пересечения в м³

![image](https://github.com/user-attachments/assets/6f2c9fb6-2c0f-45fe-9e1c-d6b138db4da0)
