### PR TITLE
RevitFinishingWalls: Добавлена возможность указывать смещение отделки внутрь помещения

### DIFF
--- a/src/RevitFinishingWalls/Models/PluginConfig.cs
+++ b/src/RevitFinishingWalls/Models/PluginConfig.cs
@@ -12,10 +12,24 @@ namespace RevitFinishingWalls.Models {
     /// <summary>
     /// Настройки расстановки отделочных стен
     /// </summary>
-    internal class PluginConfig : ProjectConfig {
+    internal class PluginConfig : ProjectConfig<RevitSettings> {
         [JsonIgnore] public override string ProjectConfigPath { get; set; }
 
         [JsonIgnore] public override IConfigSerializer Serializer { get; set; }
+
+
+        public static PluginConfig GetPluginConfig() {
+            return new ProjectConfigBuilder()
+                .SetSerializer(new ConfigSerializer())
+                .SetPluginName(nameof(RevitFinishingWalls))
+                .SetRevitVersion(ModuleEnvironment.RevitVersion)
+                .SetProjectConfigName(nameof(PluginConfig) + ".json")
+                .Build<PluginConfig>();
+        }
+    }
+
+    internal class RevitSettings : ProjectSettings {
+        public override string ProjectName { get; set; }
 
         /// <summary>
         /// Тип отделочной стены
@@ -46,15 +60,5 @@ namespace RevitFinishingWalls.Models {
         /// Смещение стены внутрь помещения
         /// </summary>
         public double WallSideOffsetMm { get; set; } = 0;
-
-
-        public static PluginConfig GetPluginConfig() {
-            return new ProjectConfigBuilder()
-                .SetSerializer(new ConfigSerializer())
-                .SetPluginName(nameof(RevitFinishingWalls))
-                .SetRevitVersion(ModuleEnvironment.RevitVersion)
-                .SetProjectConfigName(nameof(PluginConfig) + ".json")
-                .Build<PluginConfig>();
-        }
     }
 }

--- a/src/RevitFinishingWalls/Models/PluginConfig.cs
+++ b/src/RevitFinishingWalls/Models/PluginConfig.cs
@@ -42,6 +42,11 @@ namespace RevitFinishingWalls.Models {
         /// </summary>
         public double WallBaseOffsetMm { get; set; } = 0;
 
+        /// <summary>
+        /// Смещение стены внутрь помещения
+        /// </summary>
+        public double WallSideOffsetMm { get; set; } = 0;
+
 
         public static PluginConfig GetPluginConfig() {
             return new ProjectConfigBuilder()

--- a/src/RevitFinishingWalls/Models/RevitRepository.cs
+++ b/src/RevitFinishingWalls/Models/RevitRepository.cs
@@ -406,13 +406,13 @@ namespace RevitFinishingWalls.Models {
             if(borderEl is ModelLine || borderEl is null) {
                 // в фильтр должны попадать элементы категорий: стены, несущие колонны, колонны,
                 // у которых значение параметра "Граница помещения" не равен 0, если параметр есть у элемента.
-                var categoryFilter = new LogicalAndFilter(new List<ElementFilter>(){
+                var categoryFilter = new LogicalAndFilter(new ElementFilter[] {
                     new ElementMulticategoryFilter(
                         new BuiltInCategory[] {
                             BuiltInCategory.OST_Walls,
                             BuiltInCategory.OST_StructuralColumns,
                             BuiltInCategory.OST_Columns }),
-                    new LogicalOrFilter(new List<ElementFilter>() {
+                    new LogicalOrFilter(new ElementFilter[] {
                         new ElementParameterFilter(
                             ParameterFilterRuleFactory.CreateNotEqualsRule(
                                 new ElementId(BuiltInParameter.WALL_ATTR_ROOM_BOUNDING), 0))

--- a/src/RevitFinishingWalls/Models/RevitRepository.cs
+++ b/src/RevitFinishingWalls/Models/RevitRepository.cs
@@ -147,7 +147,10 @@ namespace RevitFinishingWalls.Models {
             notJoinedElements = new List<ElementId>();
             foreach(Element item in wallCreationData.ElementsForJoin) {
                 try {
-                    JoinGeometryUtils.JoinGeometry(Document, wall, item);
+                    if(!(item is RevitLinkInstance)) {
+                        // нельзя соединить элементы из связей
+                        JoinGeometryUtils.JoinGeometry(Document, wall, item);
+                    }
                 } catch(Autodesk.Revit.Exceptions.ArgumentException) {
                     notJoinedElements.Add(item.Id);
                 }

--- a/src/RevitFinishingWalls/Models/RevitRepository.cs
+++ b/src/RevitFinishingWalls/Models/RevitRepository.cs
@@ -418,6 +418,15 @@ namespace RevitFinishingWalls.Models {
                         view3D.SetCategoryHidden(categoryId, false);
                     }
                 }
+                ElementId[] links = new FilteredElementCollector(Document)
+                    .OfCategory(BuiltInCategory.OST_RvtLinks)
+                    .ToElements()
+                    .Where(e => e.IsHidden(view3D))
+                    .Select(e => e.Id)
+                    .ToArray(); // типы и экземпляры связей
+                if(links.Length > 0) {
+                    view3D.UnhideElements(links);
+                }
                 t.Commit();
             }
         }

--- a/src/RevitFinishingWalls/Models/RevitRepository.cs
+++ b/src/RevitFinishingWalls/Models/RevitRepository.cs
@@ -434,7 +434,7 @@ namespace RevitFinishingWalls.Models {
 
             ReferenceIntersector intersector
                 = new ReferenceIntersector(elementFilter, FindReferenceTarget.Element, view3D) {
-                    FindReferencesInRevitLinks = false
+                    FindReferencesInRevitLinks = true
                 };
             //получить вектор направления луча, который должен перечь элемент, который задает границу помещения
             XYZ toElementDirection = GetRightDirection(lineDirection);

--- a/src/RevitFinishingWalls/RevitFinishingWallsCommand.cs
+++ b/src/RevitFinishingWalls/RevitFinishingWallsCommand.cs
@@ -44,6 +44,7 @@ namespace RevitFinishingWalls {
 
                 kernel.UseXtraMessageBox<ErrorWindowViewModel>();
 
+                kernel.UseXtraProgressDialog<MainViewModel>();
                 kernel.Bind<MainViewModel>().ToSelf();
                 kernel.Bind<MainWindow>().ToSelf()
                     .WithPropertyValue(nameof(Window.Title), PluginName)

--- a/src/RevitFinishingWalls/Services/Creation/IRoomFinisher.cs
+++ b/src/RevitFinishingWalls/Services/Creation/IRoomFinisher.cs
@@ -1,4 +1,8 @@
+using System;
 using System.Collections.Generic;
+using System.Threading;
+
+using Autodesk.Revit.DB.Architecture;
 
 using RevitFinishingWalls.Models;
 using RevitFinishingWalls.ViewModels;
@@ -11,8 +15,15 @@ namespace RevitFinishingWalls.Services.Creation {
         /// <summary>
         /// Создает отделку стен
         /// </summary>
+        /// <param name="rooms">Помещения для отделки</param>
         /// <param name="config">Настройки отделки стен</param>
+        /// <param name="progress">Уведомитель процесса</param>
+        /// <param name="ct">Токен отмены</param>
         /// <returns>Ошибки в построении отделочных стен в помещениях</returns>
-        ICollection<RoomErrorsViewModel> CreateWallsFinishing(PluginConfig config);
+        ICollection<RoomErrorsViewModel> CreateWallsFinishing(
+            ICollection<Room> rooms,
+            PluginConfig config,
+            IProgress<int> progress = null,
+            CancellationToken ct = default);
     }
 }

--- a/src/RevitFinishingWalls/Services/Creation/IRoomFinisher.cs
+++ b/src/RevitFinishingWalls/Services/Creation/IRoomFinisher.cs
@@ -16,13 +16,13 @@ namespace RevitFinishingWalls.Services.Creation {
         /// Создает отделку стен
         /// </summary>
         /// <param name="rooms">Помещения для отделки</param>
-        /// <param name="config">Настройки отделки стен</param>
+        /// <param name="settings">Настройки отделки стен</param>
         /// <param name="progress">Уведомитель процесса</param>
         /// <param name="ct">Токен отмены</param>
         /// <returns>Ошибки в построении отделочных стен в помещениях</returns>
         ICollection<RoomErrorsViewModel> CreateWallsFinishing(
             ICollection<Room> rooms,
-            PluginConfig config,
+            RevitSettings settings,
             IProgress<int> progress = null,
             CancellationToken ct = default);
     }

--- a/src/RevitFinishingWalls/Services/Creation/IWallCreationDataProvider.cs
+++ b/src/RevitFinishingWalls/Services/Creation/IWallCreationDataProvider.cs
@@ -11,7 +11,6 @@ namespace RevitFinishingWalls.Services.Creation {
         /// </summary>
         /// <param name="room">Помещение, в котором нужно создать отделочные стены</param>
         /// <param name="config">Настройки создания отделочных стен</param>
-        /// <returns></returns>
         IList<WallCreationData> GetWallCreationData(Room room, PluginConfig config);
     }
 }

--- a/src/RevitFinishingWalls/Services/Creation/IWallCreationDataProvider.cs
+++ b/src/RevitFinishingWalls/Services/Creation/IWallCreationDataProvider.cs
@@ -10,7 +10,7 @@ namespace RevitFinishingWalls.Services.Creation {
         /// Возвращает список классов с данными для создания отделочных стен
         /// </summary>
         /// <param name="room">Помещение, в котором нужно создать отделочные стены</param>
-        /// <param name="config">Настройки создания отделочных стен</param>
-        IList<WallCreationData> GetWallCreationData(Room room, PluginConfig config);
+        /// <param name="settings">Настройки создания отделочных стен</param>
+        IList<WallCreationData> GetWallCreationData(Room room, RevitSettings settings);
     }
 }

--- a/src/RevitFinishingWalls/Services/Creation/Implements/RoomFinisher.cs
+++ b/src/RevitFinishingWalls/Services/Creation/Implements/RoomFinisher.cs
@@ -46,6 +46,7 @@ namespace RevitFinishingWalls.Services.Creation.Implements {
                     } catch(CannotCreateWallException ex) {
                         roomErrors.Errors.Add(
                             new ErrorViewModel("Ошибки обработки контура помещения", ex.Message, room.Id));
+                        errors.Add(roomErrors);
                         continue;
                     }
                     for(int i = 0; i < datas.Count; i++) {

--- a/src/RevitFinishingWalls/Services/Creation/Implements/RoomFinisher.cs
+++ b/src/RevitFinishingWalls/Services/Creation/Implements/RoomFinisher.cs
@@ -32,12 +32,12 @@ namespace RevitFinishingWalls.Services.Creation.Implements {
 
         public ICollection<RoomErrorsViewModel> CreateWallsFinishing(
             ICollection<Room> rooms,
-            PluginConfig config,
+            RevitSettings settings,
             IProgress<int> progress = null,
             CancellationToken ct = default) {
 
             if(rooms is null) { throw new ArgumentNullException(nameof(rooms)); }
-            if(config is null) { throw new ArgumentNullException(nameof(config)); }
+            if(settings is null) { throw new ArgumentNullException(nameof(settings)); }
             List<RoomErrorsViewModel> errors = new List<RoomErrorsViewModel>();
 
             using(var transaction = _revitRepository.Document.StartTransaction("Создание отделочных стен")) {
@@ -51,7 +51,7 @@ namespace RevitFinishingWalls.Services.Creation.Implements {
                     RoomErrorsViewModel roomErrors = new RoomErrorsViewModel(room);
                     IList<WallCreationData> datas;
                     try {
-                        datas = _wallCreationDataProvider.GetWallCreationData(room, config);
+                        datas = _wallCreationDataProvider.GetWallCreationData(room, settings);
                     } catch(CannotCreateWallException ex) {
                         roomErrors.Errors.Add(
                             new ErrorViewModel("Ошибки обработки контура помещения", ex.Message, room.Id));

--- a/src/RevitFinishingWalls/Services/Creation/Implements/RoomFinisher.cs
+++ b/src/RevitFinishingWalls/Services/Creation/Implements/RoomFinisher.cs
@@ -39,8 +39,15 @@ namespace RevitFinishingWalls.Services.Creation.Implements {
                 failOpt.SetFailuresPreprocessor(new WallAndRoomSeparationLineOverlapHandler());
                 transaction.SetFailureHandlingOptions(failOpt);
                 foreach(var room in rooms) {
-                    IList<WallCreationData> datas = _wallCreationDataProvider.GetWallCreationData(room, config);
                     RoomErrorsViewModel roomErrors = new RoomErrorsViewModel(room);
+                    IList<WallCreationData> datas;
+                    try {
+                        datas = _wallCreationDataProvider.GetWallCreationData(room, config);
+                    } catch(CannotCreateWallException ex) {
+                        roomErrors.Errors.Add(
+                            new ErrorViewModel("Ошибки обработки контура помещения", ex.Message, room.Id));
+                        continue;
+                    }
                     for(int i = 0; i < datas.Count; i++) {
                         try {
                             var wall = _revitRepository.CreateWall(

--- a/src/RevitFinishingWalls/ViewModels/MainViewModel.cs
+++ b/src/RevitFinishingWalls/ViewModels/MainViewModel.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Linq;
 using System.Windows.Input;
 
@@ -14,7 +13,7 @@ using RevitFinishingWalls.Services;
 using RevitFinishingWalls.Services.Creation;
 
 namespace RevitFinishingWalls.ViewModels {
-    internal class MainViewModel : BaseViewModel, IDataErrorInfo {
+    internal class MainViewModel : BaseViewModel {
         private readonly PluginConfig _pluginConfig;
         private readonly RevitRepository _revitRepository;
         private readonly IRoomFinisher _roomFinisher;
@@ -25,6 +24,8 @@ namespace RevitFinishingWalls.ViewModels {
         private const int _wallBaseMaxOffsetMM = 5000;
         /// <summary>Минимальное смещение низа стены вниз в мм</summary>
         private const int _wallBaseMinOffsetMM = -5000;
+        /// <summary>Максимальное смещение стены внутрь помещения в мм</summary>
+        private const int _wallSideMaxOffsetMM = 200;
 
 
         public MainViewModel(
@@ -51,7 +52,12 @@ namespace RevitFinishingWalls.ViewModels {
 
         public ICommand AcceptViewCommand { get; }
 
-        public string ErrorText => Error;
+
+        private string _errorText;
+        public string ErrorText {
+            get => _errorText;
+            set => RaiseAndSetIfChanged(ref _errorText, value);
+        }
 
 
         public ObservableCollection<RoomGetterMode> RoomGetterModes { get; }
@@ -68,21 +74,14 @@ namespace RevitFinishingWalls.ViewModels {
         private WallTypeViewModel _selectedWallType;
         public WallTypeViewModel SelectedWallType {
             get => _selectedWallType;
-            set {
-                RaiseAndSetIfChanged(ref _selectedWallType, value);
-                OnPropertyChanged(nameof(ErrorText));
-            }
+            set => RaiseAndSetIfChanged(ref _selectedWallType, value);
         }
 
 
         private string _wallHeightByUser;
         public string WallElevationByUser {
             get => _wallHeightByUser;
-            set {
-                RaiseAndSetIfChanged(ref _wallHeightByUser, value);
-                OnPropertyChanged(nameof(ErrorText));
-                OnPropertyChanged(nameof(WallBaseOffset));
-            }
+            set => RaiseAndSetIfChanged(ref _wallHeightByUser, value);
         }
 
 
@@ -97,7 +96,6 @@ namespace RevitFinishingWalls.ViewModels {
             set {
                 RaiseAndSetIfChanged(ref _selectedWallHeightMode, value);
                 OnPropertyChanged(nameof(IsWallHeightByUserEnabled));
-                OnPropertyChanged(nameof(ErrorText));
             }
         }
 
@@ -105,58 +103,13 @@ namespace RevitFinishingWalls.ViewModels {
         private string _wallBaseOffset;
         public string WallBaseOffset {
             get => _wallBaseOffset;
-            set {
-                RaiseAndSetIfChanged(ref _wallBaseOffset, value);
-                OnPropertyChanged(nameof(ErrorText));
-                OnPropertyChanged(nameof(WallElevationByUser));
-            }
+            set => RaiseAndSetIfChanged(ref _wallBaseOffset, value);
         }
 
-        public string Error => GetType()
-            .GetProperties()
-            .Select(prop => this[prop.Name])
-            .FirstOrDefault(error => !string.IsNullOrWhiteSpace(error)) ?? string.Empty;
-
-        public string this[string columnName] {
-            get {
-                switch(columnName) {
-                    case nameof(SelectedWallType): {
-                        if(SelectedWallType is null) {
-                            return "Задайте тип отделочных стен";
-                        }
-                        break;
-                    }
-                    case nameof(WallElevationByUser): {
-                        if(SelectedWallElevationMode == WallElevationMode.ManualHeight) {
-                            if(double.TryParse(WallElevationByUser, out double height)) {
-                                if(height <= 0) {
-                                    return "Отметка верха должна быть больше 0";
-                                } else if(height > _wallTopMaxElevationMM) {
-                                    return "Слишком большая отметка верха стены";
-                                } else if(double.TryParse(WallBaseOffset, out double offset) && (height <= offset)) {
-                                    return "Отметка верха должна быть больше смещения";
-                                }
-                            } else {
-                                return "Отметка верха должна быть числом";
-                            }
-                        }
-                        break;
-                    }
-                    case nameof(WallBaseOffset): {
-                        if(double.TryParse(WallBaseOffset, out double offset)) {
-                            if(offset < _wallBaseMinOffsetMM) {
-                                return "Слишком большое смещение вниз";
-                            } else if(offset > _wallBaseMaxOffsetMM) {
-                                return "Слишком большое смещение вверх";
-                            }
-                        } else {
-                            return "Смещение должно быть числом";
-                        }
-                        break;
-                    }
-                }
-                return string.Empty;
-            }
+        private string _wallSideOffset;
+        public string WallSideOffset {
+            get => _wallSideOffset;
+            set => RaiseAndSetIfChanged(ref _wallSideOffset, value);
         }
 
         private void AcceptView() {
@@ -169,7 +122,54 @@ namespace RevitFinishingWalls.ViewModels {
         }
 
         private bool CanAcceptView() {
-            return string.IsNullOrWhiteSpace(ErrorText);
+            if(SelectedWallType is null) {
+                ErrorText = "Задайте тип отделочных стен";
+                return false;
+            }
+            if(double.TryParse(WallBaseOffset, out double baseOffset)) {
+                if(baseOffset < _wallBaseMinOffsetMM) {
+                    ErrorText = "Слишком большое смещение вниз";
+                    return false;
+                } else if(baseOffset > _wallBaseMaxOffsetMM) {
+                    ErrorText = "Слишком большое смещение вверх";
+                    return false;
+                }
+            } else {
+                ErrorText = "Смещение должно быть числом";
+                return false;
+            }
+            if(SelectedWallElevationMode == WallElevationMode.ManualHeight) {
+                if(double.TryParse(WallElevationByUser, out double height)) {
+                    if(height <= 0) {
+                        ErrorText = "Отметка верха должна быть больше 0";
+                        return false;
+                    } else if(height > _wallTopMaxElevationMM) {
+                        ErrorText = "Слишком большая отметка верха стены";
+                        return false;
+                    } else if(height <= baseOffset) {
+                        ErrorText = "Отметка верха должна быть больше смещения";
+                        return false;
+                    }
+                } else {
+                    ErrorText = "Отметка верха должна быть числом";
+                    return false;
+                }
+            }
+            if(double.TryParse(WallSideOffset, out double sideOffset)) {
+                if(sideOffset < 0) {
+                    ErrorText = "Смещение внутрь не должно быть меньше 0";
+                    return false;
+                } else if(sideOffset > _wallSideMaxOffsetMM) {
+                    ErrorText = "Слишком большое смещение внутрь";
+                    return false;
+                }
+            } else {
+                ErrorText = "Смещение внутрь должно быть числом";
+                return false;
+            }
+
+            ErrorText = null;
+            return true;
         }
 
         private void LoadConfig() {
@@ -177,6 +177,7 @@ namespace RevitFinishingWalls.ViewModels {
             SelectedWallElevationMode = _pluginConfig.WallElevationMode;
             WallElevationByUser = _pluginConfig.WallElevationMm.ToString();
             WallBaseOffset = _pluginConfig.WallBaseOffsetMm.ToString();
+            WallSideOffset = _pluginConfig.WallSideOffsetMm.ToString();
             SelectedWallType = WallTypes.FirstOrDefault(wtvm => wtvm.WallTypeId == _pluginConfig.WallTypeId);
 
             OnPropertyChanged(nameof(ErrorText));
@@ -185,7 +186,8 @@ namespace RevitFinishingWalls.ViewModels {
         private void SaveConfig() {
             _pluginConfig.RoomGetterMode = SelectedRoomGetterMode;
             _pluginConfig.WallElevationMode = SelectedWallElevationMode;
-            _pluginConfig.WallBaseOffsetMm = double.TryParse(WallBaseOffset, out double offset) ? offset : 0;
+            _pluginConfig.WallBaseOffsetMm = double.TryParse(WallBaseOffset, out double baseOffset) ? baseOffset : 0;
+            _pluginConfig.WallSideOffsetMm = double.TryParse(WallSideOffset, out double sideOffset) ? sideOffset : 0;
             _pluginConfig.WallElevationMm = double.TryParse(WallElevationByUser, out double height) ? height : 0;
             _pluginConfig.WallTypeId = SelectedWallType.WallTypeId;
             _pluginConfig.SaveProjectConfig();

--- a/src/RevitFinishingWalls/Views/MainWindow.xaml
+++ b/src/RevitFinishingWalls/Views/MainWindow.xaml
@@ -23,6 +23,7 @@
     <dxmvvm:Interaction.Behaviors>
         <dxmvvm:EventToCommand EventName="Loaded"
                                Command="{Binding LoadConfigCommand}" />
+        <common:AttachServiceBehavior AttachableService="{Binding ProgressDialogFactory}" />
     </dxmvvm:Interaction.Behaviors>
     <Window.Resources>
         <converters:EnumConverter x:Key="EnumConverter" />

--- a/src/RevitFinishingWalls/Views/MainWindow.xaml
+++ b/src/RevitFinishingWalls/Views/MainWindow.xaml
@@ -14,9 +14,9 @@
                            xmlns:enums="clr-namespace:RevitFinishingWalls.Models.Enums"
                            mc:Ignorable="d"
                            WindowStartupLocation="CenterOwner"
-                           MinHeight="250"
+                           MinHeight="275"
                            MinWidth="600"
-                           MaxHeight="250"
+                           MaxHeight="275"
                            MaxWidth="600"
                            d:DataContext="{d:DesignInstance vms:MainViewModel, IsDesignTimeCreatable=False}"
                            ResizeMode="NoResize">
@@ -130,6 +130,15 @@
                 <TextBlock Text="Смещение снизу от уровня:"
                            Style="{StaticResource InputDescription}" />
                 <dxe:TextEdit Text="{Binding WallBaseOffset, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
+                <TextBlock Text="мм"
+                           Width="Auto"
+                           Style="{StaticResource InputDescription}" />
+            </DockPanel>
+            
+            <DockPanel Style="{StaticResource DockPanelInput}">
+                <TextBlock Text="Смещение внутрь помещения:"
+                           Style="{StaticResource InputDescription}" />
+                <dxe:TextEdit Text="{Binding WallSideOffset, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
                 <TextBlock Text="мм"
                            Width="Auto"
                            Style="{StaticResource InputDescription}" />


### PR DESCRIPTION
- Для отделочных стен теперь можно задать смещение в мм внутрь помещения. Допустимые значения смещения внутрь в диапазоне [0 мм; 200 мм].

![image](https://github.com/user-attachments/assets/815d4b5a-cafc-432d-adc0-7cc01efa20a3)

- Сохранение конфига сделано раздельно по проектам.
- Добавлен прогресс бар обработки помещений.
- Убрана попытка соединения отделочных стен со связями, т.к. это в принципе нельзя сделать в ревите.
- Добавлен сброс настроек видимости для 3D вида до настроек по умолчанию. Измененные настройки влияют на алгоритм поиска элементов, перекрытых линией-разделителем помещений.
- Улучшен алгоритм поиска элементов, перекрытых линией-разделителем помещений.
