### PR TITLE
RevitRoomTagPlacement: Исправление ошибки со связями

### DIFF
--- a/src/RevitRoomTagPlacement/Models/RevitRepository.cs
+++ b/src/RevitRoomTagPlacement/Models/RevitRepository.cs
@@ -9,8 +9,6 @@ using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Architecture;
 using Autodesk.Revit.UI;
 
-using dosymep.Bim4Everyone;
-using dosymep.Bim4Everyone.SharedParams;
 using dosymep.Revit;
 
 using RevitRoomTagPlacement.ViewModels;
@@ -139,15 +137,7 @@ namespace RevitRoomTagPlacement.Models {
                         .ToList();
 
                     if(!depElements.Contains(selectedTagType)) {
-                        TagPointFinder pathFinder = new TagPointFinder(room.RoomObject, indentFeet);
-                        UV point = pathFinder.GetPointByPlacementWay(positionPlacementWay, activeView);
-
-                        Location roomLocation = room.RoomObject.Location;
-
-                        LocationPoint roomLocationPoint = (LocationPoint) roomLocation;
-                        XYZ testPoint = new XYZ(point.U, point.V, room.CenterPoint.Z);
-
-                        if(!room.RoomObject.IsPointInRoom(testPoint)) point = pathFinder.GetPointByPath();
+                        UV point = FindUvPoint(room, indentFeet, positionPlacementWay);
 
                         /* Невозможно отфильтровать помещения из связанного файла для активного вида.
                            Способ получения помещений через CustomExporter не работает, так как помещения не экспортируются.
@@ -176,6 +166,28 @@ namespace RevitRoomTagPlacement.Models {
                 }
                 t.Commit();
             }
+        }
+        
+        private UV FindUvPoint(RoomFromRevit room, double indent, PositionPlacementWay positionPlacementWay) {
+            TagPointFinder pathFinder = new TagPointFinder(room.RoomObject, indent);
+            UV point = pathFinder.GetPointByPlacementWay(positionPlacementWay, Document.ActiveView);
+
+            XYZ testPoint = new XYZ(point.U, point.V, room.CenterPoint.Z);
+            if(!room.RoomObject.IsPointInRoom(testPoint)) {
+                point = pathFinder.GetPointByPath();
+            }
+
+            return TransformUvPoint(room, point);
+        }
+
+        private UV TransformUvPoint(RoomFromRevit room, UV point) {
+            if(room.LinkId != null) {
+                Transform transform = ((RevitLinkInstance) Document.GetElement(room.LinkId)).GetTotalTransform();
+                XYZ transformedPointXYZ = transform.OfPoint(new XYZ(point.U, point.V, room.CenterPoint.Z));
+                return new UV(transformedPointXYZ.X, transformedPointXYZ.Y);
+            }
+
+            return point;
         }
 
 #if REVIT_2020_OR_LESS

--- a/src/RevitRoomTagPlacement/Models/RevitRepository.cs
+++ b/src/RevitRoomTagPlacement/Models/RevitRepository.cs
@@ -159,8 +159,8 @@ namespace RevitRoomTagPlacement.Models {
                         if(newTag?.get_BoundingBox(activeView) == null) {
                             Document.Delete(newTag.Id);
                         }
-                        else if(newTag != null) { 
-                            newTag.ChangeTypeId(selectedTagType);
+                        else { 
+                            newTag?.ChangeTypeId(selectedTagType);
                         }
                     }
                 }

--- a/src/RevitRoomTagPlacement/Models/RevitRepository.cs
+++ b/src/RevitRoomTagPlacement/Models/RevitRepository.cs
@@ -152,17 +152,21 @@ namespace RevitRoomTagPlacement.Models {
                         RoomTag newTag;
 
                         if(room.LinkId == null) {
-                            newTag = Document.Create.NewRoomTag(new LinkElementId(room.RoomObject.Id), point, activeView.Id);
+                            LinkElementId linkElementId = new LinkElementId(room.RoomObject.Id);
+                            newTag = Document.Create.NewRoomTag(linkElementId, point, activeView.Id);
                         } 
                         else {
-                            newTag = Document.Create.NewRoomTag(new LinkElementId(room.LinkId, room.RoomObject.Id), point, activeView.Id);
+                            LinkElementId linkElementId = new LinkElementId(room.LinkId, room.RoomObject.Id);
+                            newTag = Document.Create.NewRoomTag(linkElementId, point, activeView.Id);
                         }
 
-                        if(newTag?.get_BoundingBox(activeView) == null) {
-                            Document.Delete(newTag.Id);
-                        }
-                        else { 
-                            newTag?.ChangeTypeId(selectedTagType);
+                        if(newTag != null) {
+                            if(newTag.get_BoundingBox(activeView) == null) {
+                                Document.Delete(newTag.Id);
+                            }
+                            else {
+                                newTag.ChangeTypeId(selectedTagType);
+                            }
                         }
                     }
                 }

--- a/src/RevitRoomTagPlacement/Models/RevitRepository.cs
+++ b/src/RevitRoomTagPlacement/Models/RevitRepository.cs
@@ -51,10 +51,12 @@ namespace RevitRoomTagPlacement.Models {
                 .ToList();
 
             foreach(var link in links) {
+                Transform transform = link.GetTotalTransform();
+
                 List<RoomFromRevit> rooms = new FilteredElementCollector(link.GetLinkDocument())
                 .OfCategory(BuiltInCategory.OST_Rooms)
                 .OfType<Room>()
-                .Select(x => new RoomFromRevit(x, link.Id))
+                .Select(x => new RoomFromRevit(x, link.Id, transform))
                 .ToList();
 
                 allRooms.AddRange(rooms);
@@ -181,9 +183,8 @@ namespace RevitRoomTagPlacement.Models {
         }
 
         private UV TransformUvPoint(RoomFromRevit room, UV point) {
-            if(room.LinkId != null) {
-                Transform transform = ((RevitLinkInstance) Document.GetElement(room.LinkId)).GetTotalTransform();
-                XYZ transformedPointXYZ = transform.OfPoint(new XYZ(point.U, point.V, room.CenterPoint.Z));
+            if(room.Transform != null) {
+                XYZ transformedPointXYZ = room.Transform.OfPoint(new XYZ(point.U, point.V, room.CenterPoint.Z));
                 return new UV(transformedPointXYZ.X, transformedPointXYZ.Y);
             }
 

--- a/src/RevitRoomTagPlacement/Models/RoomFromRevit.cs
+++ b/src/RevitRoomTagPlacement/Models/RoomFromRevit.cs
@@ -13,11 +13,13 @@ namespace RevitRoomTagPlacement.Models {
     internal class RoomFromRevit {
         private readonly Room _room;
         private readonly ElementId _linkId;
+        private readonly Transform _transform;
         private readonly string _name;
 
-        public RoomFromRevit(Room room, ElementId linkId = null) {
+        public RoomFromRevit(Room room, ElementId linkId = null, Transform transform = null) {
             _room = room;
             _linkId = linkId;
+            _transform = transform;
             // Стандартное свойство Name нельзя использовать,
             // так как оно возвращает имя вместе с номером помещения
             _name = _room.GetParamValueOrDefault(BuiltInParameter.ROOM_NAME, "<Без имени>");
@@ -28,6 +30,7 @@ namespace RevitRoomTagPlacement.Models {
         public string Name => _name;
 
         public ElementId LinkId => _linkId;
+        public Transform Transform => _transform;
 
         public XYZ CenterPoint => _room.ClosedShell
             .OfType<Solid>()


### PR DESCRIPTION
Исправлена ошибка размещения марок на помещениях из связанных файлов.
Когда скрипт запускается на виде, на котором есть помещения из связанного файла, марки этих помещений размещаются не на самих помещениях, а со смещением.

![image](https://github.com/user-attachments/assets/b6edecff-ebb0-4b9c-bf3d-fb306465c984)

Для решения проблемы добавлена трансформация координаты марки.