### PR TITLE
RevitServerFolders: Исправлена проблема с отсутствием скрытия РН при экспорте в NWC

### DIFF
--- a/src/RevitServerFolders/Models/RevitRepository.cs
+++ b/src/RevitServerFolders/Models/RevitRepository.cs
@@ -20,13 +20,15 @@ namespace RevitServerFolders.Models {
 
         public Document OpenDocumentFile(string fileName) {
             var modelPath = ModelPathUtils.ConvertUserVisiblePathToModelPath(fileName);
+            var opts = new OpenOptions() {
+                AllowOpeningLocalByWrongUser = true,
+                OpenForeignOption = OpenForeignOption.Open,
+                DetachFromCentralOption = DetachFromCentralOption.DetachAndPreserveWorksets
+            };
+            opts.SetOpenWorksetsConfiguration(new WorksetConfiguration(WorksetConfigurationOption.OpenAllWorksets));
             return Application.OpenDocumentFile(
                 modelPath,
-                new OpenOptions() {
-                    AllowOpeningLocalByWrongUser = true,
-                    OpenForeignOption = OpenForeignOption.Open,
-                    DetachFromCentralOption = DetachFromCentralOption.DetachAndDiscardWorksets,
-                });
+                opts);
         }
 
         public string GetFileName(string fileName) {


### PR DESCRIPTION
До этого файл rvt открывался с отсоединением без сохранения рабочих наборов, из-за чего на виде Navisworks полностью слетали настройки скрытия рабочих наборов. Теперь файл rvt открывается с отсоединением, с сохранением рабочих наборов, с открытием всех рабочих наборов.

Плашка "Рабочие наборы" есть только в файлах, в которых включена совместная работа соответственно включены рабочие наборы:
![image](https://github.com/user-attachments/assets/cd3e9564-575d-41b3-9aff-be13a55f1005)
