### PR TITLE
RevitServerFolders: Добавлена возможность отключать очистку целевой папки

### DIFF
--- a/src/RevitServerFolders/Models/PluginConfig.cs
+++ b/src/RevitServerFolders/Models/PluginConfig.cs
@@ -1,4 +1,4 @@
-﻿using dosymep.Bim4Everyone;
+using dosymep.Bim4Everyone;
 using dosymep.Bim4Everyone.ProjectConfigs;
 using dosymep.Serializers;
 
@@ -9,15 +9,16 @@ namespace RevitServerFolders.Models {
         [JsonIgnore] public override string ProjectConfigPath { get; set; }
 
         [JsonIgnore] public override IConfigSerializer Serializer { get; set; }
-        
+
         public string TargetFolder { get; set; }
         public string SourceFolder { get; set; }
+        public bool ClearTargetFolder { get; set; } = false;
         public string[] SkippedObjects { get; set; }
     }
 
     internal class FileModelObjectConfig : PluginConfig {
         public bool IsExportRooms { get; set; }
-        
+
         public static FileModelObjectConfig GetPluginConfig() {
             return new ProjectConfigBuilder()
                 .SetSerializer(new ConfigSerializer())
@@ -27,7 +28,7 @@ namespace RevitServerFolders.Models {
                 .Build<FileModelObjectConfig>();
         }
     }
-    
+
     internal class RsModelObjectConfig : PluginConfig {
         public static RsModelObjectConfig GetPluginConfig() {
             return new ProjectConfigBuilder()

--- a/src/RevitServerFolders/Services/IModelsExportService.cs
+++ b/src/RevitServerFolders/Services/IModelsExportService.cs
@@ -11,11 +11,13 @@ namespace RevitServerFolders.Services {
         /// </summary>
         /// <param name="targetFolder">Абсолютный путь к директории, в которую нужно экспортировать файлы</param>
         /// <param name="modelFiles">Массив абсолютных путей к файлам, которые нужно экспортировать</param>
+        /// <param name="clearTargetFolder">True, если целевую директорию надо очистить, иначе False</param>
         /// <param name="progress">Прогресс для уведомления о ходе выполнения операции</param>
         /// <param name="ct">Токен отмены</param>
         void ExportModelObjects(
             string targetFolder,
             string[] modelFiles,
+            bool clearTargetFolder = false,
             IProgress<int> progress = null,
             CancellationToken ct = default);
     }

--- a/src/RevitServerFolders/Services/NwcExportService.cs
+++ b/src/RevitServerFolders/Services/NwcExportService.cs
@@ -32,6 +32,7 @@ namespace RevitServerFolders.Services {
         public void ExportModelObjects(
             string targetFolder,
             string[] modelFiles,
+            bool clearTargetFolder = false,
             IProgress<int> progress = null,
             CancellationToken ct = default) {
             if(string.IsNullOrWhiteSpace(targetFolder)) {
@@ -43,10 +44,12 @@ namespace RevitServerFolders.Services {
 
             Directory.CreateDirectory(targetFolder);
 
-            var navisFiles = Directory.GetFiles(targetFolder, _nwcSearchPattern);
-            foreach(var navisFile in navisFiles) {
-                File.SetAttributes(navisFile, FileAttributes.Normal);
-                File.Delete(navisFile);
+            if(clearTargetFolder) {
+                var navisFiles = Directory.GetFiles(targetFolder, _nwcSearchPattern);
+                foreach(var navisFile in navisFiles) {
+                    File.SetAttributes(navisFile, FileAttributes.Normal);
+                    File.Delete(navisFile);
+                }
             }
 
             for(int i = 0; i < modelFiles.Length; i++) {

--- a/src/RevitServerFolders/Services/RvtExportService.cs
+++ b/src/RevitServerFolders/Services/RvtExportService.cs
@@ -25,6 +25,7 @@ namespace RevitServerFolders.Services {
         public void ExportModelObjects(
             string targetFolder,
             string[] modelFiles,
+            bool clearTargetFolder = false,
             IProgress<int> progress = null,
             CancellationToken ct = default) {
             if(string.IsNullOrWhiteSpace(targetFolder)) {
@@ -36,10 +37,12 @@ namespace RevitServerFolders.Services {
 
             Directory.CreateDirectory(targetFolder);
 
-            var revitFiles = Directory.GetFiles(targetFolder, _rvtSearchPattern);
-            foreach(var revitFile in revitFiles) {
-                File.SetAttributes(revitFile, FileAttributes.Normal);
-                File.Delete(revitFile);
+            if(clearTargetFolder) {
+                var revitFiles = Directory.GetFiles(targetFolder, _rvtSearchPattern);
+                foreach(var revitFile in revitFiles) {
+                    File.SetAttributes(revitFile, FileAttributes.Normal);
+                    File.Delete(revitFile);
+                }
             }
 
             for(int i = 0; i < modelFiles.Length; i++) {

--- a/src/RevitServerFolders/ViewModels/FileSystemViewModel.cs
+++ b/src/RevitServerFolders/ViewModels/FileSystemViewModel.cs
@@ -45,7 +45,7 @@ namespace RevitServerFolders.ViewModels {
                 CancellationToken ct = dialog.CreateCancellationToken();
                 dialog.Show();
 
-                _exportService.ExportModelObjects(TargetFolder, modelFiles, progress, ct);
+                _exportService.ExportModelObjects(TargetFolder, modelFiles, ClearTargetFolder, progress, ct);
             }
         }
     }

--- a/src/RevitServerFolders/ViewModels/MainViewModel.cs
+++ b/src/RevitServerFolders/ViewModels/MainViewModel.cs
@@ -28,6 +28,7 @@ namespace RevitServerFolders.ViewModels {
 
         private bool _isExportRooms;
         private bool _isExportRoomsVisible;
+        private bool _clearTargetFolder;
 
         public MainViewModel(PluginConfig pluginConfig,
             IModelObjectService objectService,
@@ -66,6 +67,11 @@ namespace RevitServerFolders.ViewModels {
         public string TargetFolder {
             get => _targetFolder;
             set => this.RaiseAndSetIfChanged(ref _targetFolder, value);
+        }
+
+        public bool ClearTargetFolder {
+            get => _clearTargetFolder;
+            set => this.RaiseAndSetIfChanged(ref _clearTargetFolder, value);
         }
 
         public string SourceFolder {
@@ -179,6 +185,7 @@ namespace RevitServerFolders.ViewModels {
         private void LoadConfig() {
             TargetFolder = _pluginConfig.TargetFolder;
             SourceFolder = _pluginConfig.SourceFolder;
+            ClearTargetFolder = _pluginConfig.ClearTargetFolder;
 
             LoadConfigImpl();
         }
@@ -186,6 +193,7 @@ namespace RevitServerFolders.ViewModels {
         private void SaveConfig() {
             _pluginConfig.TargetFolder = TargetFolder;
             _pluginConfig.SourceFolder = SourceFolder;
+            _pluginConfig.ClearTargetFolder = ClearTargetFolder;
             _pluginConfig.SkippedObjects = ModelObjects
                 .Where(item => item.SkipObject)
                 .Select(item => item.FullName)

--- a/src/RevitServerFolders/ViewModels/RsViewModel.cs
+++ b/src/RevitServerFolders/ViewModels/RsViewModel.cs
@@ -36,7 +36,7 @@ namespace RevitServerFolders.ViewModels {
                 CancellationToken ct = dialog.CreateCancellationToken();
                 dialog.Show();
 
-                _exportService.ExportModelObjects(TargetFolder, modelFiles, progress, ct);
+                _exportService.ExportModelObjects(TargetFolder, modelFiles, ClearTargetFolder, progress, ct);
             }
         }
     }

--- a/src/RevitServerFolders/Views/MainWindow.xaml
+++ b/src/RevitServerFolders/Views/MainWindow.xaml
@@ -146,6 +146,10 @@
                 EditValue="{Binding IsExportRooms}"
                 Visibility="{Binding IsExportRoomsVisible, 
                     Converter={StaticResource BooleanToVisibilityConverter}}" />
+            <dxe:CheckEdit
+                Margin="5 0"
+                Content="Очищать папку назначения"
+                EditValue="{Binding ClearTargetFolder}" />
         </DockPanel>
 
         <dxe:ButtonEdit


### PR DESCRIPTION
Добавлена галочка в выгрузку rvt из RS и nwc из rvt, чтобы можно было включить/отключить очистку целевой папки

![image](https://github.com/user-attachments/assets/c812b8ac-07b0-4e59-b6ea-4f1418341bcd)
