### PR TITLE
RevitServerFolders: Корректировка сообщений логов

### DIFF
--- a/src/RevitServerFolders/Services/NwcExportService.cs
+++ b/src/RevitServerFolders/Services/NwcExportService.cs
@@ -83,8 +83,8 @@ namespace RevitServerFolders.Services {
 
                         if(navisView == null) {
                             _loggerService.Warning(
-                                "Document {@FileName} doesn't contains {@NavisView} view.",
-                                fileName, navisView);
+                                "Файл {@FileName} не содержит вид {@NavisView}.",
+                                fileName, _navisworksViewName);
                             return;
                         }
 
@@ -100,8 +100,8 @@ namespace RevitServerFolders.Services {
 
                         if(!hasElements) {
                             _loggerService.Warning(
-                                "View {@NavisView} in document {@FileName} doesn't contains elements.",
-                                 navisView, fileName);
+                                "Вид {@NavisView} в файле {@FileName} не содержит элементы.",
+                                 navisView.Name, fileName);
                             return;
                         }
 

--- a/src/RevitServerFolders/Services/NwcExportService.cs
+++ b/src/RevitServerFolders/Services/NwcExportService.cs
@@ -82,6 +82,9 @@ namespace RevitServerFolders.Services {
                                 item.Name.Equals(_navisworksViewName, StringComparison.OrdinalIgnoreCase));
 
                         if(navisView == null) {
+                            _loggerService.Warning(
+                                "Document {@FileName} doesn't contains {@NavisView} view.",
+                                fileName, navisView);
                             return;
                         }
 
@@ -96,6 +99,9 @@ namespace RevitServerFolders.Services {
                                 .Any();
 
                         if(!hasElements) {
+                            _loggerService.Warning(
+                                "View {@NavisView} in document {@FileName} doesn't contains elements.",
+                                 navisView, fileName);
                             return;
                         }
 
@@ -164,6 +170,9 @@ namespace RevitServerFolders.Services {
                 })
                 .ToArray();
 
+            if(failureMessages.Length == 0) {
+                return;
+            }
             _loggerService.Information(
                 "Event handler: {@EventHandler}; title: {@DocTitle}; Failures: {@Failures}",
                 nameof(ApplicationOnFailuresProcessing), accessor.GetDocument().Title, failureMessages);


### PR DESCRIPTION
Из-за недостаточных сообщений логов не было понятно, почему не выполняется экспорт RVT в NWC.
Добавлены сообщения, когда не найден вид для экспорта и когда на этом виде не обнаружено элементов для экспорта.
Также сделан выход из обработчика ошибок, когда ошибок не обнаружено.