### PR TITLE
RevitServerFolders: Исправление ошибки с поиском элементов на виде

### DIFF
--- a/src/RevitServerFolders/Services/NwcExportService.cs
+++ b/src/RevitServerFolders/Services/NwcExportService.cs
@@ -96,7 +96,7 @@ namespace RevitServerFolders.Services {
 #else
                                 .WherePasses(new VisibleInViewFilter(document, navisView.Id))
 #endif
-                                .Any();
+                                .Any(e => e.Category != null); // На виде, где выключена видимость всех элементов через GUI ревита, присутствует 1 элемент ExtentElem c категорией null
 
                         if(!hasElements) {
                             _loggerService.Warning(


### PR DESCRIPTION
# Проблема с непонятным элементом, который остается на виде
Когда на 3D виде Navisworks выключена видимость всех элементов через GUI, на виде всё еще присутствует 1 элемент - ExtentElem. Из-за этого элемента не работала проверка на Any в списке элементов на виде.
Теперь в Any проверяется также на наличие категории у элементов.

Диалоговое окно модуля по экспорту в NWC, которое возникает, если на вход дать 3D вид с одним ExtentElem, и которое не обрабатывается обработчиком UIApplicationOnDialogBoxShowing:
![image](https://github.com/user-attachments/assets/b5f07278-a33d-41f8-8737-5b6dbb646664)

Значения свойств ExtentElem:
![image](https://github.com/user-attachments/assets/d64dc02f-e697-424f-a64f-cca96e27ee59)
![image](https://github.com/user-attachments/assets/98f86705-2113-4e8a-aff8-77c0772b27c0)
