### PR TITLE
RevitClashDetective: Устранён бага с потерей значений при скролле окна

### DIFF
--- a/src/RevitClashDetective/Views/ClashReportDiffView.xaml
+++ b/src/RevitClashDetective/Views/ClashReportDiffView.xaml
@@ -14,7 +14,9 @@
     
     mc:Ignorable="d"
     Title="ClashReportDiffView" Height="450" Width="800"
-    d:DataContext="{d:DesignInstance vm:ClashReportDiffViewModel, IsDesignTimeCreatable=False}">
+    d:DataContext="{d:DesignInstance vm:ClashReportDiffViewModel, IsDesignTimeCreatable=False}"
+    MinHeight="300"
+    MinWidth="500">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />

--- a/src/RevitClashDetective/Views/ClashReportDiffView.xaml
+++ b/src/RevitClashDetective/Views/ClashReportDiffView.xaml
@@ -14,9 +14,9 @@
     
     mc:Ignorable="d"
     Title="ClashReportDiffView" Height="450" Width="800"
-    d:DataContext="{d:DesignInstance vm:ClashReportDiffViewModel, IsDesignTimeCreatable=False}"
     MinHeight="300"
-    MinWidth="500">
+    MinWidth="500"
+    d:DataContext="{d:DesignInstance vm:ClashReportDiffViewModel, IsDesignTimeCreatable=False}">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />

--- a/src/RevitClashDetective/Views/FilterCreatorView.xaml
+++ b/src/RevitClashDetective/Views/FilterCreatorView.xaml
@@ -14,6 +14,8 @@
     
     mc:Ignorable="d"
     Title="Поисковые наборы" Height="450" Width="1000"
+    MinHeight="300"
+    MinWidth="500"
     x:Name="ViewFilterCreator"
     d:DataContext="{d:DesignInstance vm:FiltersViewModel, IsDesignTimeCreatable=False}">
     <Grid Margin="10">

--- a/src/RevitClashDetective/Views/MainWindow.xaml
+++ b/src/RevitClashDetective/Views/MainWindow.xaml
@@ -14,6 +14,8 @@
     mc:Ignorable="d"
     x:Name="_this"
     Title="Проверки на коллизии" Height="450" Width="800"
+    MinHeight="300"
+    MinWidth="500"
     d:DataContext="{d:DesignInstance clashDetective:MainViewModel, IsDesignTimeCreatable=False}">
     <Grid Margin="10">
         <Grid.RowDefinitions>

--- a/src/RevitClashDetective/Views/NavigatorView.xaml
+++ b/src/RevitClashDetective/Views/NavigatorView.xaml
@@ -19,7 +19,7 @@
                            Width="800"
                            MinHeight="300"
                            MinWidth="500"
-    d:DataContext="{d:DesignInstance vm:ReportsViewModel, IsDesignTimeCreatable=False}">
+                           d:DataContext="{d:DesignInstance vm:ReportsViewModel, IsDesignTimeCreatable=False}">
     <b:Interaction.Triggers>
         <b:EventTrigger EventName="Closing">
             <b:InvokeCommandAction Command="{Binding OpenClashDetectorCommand}" />

--- a/src/RevitClashDetective/Views/NavigatorView.xaml
+++ b/src/RevitClashDetective/Views/NavigatorView.xaml
@@ -17,7 +17,9 @@
                            Title="Навигатор"
                            Height="450"
                            Width="800"
-                           d:DataContext="{d:DesignInstance vm:ReportsViewModel, IsDesignTimeCreatable=False}">
+                           MinHeight="300"
+                           MinWidth="500"
+    d:DataContext="{d:DesignInstance vm:ReportsViewModel, IsDesignTimeCreatable=False}">
     <b:Interaction.Triggers>
         <b:EventTrigger EventName="Closing">
             <b:InvokeCommandAction Command="{Binding OpenClashDetectorCommand}" />

--- a/src/RevitClashDetective/Views/ProviderComboBox.xaml
+++ b/src/RevitClashDetective/Views/ProviderComboBox.xaml
@@ -17,14 +17,14 @@
             <ColumnDefinition />
         </Grid.ColumnDefinitions>
         <dxe:ComboBoxEdit Grid.Column="0"
-            NullText="Выберите файлы"
-            SeparatorString=", "
-            IsTextEditable="False"
-            TextWrapping="Wrap"
-            DisplayMember="Name"
-            AllowUpdateTwoWayBoundPropertiesOnSynchronization="False"
-            ItemsSource="{Binding Files}"
-            EditValue="{Binding SelectedFileObjects, UpdateSourceTrigger=PropertyChanged}">
+                          NullText="Выберите файлы"
+                          SeparatorString=", "
+                          IsTextEditable="False"
+                          TextWrapping="Wrap"
+                          DisplayMember="Name"
+                          AllowUpdateTwoWayBoundPropertiesOnSynchronization="False"
+                          ItemsSource="{Binding Files}"
+                          EditValue="{Binding SelectedFileObjects, UpdateSourceTrigger=PropertyChanged}">
             <dxe:ComboBoxEdit.StyleSettings>
                 <dxe:CheckedComboBoxStyleSettings />
             </dxe:ComboBoxEdit.StyleSettings>

--- a/src/RevitClashDetective/Views/ProviderComboBox.xaml
+++ b/src/RevitClashDetective/Views/ProviderComboBox.xaml
@@ -17,13 +17,14 @@
             <ColumnDefinition />
         </Grid.ColumnDefinitions>
         <dxe:ComboBoxEdit Grid.Column="0"
-                          NullText="Выберите файлы"
-                          SeparatorString=", "
-                          IsTextEditable="False"
-                          TextWrapping="Wrap"
-                          DisplayMember="Name"
-                          ItemsSource="{Binding Files}"
-                          EditValue="{Binding SelectedFileObjects, UpdateSourceTrigger=PropertyChanged}">
+            NullText="Выберите файлы"
+            SeparatorString=", "
+            IsTextEditable="False"
+            TextWrapping="Wrap"
+            DisplayMember="Name"
+            AllowUpdateTwoWayBoundPropertiesOnSynchronization="False"
+            ItemsSource="{Binding Files}"
+            EditValue="{Binding SelectedFileObjects, UpdateSourceTrigger=PropertyChanged}">
             <dxe:ComboBoxEdit.StyleSettings>
                 <dxe:CheckedComboBoxStyleSettings />
             </dxe:ComboBoxEdit.StyleSettings>
@@ -34,6 +35,7 @@
                           IsTextEditable="False"
                           TextWrapping="Wrap"
                           DisplayMember="Name"
+                          AllowUpdateTwoWayBoundPropertiesOnSynchronization="False"
                           ItemsSource="{Binding Providers}"
                           EditValue="{Binding SelectedProvidersObjects, UpdateSourceTrigger=PropertyChanged}">
             <dxe:ComboBoxEdit.StyleSettings>

--- a/src/RevitClashDetective/Views/RevitReportClashNavigator.xaml
+++ b/src/RevitClashDetective/Views/RevitReportClashNavigator.xaml
@@ -13,6 +13,8 @@
     xmlns:mvvm="http://schemas.devexpress.com/winfx/2008/xaml/mvvm"
     mc:Ignorable="d"
     Title="Навигатор" Height="450" Width="800"
+    MinHeight="300"
+    MinWidth="500"
     d:DataContext="{d:DesignInstance vm:RevitReportClashesViewModel, IsDesignTimeCreatable=False}">
     <Grid Margin="10">
         <Grid.RowDefinitions>


### PR DESCRIPTION
# Баг с потерей выбранных значений в комбобоксе при скролле

## Описание бага

При скролле GridControl, в View которого в строках есть ComboBoxEdit, в этих ComboBoxEdit стиралось выбранное значение при скролле.
До скролла:
![image](https://github.com/user-attachments/assets/6bb8ebb1-f17f-4a63-bff5-7c12664a3758)

после скролла:
![image](https://github.com/user-attachments/assets/7f074f81-da53-4b12-84ad-49f08e1c67bb)

## Решение проблемы

Надо устанавливать в ComboBoxEdit свойство `AllowUpdateTwoWayBoundPropertiesOnSynchronization="False"`

Ссылка на аналогичную ошибку:
https://supportcenter.devexpress.com/Ticket/Details/T585438/custom-comboboxedit-in-gridcontrol-loses-value-after-scrolling