### PR TITLE
RevitOpeningPlacement: Скорректировано отображение названия параметра для диаметра труб в GUI

### DIFF
--- a/src/RevitOpeningPlacement/ViewModels/OpeningConfig/MepCategoryViewModel.cs
+++ b/src/RevitOpeningPlacement/ViewModels/OpeningConfig/MepCategoryViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -14,6 +15,7 @@ using RevitOpeningPlacement.Models.TypeNamesProviders;
 
 namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
     internal class MepCategoryViewModel : BaseViewModel {
+        private const string _pipeDiameterDisplayName = "Внешний диаметр";
         private string _name;
         private ObservableCollection<SizeViewModel> _minSizes;
         private ObservableCollection<OffsetViewModel> _offsets;
@@ -36,7 +38,7 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
             SelectedRounding = mepCategory.Rounding;
             var categoriesInfoViewModel = GetCategoriesInfoViewModel(revitRepository, Name);
             SetViewModel = new SetViewModel(revitRepository, categoriesInfoViewModel, mepCategory.Set);
-
+            RenameDisplayParameters();
             AddOffsetCommand = RelayCommand.Create(AddOffset);
             RemoveOffsetCommand = RelayCommand.Create<OffsetViewModel>(RemoveOffset, CanRemoveOffset);
         }
@@ -128,6 +130,20 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
             };
         }
 
+
+        private void RenameDisplayParameters() {
+            if(Name.Equals(
+                RevitRepository.MepCategoryNames[MepCategoryEnum.Pipe],
+                StringComparison.InvariantCultureIgnoreCase)) {
+
+                var diameter = MinSizes.FirstOrDefault(p => p.DisplayName.Equals(
+                    RevitRepository.ParameterNames[Parameters.Diameter],
+                    StringComparison.InvariantCultureIgnoreCase));
+                if(diameter != null) {
+                    diameter.DisplayName = _pipeDiameterDisplayName;
+                }
+            }
+        }
 
         private void AddOffset() {
             Offsets.Add(new OffsetViewModel(new TypeNamesProvider(IsRound)));

--- a/src/RevitOpeningPlacement/ViewModels/OpeningConfig/SizeViewModel.cs
+++ b/src/RevitOpeningPlacement/ViewModels/OpeningConfig/SizeViewModel.cs
@@ -1,14 +1,16 @@
-﻿using dosymep.WPF.ViewModels;
+using dosymep.WPF.ViewModels;
 
 using RevitOpeningPlacement.Models.Configs;
 
 namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
     internal class SizeViewModel : BaseViewModel {
         private double _value;
-        private string _name;
+        private string _displayName;
+        private readonly string _sizeName;
 
         public SizeViewModel(Size size) {
-            Name = size.Name;
+            _sizeName = size.Name;
+            DisplayName = size.Name;
             Value = size.Value;
         }
 
@@ -16,9 +18,9 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
 
         }
 
-        public string Name {
-            get => _name;
-            set => this.RaiseAndSetIfChanged(ref _name, value);
+        public string DisplayName {
+            get => _displayName;
+            set => this.RaiseAndSetIfChanged(ref _displayName, value);
         }
         public double Value {
             get => _value;
@@ -27,13 +29,13 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
 
         public string GetErrorText() {
             if(Value < 0) {
-                return $"значение параметра \"{Name}\" должно быть неотрицательным.";
+                return $"значение параметра \"{DisplayName}\" должно быть неотрицательным.";
             }
             return null;
         }
 
         public Size GetSize() {
-            return new Size() { Name = Name, Value = Value };
+            return new Size() { Name = _sizeName, Value = Value };
         }
     }
 }

--- a/src/RevitOpeningPlacement/Views/SettingView.xaml
+++ b/src/RevitOpeningPlacement/Views/SettingView.xaml
@@ -71,11 +71,11 @@
                                         </dxg:GridControl.View>
                                         <dxg:GridControl.Columns>
                                             <dxg:GridColumn Header="Параметр"
-                                                            FieldName="Name"
-                                                            Width="*"
+                                                            FieldName="DisplayName"
+                                                            Width="2*"
                                                             ReadOnly="True" />
                                             <dxg:GridColumn Header="Значение"
-                                                            Width="*"
+                                                            Width="1*"
                                                             AllowEditing="True"
                                                             FieldName="Value" />
                                         </dxg:GridControl.Columns>


### PR DESCRIPTION
# Изменено отображение параметра в GUI

Теперь в GUI параметр "Диаметр" для труб отображается как "Внешний диаметр"

![image](https://github.com/user-attachments/assets/545142e9-3481-49fc-b18c-2fb4e5b3f314)
