### PR TITLE
Обновление имени системы: Блокированный параметр

### DIFF
--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamSystemFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamSystemFiller.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Autodesk.Revit.DB;
 
+using dosymep.Bim4Everyone;
 using dosymep.Revit;
 
 using RevitMechanicalSpecification.Entities;
@@ -48,7 +49,12 @@ namespace RevitMechanicalSpecification.Models.Fillers {
             // Он будет устраняться из всех шаблонов, включая шаблоны самой B4E. Но пока он глубоко интегрирован в документацию, 
             // будем обновлять, чтоб не плодить переработки. 
             if(specificationElement.Element.IsExistsParam(_tempSharedNameName)) {
-                specificationElement.Element.SetParamValue(_tempSharedNameName, calculatedSystem);
+                Parameter adsk_name = specificationElement.Element.GetParam(_tempSharedNameName);
+
+                // В основном ситуация с рид-онли встречается у внешних пользователей, наши не блокируют этот параметр
+                if(!adsk_name.IsReadOnly) {
+                    adsk_name.Set(calculatedSystem);
+                }
             }
         }
 

--- a/src/RevitMechanicalSpecification/Service/ParamChecker.cs
+++ b/src/RevitMechanicalSpecification/Service/ParamChecker.cs
@@ -91,15 +91,7 @@ namespace RevitMechanicalSpecification.Service {
             _document = document;
             _specConfiguration = specConfiguration;
             ProjectParameters projectParameters = ProjectParameters.Create(document.Application);
-            //projectParameters.SetupRevitParams(document, _revitParams);
-
-            // Если использовать SetupRevitParams для всего листа сразу - любые снятые/добавленные галочки перебьются.
-            // Это плохо играет на кастомных категориях
-            foreach(RevitParam revitParam in _revitParams) {
-                if(!document.IsExistsParam(revitParam.Name)){
-                    projectParameters.SetupRevitParam(document, revitParam);
-                }
-            }
+            projectParameters.SetupRevitParams(document, _revitParams);
 
             CheckParamterValues();
         }


### PR DESCRIPTION
У некоторых организаций начались сбои, параметр ADSK_Имя системы у них периодически уведен в ReadOnly. 

Убираю его обработку в случае подобной блокировки. 

Заодно возвращаю нормальную настройку параметров - текущая версия шаблона платформы уже устраивает, нет нужды его избегать. 