### PR TITLE
Пакетная печать: Исправление выбора формата при печати

### DIFF
--- a/src/RevitBatchPrint/Models/Format.cs
+++ b/src/RevitBatchPrint/Models/Format.cs
@@ -6,66 +6,63 @@ using System.Linq;
 
 namespace RevitBatchPrint.Models {
     internal class Format {
-        private static readonly List<Format> _formats = new List<Format>() {
-            new Format() {Name = "GOST_A0", Width = 841, Height = 1189},
-            new Format() {Name = "GOST_A0x2", Width = 1189, Height = 1682},
-            new Format() {Name = "GOST_A0x3", Width = 1189, Height = 2523},
-            new Format() {Name = "GOST_A1", Width = 594, Height = 841},
-            new Format() {Name = "GOST_A1x3", Width = 841, Height = 1783},
-            new Format() {Name = "GOST_A1x4", Width = 841, Height = 2378},
-            new Format() {Name = "GOST_A2", Width = 420, Height = 594},
-            new Format() {Name = "GOST_A2x3", Width = 594, Height = 1261},
-            new Format() {Name = "GOST_A2x4", Width = 594, Height = 1682},
-            new Format() {Name = "GOST_A2x5", Width = 594, Height = 2102},
-            new Format() {Name = "GOST_A3", Width = 297, Height = 420},
-            new Format() {Name = "GOST_A3x3", Width = 420, Height = 891},
-            new Format() {Name = "GOST_A3x4", Width = 420, Height = 1189},
-            new Format() {Name = "GOST_A3x5", Width = 420, Height = 1486},
-            new Format() {Name = "GOST_A3x6", Width = 420, Height = 1783},
-            new Format() {Name = "GOST_A3x7", Width = 420, Height = 2080},
-            new Format() {Name = "GOST_A4", Width = 210, Height = 297},
-            new Format() {Name = "GOST_A4x3", Width = 297, Height = 630},
-            new Format() {Name = "GOST_A4x4", Width = 297, Height = 841},
-            new Format() {Name = "GOST_A4x5", Width = 297, Height = 1051},
-            new Format() {Name = "GOST_A4x6", Width = 297, Height = 1261},
-            new Format() {Name = "GOST_A4x7", Width = 297, Height = 1471},
-            new Format() {Name = "GOST_A4x8", Width = 297, Height = 1682},
-            new Format() {Name = "GOST_A4x9", Width = 297, Height = 1892},
+        public const string GostPrefix = "B4E_GOST";
+        public const string CustomPrefix = "B4E_Custom";
+
+        private const int _defaultFormatTolerance = 5;
+
+        private static readonly List<Format> _gostFormats = new List<Format>() {
+            new Format() {Name = $"{GostPrefix}_A0", Width = 841, Height = 1189},
+            new Format() {Name = $"{GostPrefix}_A0x2", Width = 1189, Height = 1682},
+            new Format() {Name = $"{GostPrefix}_A0x3", Width = 1189, Height = 2523},
+            new Format() {Name = $"{GostPrefix}_A1", Width = 594, Height = 841},
+            new Format() {Name = $"{GostPrefix}_A1x3", Width = 841, Height = 1783},
+            new Format() {Name = $"{GostPrefix}_A1x4", Width = 841, Height = 2378},
+            new Format() {Name = $"{GostPrefix}_A2", Width = 420, Height = 594},
+            new Format() {Name = $"{GostPrefix}_A2x3", Width = 594, Height = 1261},
+            new Format() {Name = $"{GostPrefix}_A2x4", Width = 594, Height = 1682},
+            new Format() {Name = $"{GostPrefix}_A2x5", Width = 594, Height = 2102},
+            new Format() {Name = $"{GostPrefix}_A3", Width = 297, Height = 420},
+            new Format() {Name = $"{GostPrefix}_A3x3", Width = 420, Height = 891},
+            new Format() {Name = $"{GostPrefix}_A3x4", Width = 420, Height = 1189},
+            new Format() {Name = $"{GostPrefix}_A3x5", Width = 420, Height = 1486},
+            new Format() {Name = $"{GostPrefix}_A3x6", Width = 420, Height = 1783},
+            new Format() {Name = $"{GostPrefix}_A3x7", Width = 420, Height = 2080},
+            new Format() {Name = $"{GostPrefix}_A4", Width = 210, Height = 297},
+            new Format() {Name = $"{GostPrefix}_A4x3", Width = 297, Height = 630},
+            new Format() {Name = $"{GostPrefix}_A4x4", Width = 297, Height = 841},
+            new Format() {Name = $"{GostPrefix}_A4x5", Width = 297, Height = 1051},
+            new Format() {Name = $"{GostPrefix}_A4x6", Width = 297, Height = 1261},
+            new Format() {Name = $"{GostPrefix}_A4x7", Width = 297, Height = 1471},
+            new Format() {Name = $"{GostPrefix}_A4x8", Width = 297, Height = 1682},
+            new Format() {Name = $"{GostPrefix}_A4x9", Width = 297, Height = 1892},
         };
 
         public int Width { get; set; }
         public int Height { get; set; }
         public string Name { get; set; }
 
-        public static Format GetFormat(FamilyInstance familyInstance) {
-            var pFormat = familyInstance.LookupParameter("А")?.AsValueString();
-            var pMultiplier = familyInstance.LookupParameter("х")?.AsValueString();
-            pMultiplier = pMultiplier?.Equals("1") == true ? null : pMultiplier;
-
-            var formatName = $"GOST_A{pFormat}x{pMultiplier}";
-            return _formats.FirstOrDefault(item => item.Name.Equals(formatName));
-        }
-
         public static Format GetFormat(int width, int height) {
             if(width > height) {
-                int temp = height;
-                height = width;
-                width = temp;
+                (height, width) = (width, height);
             }
 
-            return _formats.FirstOrDefault(item => IsNormalWidth(width, item) && IsNormalHeight(height, item))
-                   ?? new Format() {Name = $"Custom_{height}x{width}", Width = width, Height = height};
+            return _gostFormats.FirstOrDefault(item =>
+                       IsNormalWidth(width, item) && IsNormalHeight(height, item))
+                   ?? new Format() {Name = $"{CustomPrefix}_{height}x{width}", Width = width, Height = height};
         }
 
         private static bool IsNormalHeight(int height, Format item) {
-            return IsNormalLength(item.Width, height) || IsNormalLength(item.Height, height);
+            return IsNormalLength(item.Width, height)
+                   || IsNormalLength(item.Height, height);
         }
 
         private static bool IsNormalWidth(int width, Format item) {
-            return (IsNormalLength(item.Width, width) || IsNormalLength(item.Height, width));
+            return (IsNormalLength(item.Width, width)
+                    || IsNormalLength(item.Height, width));
         }
 
-        private static bool IsNormalLength(int leftValue, int rightValue, int tolerance = 5) {
+        private static bool IsNormalLength(int leftValue, int rightValue, int tolerance = _defaultFormatTolerance) {
             return Math.Abs(leftValue - rightValue) <= tolerance;
         }
     }

--- a/src/RevitBatchPrint/Models/RevitPrint.cs
+++ b/src/RevitBatchPrint/Models/RevitPrint.cs
@@ -69,8 +69,6 @@ namespace RevitBatchPrint.Models {
 
                 try {
                     using(Transaction transaction = _revitRepository.Document.StartTransaction("PrintSettings")) {
-                        transaction.Start();
-
                         PrintManager.PrintSetup.CurrentPrintSetting = PrintManager.PrintSetup.InSession;
 
                         PaperSize paperSize = _revitRepository.GetPaperSizeByName(printSettings.Format.Name);
@@ -88,6 +86,8 @@ namespace RevitBatchPrint.Models {
 
                         PrintManager.Apply();
                         PrintManager.SubmitPrint(viewSheet);
+
+                        transaction.RollBack();
                     }
                 } catch(Exception ex) {
                     printErrors.Add((viewSheet, ex.Message));

--- a/src/RevitBatchPrint/Models/RevitPrint.cs
+++ b/src/RevitBatchPrint/Models/RevitPrint.cs
@@ -138,7 +138,7 @@ namespace RevitBatchPrint.Models {
                 .Select(item => GetMessage(item.ViewSheet, item.ViewsWithoutCrop));
 
             if(messages.Any()) {
-                Errors.Add("Листы у которые есть виды с отключенной подрезкой:" + Environment.NewLine +
+                Errors.Add("Листы у которых есть виды с отключенной подрезкой:" + Environment.NewLine +
                            string.Join(Environment.NewLine, messages));
             }
         }

--- a/src/RevitBatchPrint/Models/RevitRepository.cs
+++ b/src/RevitBatchPrint/Models/RevitRepository.cs
@@ -78,6 +78,7 @@ namespace RevitBatchPrint.Models {
             return viewSheet.GetAllPlacedViews()
                 .Select(item => Document.GetElement(item))
                 .OfType<View>()
+                .Where(item => item.CropBox != null)
                 .Where(item => !item.CropBoxActive)
                 .ToList();
         }

--- a/src/RevitBatchPrint/Models/RevitRepository.cs
+++ b/src/RevitBatchPrint/Models/RevitRepository.cs
@@ -78,7 +78,7 @@ namespace RevitBatchPrint.Models {
             return viewSheet.GetAllPlacedViews()
                 .Select(item => Document.GetElement(item))
                 .OfType<View>()
-                .Where(item => item.CropBox != null)
+                .Where(item => item.IsExistsParam(BuiltInParameter.VIEWER_CROP_REGION))
                 .Where(item => !item.CropBoxActive)
                 .ToList();
         }


### PR DESCRIPTION
- исправил выбор формата при печати


> При разборе ошибки, стало понятно, что это из-за того что в ревите печать стала асинхронной, причиной этого что является не совсем ясно, тут может быть виноват revit, windows, pdf24. При асинхронной печати происходит отправка на печать и возврат управления в код, а код в этот момент удаляет формат листа, а pdf24 при печати потом выбирает случайный.

решение:
удаление формата происходит при запуске печати.
создаем во время печати нужный формат, а потом в конце его не удаляем. 