### PR TITLE
Полное обновление: Преобразование в выпадающий список

### DIFF
--- a/src/RevitMechanicalSpecification/Models/RevitRepository.cs
+++ b/src/RevitMechanicalSpecification/Models/RevitRepository.cs
@@ -125,7 +125,7 @@ namespace RevitMechanicalSpecification.Models {
         /// Обновление только по филлерам спецификации
         /// </summary>
         public void SpecificationRefresh() {
-            _elements = _collector.GetElementsToSpecificate();
+            _elements = _collector.GetElementsByCategories();
             _elementProcessor.ProcessElements(_fillersSpecRefresh, _elements);
         }
 
@@ -133,7 +133,7 @@ namespace RevitMechanicalSpecification.Models {
         /// Обновление только по филлерам системы
         /// </summary>
         public void RefreshSystemName() {
-            _elements = _collector.GetElementsToSpecificate();
+            _elements = _collector.GetElementsByCategories();
             _elementProcessor.ProcessElements(_fillersSystemRefresh, _elements);
         }
 
@@ -141,20 +141,32 @@ namespace RevitMechanicalSpecification.Models {
         /// Обновление только по филлерам функции
         /// </summary>
         public void RefreshSystemFunction() {
-            _elements = _collector.GetElementsToSpecificate();
+            _elements = _collector.GetElementsByCategories();
             _elementProcessor.ProcessElements(_fillersFunctionRefresh, _elements);
         }
 
         /// <summary>
         /// Здесь нужно провести полное обновление всех параметров, поэтому будут сложены все филлеры в один лист 
         /// </summary>
-        public void FullRefresh(bool visible = false, bool selected = false) {
-            _elements = _collector.GetElementsToSpecificate(visible, selected);
-            List<ElementParamFiller> fillers = new List<ElementParamFiller>();
-            fillers.AddRange(_fillersSpecRefresh);
-            fillers.AddRange(_fillersFunctionRefresh);
-            fillers.AddRange(_fillersSystemRefresh);
-            _elementProcessor.ProcessElements(fillers, _elements);
+        public void FullRefresh() {
+            _elements = _collector.GetElementsByCategories();
+            _elementProcessor.ProcessElements(FoldFillerLists(), _elements);
+        }
+
+        /// <summary>
+        /// Здесь нужно провести полное обновление видимых элементов и всех параметров, поэтому будут сложены все филлеры в один лист 
+        /// </summary>
+        public void VisibleFullRefresh() {
+            _elements = _collector.GetVisibleElementsByCategories();
+            _elementProcessor.ProcessElements(FoldFillerLists(), _elements);
+        }
+
+        /// <summary>
+        /// Здесь нужно провести полное обновление выбранных элементов и всех параметров, поэтому будут сложены все филлеры в один лист 
+        /// </summary>
+        public void SelectedFullRefresh() {
+            _elements = _collector.GetSelectedElementsByCategories();
+            _elementProcessor.ProcessElements(FoldFillerLists(), _elements);
         }
 
         /// <summary>
@@ -168,6 +180,14 @@ namespace RevitMechanicalSpecification.Models {
                 }
                 t.Commit();
             }
+        }
+
+        private List<ElementParamFiller> FoldFillerLists() {
+            List<ElementParamFiller> fillers = new List<ElementParamFiller>();
+            fillers.AddRange(_fillersSpecRefresh);
+            fillers.AddRange(_fillersFunctionRefresh);
+            fillers.AddRange(_fillersSystemRefresh);
+            return fillers;
         }
 
     }

--- a/src/RevitMechanicalSpecification/Models/RevitRepository.cs
+++ b/src/RevitMechanicalSpecification/Models/RevitRepository.cs
@@ -26,7 +26,7 @@ namespace RevitMechanicalSpecification.Models {
         private readonly List<ElementParamFiller> _fillersSystemRefresh;
         private readonly List<ElementParamFiller> _fillersFunctionRefresh;
         private readonly CollectionFactory _collector;
-        private readonly List<Element> _elements;
+        private List<Element> _elements;
         private readonly List<VisSystem> _visSystems;
         private readonly SpecConfiguration _specConfiguration;
         private readonly VisElementsCalculator _calculator;
@@ -37,11 +37,10 @@ namespace RevitMechanicalSpecification.Models {
             UIApplication = uiApplication;
             _elementProcessor = new ElementProcessor(UIApplication.Application.Username, Document);
             _specConfiguration = new SpecConfiguration(Document.ProjectInformation);
-            _collector = new CollectionFactory(Document, _specConfiguration);
+            _collector = new CollectionFactory(Document, _specConfiguration, ActiveUIDocument);
             _calculator = new VisElementsCalculator(_specConfiguration, Document);
             _maskReplacer = new MaskReplacer(_specConfiguration);
 
-            _elements = _collector.GetElementsToSpecificate();
             _visSystems = _collector.GetVisSystems();
 
             _fillersSpecRefresh = new List<ElementParamFiller>()
@@ -126,6 +125,7 @@ namespace RevitMechanicalSpecification.Models {
         /// Обновление только по филлерам спецификации
         /// </summary>
         public void SpecificationRefresh() {
+            _elements = _collector.GetElementsToSpecificate();
             _elementProcessor.ProcessElements(_fillersSpecRefresh, _elements);
         }
 
@@ -133,6 +133,7 @@ namespace RevitMechanicalSpecification.Models {
         /// Обновление только по филлерам системы
         /// </summary>
         public void RefreshSystemName() {
+            _elements = _collector.GetElementsToSpecificate();
             _elementProcessor.ProcessElements(_fillersSystemRefresh, _elements);
         }
 
@@ -140,13 +141,15 @@ namespace RevitMechanicalSpecification.Models {
         /// Обновление только по филлерам функции
         /// </summary>
         public void RefreshSystemFunction() {
+            _elements = _collector.GetElementsToSpecificate();
             _elementProcessor.ProcessElements(_fillersFunctionRefresh, _elements);
         }
 
         /// <summary>
         /// Здесь нужно провести полное обновление всех параметров, поэтому будут сложены все филлеры в один лист 
         /// </summary>
-        public void FullRefresh() {
+        public void FullRefresh(bool visible = false, bool selected = false) {
+            _elements = _collector.GetElementsToSpecificate(visible, selected);
             List<ElementParamFiller> fillers = new List<ElementParamFiller>();
             fillers.AddRange(_fillersSpecRefresh);
             fillers.AddRange(_fillersFunctionRefresh);

--- a/src/RevitMechanicalSpecification/RevitMechanicalCreateNameCmd.cs
+++ b/src/RevitMechanicalSpecification/RevitMechanicalCreateNameCmd.cs
@@ -30,7 +30,7 @@ namespace RevitMechanicalSpecification {
     [Transaction(TransactionMode.Manual)]
     public class RevitMechanicalCreateNameCmd : BasePluginCommand {
         public RevitMechanicalCreateNameCmd() {
-            PluginName = "RevitMechanicalSpecification";
+            PluginName = "Сформировать имя";
         }
 
         protected override void Execute(UIApplication uiApplication) {

--- a/src/RevitMechanicalSpecification/RevitMechanicalFullRefreshCmd.cs
+++ b/src/RevitMechanicalSpecification/RevitMechanicalFullRefreshCmd.cs
@@ -30,7 +30,7 @@ namespace RevitMechanicalSpecification {
     [Transaction(TransactionMode.Manual)]
     public class RevitMechanicalFullRefreshCmd : BasePluginCommand {
         public RevitMechanicalFullRefreshCmd() {
-            PluginName = "RevitMechanicalSpecification";
+            PluginName = "Полное обновление";
         }
 
         protected override void Execute(UIApplication uiApplication) {

--- a/src/RevitMechanicalSpecification/RevitMechanicalFunctionRefreshCmd.cs
+++ b/src/RevitMechanicalSpecification/RevitMechanicalFunctionRefreshCmd.cs
@@ -30,7 +30,7 @@ namespace RevitMechanicalSpecification {
     [Transaction(TransactionMode.Manual)]
     public class RevitMechanicalFunctionRefreshCmd : BasePluginCommand {
         public RevitMechanicalFunctionRefreshCmd() {
-            PluginName = "RevitMechanicalSpecification";
+            PluginName = "Обновление функции";
         }
 
         protected override void Execute(UIApplication uiApplication) {

--- a/src/RevitMechanicalSpecification/RevitMechanicalSelectedFullRefreshCmd.cs
+++ b/src/RevitMechanicalSpecification/RevitMechanicalSelectedFullRefreshCmd.cs
@@ -30,7 +30,7 @@ namespace RevitMechanicalSpecification {
     [Transaction(TransactionMode.Manual)]
     public class RevitMechanicalSelectedFullRefreshCmd : BasePluginCommand {
         public RevitMechanicalSelectedFullRefreshCmd() {
-            PluginName = "RevitMechanicalSpecification";
+            PluginName = "Полное обновление выбранного";
         }
 
         protected override void Execute(UIApplication uiApplication) {

--- a/src/RevitMechanicalSpecification/RevitMechanicalSelectedFullRefreshCmd.cs
+++ b/src/RevitMechanicalSpecification/RevitMechanicalSelectedFullRefreshCmd.cs
@@ -34,9 +34,7 @@ namespace RevitMechanicalSpecification {
         }
 
         protected override void Execute(UIApplication uiApplication) {
-            bool selected = true;
-            bool visible = false;
-            new RevitRepository(uiApplication).FullRefresh(visible, selected);
+            new RevitRepository(uiApplication).FullRefresh(selected: true);
         }
     }
 }

--- a/src/RevitMechanicalSpecification/RevitMechanicalSelectedFullRefreshCmd.cs
+++ b/src/RevitMechanicalSpecification/RevitMechanicalSelectedFullRefreshCmd.cs
@@ -34,7 +34,7 @@ namespace RevitMechanicalSpecification {
         }
 
         protected override void Execute(UIApplication uiApplication) {
-            new RevitRepository(uiApplication).FullRefresh(selected: true);
+            new RevitRepository(uiApplication).SelectedFullRefresh();
         }
     }
 }

--- a/src/RevitMechanicalSpecification/RevitMechanicalSelectedFullRefreshCmd.cs
+++ b/src/RevitMechanicalSpecification/RevitMechanicalSelectedFullRefreshCmd.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Interop;
+
+
+using Autodesk.Revit.ApplicationServices;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+
+using dosymep.Bim4Everyone;
+using dosymep.Bim4Everyone.SimpleServices;
+using dosymep.SimpleServices;
+using dosymep.WPF.Views;
+using dosymep.Xpf.Core.Ninject;
+
+using Ninject;
+
+using RevitMechanicalSpecification.Models;
+using RevitMechanicalSpecification.ViewModels;
+using RevitMechanicalSpecification.Views;
+
+namespace RevitMechanicalSpecification {
+    [Transaction(TransactionMode.Manual)]
+    public class RevitMechanicalSelectedFullRefreshCmd : BasePluginCommand {
+        public RevitMechanicalSelectedFullRefreshCmd() {
+            PluginName = "RevitMechanicalSpecification";
+        }
+
+        protected override void Execute(UIApplication uiApplication) {
+            bool selected = true;
+            bool visible = false;
+            new RevitRepository(uiApplication).FullRefresh(visible, selected);
+        }
+    }
+}

--- a/src/RevitMechanicalSpecification/RevitMechanicalSpecificationRefreshCmd.cs
+++ b/src/RevitMechanicalSpecification/RevitMechanicalSpecificationRefreshCmd.cs
@@ -30,7 +30,7 @@ namespace RevitMechanicalSpecification {
     [Transaction(TransactionMode.Manual)]
     public class RevitMechanicalSpecificationRefreshCmd : BasePluginCommand {
         public RevitMechanicalSpecificationRefreshCmd() {
-            PluginName = "RevitMechanicalSpecification";
+            PluginName = "Обновление спецификации";
         }
 
         protected override void Execute(UIApplication uiApplication) {

--- a/src/RevitMechanicalSpecification/RevitMechanicalSystemRefreshCmd.cs
+++ b/src/RevitMechanicalSpecification/RevitMechanicalSystemRefreshCmd.cs
@@ -30,7 +30,7 @@ namespace RevitMechanicalSpecification {
     [Transaction(TransactionMode.Manual)]
     public class RevitMechanicalSystemRefreshCmd : BasePluginCommand {
         public RevitMechanicalSystemRefreshCmd() {
-            PluginName = "RevitMechanicalSpecification";
+            PluginName = "Обновление имени системы";
         }
 
         protected override void Execute(UIApplication uiApplication) {

--- a/src/RevitMechanicalSpecification/RevitMechanicalVisibleFullRefreshCmd.cs
+++ b/src/RevitMechanicalSpecification/RevitMechanicalVisibleFullRefreshCmd.cs
@@ -34,10 +34,7 @@ namespace RevitMechanicalSpecification {
         }
 
         protected override void Execute(UIApplication uiApplication) {
-            bool selected = false;
-            bool visible = true;
-            Console.WriteLine(visible);
-            new RevitRepository(uiApplication).FullRefresh(visible, selected);
+            new RevitRepository(uiApplication).FullRefresh(visible: true);
         }
     }
 }

--- a/src/RevitMechanicalSpecification/RevitMechanicalVisibleFullRefreshCmd.cs
+++ b/src/RevitMechanicalSpecification/RevitMechanicalVisibleFullRefreshCmd.cs
@@ -30,7 +30,7 @@ namespace RevitMechanicalSpecification {
     [Transaction(TransactionMode.Manual)]
     public class RevitMechanicalVisibleFullRefreshCmd : BasePluginCommand {
         public RevitMechanicalVisibleFullRefreshCmd() {
-            PluginName = "RevitMechanicalSpecification";
+            PluginName = "Полное обновление видимого";
         }
 
         protected override void Execute(UIApplication uiApplication) {

--- a/src/RevitMechanicalSpecification/RevitMechanicalVisibleFullRefreshCmd.cs
+++ b/src/RevitMechanicalSpecification/RevitMechanicalVisibleFullRefreshCmd.cs
@@ -34,7 +34,7 @@ namespace RevitMechanicalSpecification {
         }
 
         protected override void Execute(UIApplication uiApplication) {
-            new RevitRepository(uiApplication).FullRefresh(visible: true);
+            new RevitRepository(uiApplication).VisibleFullRefresh();
         }
     }
 }

--- a/src/RevitMechanicalSpecification/RevitMechanicalVisibleFullRefreshCmd.cs
+++ b/src/RevitMechanicalSpecification/RevitMechanicalVisibleFullRefreshCmd.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Interop;
+
+
+using Autodesk.Revit.ApplicationServices;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+
+using dosymep.Bim4Everyone;
+using dosymep.Bim4Everyone.SimpleServices;
+using dosymep.SimpleServices;
+using dosymep.WPF.Views;
+using dosymep.Xpf.Core.Ninject;
+
+using Ninject;
+
+using RevitMechanicalSpecification.Models;
+using RevitMechanicalSpecification.ViewModels;
+using RevitMechanicalSpecification.Views;
+
+namespace RevitMechanicalSpecification {
+    [Transaction(TransactionMode.Manual)]
+    public class RevitMechanicalVisibleFullRefreshCmd : BasePluginCommand {
+        public RevitMechanicalVisibleFullRefreshCmd() {
+            PluginName = "RevitMechanicalSpecification";
+        }
+
+        protected override void Execute(UIApplication uiApplication) {
+            bool selected = false;
+            bool visible = true;
+            Console.WriteLine(visible);
+            new RevitRepository(uiApplication).FullRefresh(visible, selected);
+        }
+    }
+}

--- a/src/RevitMechanicalSpecification/Service/CollectionFactory.cs
+++ b/src/RevitMechanicalSpecification/Service/CollectionFactory.cs
@@ -44,23 +44,6 @@ namespace RevitMechanicalSpecification.Service {
         }
 
         /// <summary>
-        /// Получение специфицируемых элементов
-        /// </summary>
-        /// <returns></returns>
-        public List<Element> GetElementsToSpecificate(bool visible = false, bool selected = false) {
-
-            if (visible) {
-                return GetVisibleElementsByCategories();
-            }
-
-            if(selected) {
-                return GetSelectedElementsByCategories();
-            }
-
-            return GetElementsByCategories();
-        }
-
-        /// <summary>
         /// Получение списка систем труб и воздуховодов и создание из них списка VisSystem-ов
         /// </summary>
         /// <returns></returns>
@@ -83,29 +66,15 @@ namespace RevitMechanicalSpecification.Service {
 
                 SystemForsedInstanceName = element
                 .GetSharedParamValueOrDefault<string>(_specConfiguration.ForcedSystemName)
-                
+
             }));
 
             return mechanicalSystems;
         }
 
         /// <summary>
-        /// Логический фильтр на исключение текста модели
+        /// Получаем выбранные элементы по списку категорий
         /// </summary>
-        /// <param name="element"></param>
-        /// <returns></returns>
-        private bool ElementNotInGroupOrModelText(Element element) {
-
-            if(element is ModelText) {
-                return false;
-            }
-
-            if(element.GroupId.IsNull()) {
-                return true;
-            }
-            return false;
-        }
-
         public List<Element> GetSelectedElementsByCategories() {
             var filter = new ElementMulticategoryFilter(_mechanicalCategories);
 
@@ -128,6 +97,9 @@ namespace RevitMechanicalSpecification.Service {
             return filteredElements;
         }
 
+        /// <summary>
+        /// Получаем видимые элементы по списку категорий
+        /// </summary>
         public List<Element> GetVisibleElementsByCategories() {
             var filter = new ElementMulticategoryFilter(_mechanicalCategories);
             var view = _document.ActiveView;
@@ -145,7 +117,7 @@ namespace RevitMechanicalSpecification.Service {
         /// Получаем элементы по списку категорий
         /// </summary>
         public List<Element> GetElementsByCategories(List<BuiltInCategory> builtInCategories = null) {
-            if (builtInCategories == null) {
+            if(builtInCategories == null) {
                 builtInCategories = _mechanicalCategories;
             }
             var filter = new ElementMulticategoryFilter(builtInCategories);
@@ -154,6 +126,23 @@ namespace RevitMechanicalSpecification.Service {
                 .WhereElementIsNotElementType()
                 .ToElements();
             return elements.Where(e => ElementNotInGroupOrModelText(e)).ToList();
+        }
+
+        /// <summary>
+        /// Логический фильтр на исключение текста модели
+        /// </summary>
+        /// <param name="element"></param>
+        /// <returns></returns>
+        private bool ElementNotInGroupOrModelText(Element element) {
+
+            if(element is ModelText) {
+                return false;
+            }
+
+            if(element.GroupId.IsNull()) {
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/src/RevitMechanicalSpecification/Service/CollectionFactory.cs
+++ b/src/RevitMechanicalSpecification/Service/CollectionFactory.cs
@@ -107,7 +107,7 @@ namespace RevitMechanicalSpecification.Service {
 
         private List<Element> GetSelectedElementsByCategories(List<BuiltInCategory> builtInCategories) {
             var filter = new ElementMulticategoryFilter(builtInCategories);
-            var elementIds = _uidocument.Selection.GetElementIds();
+            var elementIds = _uidocument.GetSelectedElements();
 
             var selectedElements = elementIds.Select(elemId => _uidocument.Document.GetElement(elemId)).ToList();
 

--- a/src/RevitMechanicalSpecification/Service/CollectionFactory.cs
+++ b/src/RevitMechanicalSpecification/Service/CollectionFactory.cs
@@ -128,7 +128,6 @@ namespace RevitMechanicalSpecification.Service {
             return filteredElements;
         }
 
-
         private List<Element> GetVisibleElementsByCategories(List<BuiltInCategory> builtInCategories) {
             var filter = new ElementMulticategoryFilter(builtInCategories);
             var view = _document.ActiveView;
@@ -141,7 +140,6 @@ namespace RevitMechanicalSpecification.Service {
 
             return visibleElements.Where(e => ElementNotInGroupOrModelText(e)).ToList();
         }
-
 
         /// <summary>
         /// Получаем элементы по списку категорий

--- a/src/RevitMechanicalSpecification/Service/VisElementsCalculator.cs
+++ b/src/RevitMechanicalSpecification/Service/VisElementsCalculator.cs
@@ -105,7 +105,6 @@ namespace RevitMechanicalSpecification.Service {
                     return startName;
             }
 
-
             string size = element.GetParamValue<string>(BuiltInParameter.RBS_CALCULATED_SIZE);
             //Ревит пишет размеры всех коннекторов. Для всего кроме тройника и перехода нам хватит первого размера
             if(!(fitting.PartType is PartType.Transition) & !(fitting.PartType is PartType.Tee)) {

--- a/src/RevitMechanicalSpecification/Service/VisElementsCalculator.cs
+++ b/src/RevitMechanicalSpecification/Service/VisElementsCalculator.cs
@@ -107,7 +107,11 @@ namespace RevitMechanicalSpecification.Service {
 
             string size = element.GetParamValue<string>(BuiltInParameter.RBS_CALCULATED_SIZE);
             //Ревит пишет размеры всех коннекторов. Для всего кроме тройника и перехода нам хватит первого размера
-            if(!(fitting.PartType is PartType.Transition) & !(fitting.PartType is PartType.Tee)) {
+
+            bool notTransition = !(fitting.PartType is PartType.Transition);
+            bool notTee = !(fitting.PartType is PartType.Tee); 
+
+            if(notTransition && notTee) {
                 size = size.Split('-').First();
             }
             return startName + " " + size + ", с толщиной стенки " + thikness + " мм";

--- a/src/RevitMechanicalSpecification/Service/VisElementsCalculator.cs
+++ b/src/RevitMechanicalSpecification/Service/VisElementsCalculator.cs
@@ -108,7 +108,7 @@ namespace RevitMechanicalSpecification.Service {
 
             string size = element.GetParamValue<string>(BuiltInParameter.RBS_CALCULATED_SIZE);
             //Ревит пишет размеры всех коннекторов. Для всего кроме тройника и перехода нам хватит первого размера
-            if(!(fitting.PartType is PartType.Transition) || !(fitting.PartType is PartType.Tee)) {
+            if(!(fitting.PartType is PartType.Transition) & !(fitting.PartType is PartType.Tee)) {
                 size = size.Split('-').First();
             }
             return startName + " " + size + ", с толщиной стенки " + thikness + " мм";


### PR DESCRIPTION
Для работы в больших командах стало критичным взаимозанимание элементов при настройке спеки. 

Воизбежание:
Добавляем возможжность обновить полностью только выделенные элементы
Добавляем возможность обновить полностью только видимые элементы

Багфикс:
Поправил условие для деления размера фитингов воздуховодов, работало некорректно