### PR TITLE
RevitOpeningPlacement: Исправлено правописание в навигаторе АР-КР

### DIFF
--- a/src/RevitOpeningPlacement/Views/NavigatorArIncomingView.xaml
+++ b/src/RevitOpeningPlacement/Views/NavigatorArIncomingView.xaml
@@ -205,7 +205,7 @@
                         </dxg:GridControl.Columns>
                     </dxg:GridControl>
                 </dxdo:LayoutPanel>
-                <dxdo:LayoutPanel Caption="Размещенные отверстия, требующие в проверки"
+                <dxdo:LayoutPanel Caption="Размещенные отверстия, требующие проверки"
                                   Style="{StaticResource ChangingVisibility}"
                                   ShowPinButton="False"
                                   ShowCloseButton="False">

--- a/src/RevitOpeningPlacement/Views/NavigatorMepIncomingView.xaml
+++ b/src/RevitOpeningPlacement/Views/NavigatorMepIncomingView.xaml
@@ -243,7 +243,7 @@
                         </dxg:GridControl.Columns>
                     </dxg:GridControl>
                 </dxdo:LayoutPanel>
-                <dxdo:LayoutPanel Caption="Размещенные отверстия, требующие в проверки"
+                <dxdo:LayoutPanel Caption="Размещенные отверстия, требующие проверки"
                                   Style="{StaticResource ChangingVisibility}"
                                   ShowPinButton="False"
                                   ShowCloseButton="False">


### PR DESCRIPTION
# Исправлено правописание в окне Навигатора для АР и КР:

Было: 
![image](https://github.com/user-attachments/assets/bb95346f-4f0c-4452-8ae1-ca6c818c7150)

Стало:
![image](https://github.com/user-attachments/assets/73cfac7c-3bf3-45d9-9e90-3b769a9b79de)

