### PR TITLE
Вкладка спецификаций: Поэкземплярная работа групп

### DIFF
--- a/src/RevitMechanicalSpecification/Entities/VisSystem.cs
+++ b/src/RevitMechanicalSpecification/Entities/VisSystem.cs
@@ -10,6 +10,7 @@ namespace RevitMechanicalSpecification.Entities {
     public class VisSystem {
         public string SystemSystemName { get; set; }
         public string SystemForsedInstanceName { get; set; }
+        public string SystemForcedInstanceFunction { get; set; }
         public string SystemFunction { get; set; }
         public string SystemShortName { get; set; }
         public string SystemTargetName { get; set; }

--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamFunctionFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamFunctionFiller.cs
@@ -31,7 +31,7 @@ namespace RevitMechanicalSpecification.Models.Fillers {
 
         public override void SetParamValue(SpecificationElement specificationElement) {
             string calculatedFunction = GetFunction(specificationElement);
-            if(!(string.IsNullOrEmpty(calculatedFunction))) {
+            if(!(string.IsNullOrWhiteSpace(calculatedFunction))) {
                 TargetParam.Set(GetFunction(specificationElement));
                 return;
             }

--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamSystemFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamSystemFiller.cs
@@ -38,7 +38,7 @@ namespace RevitMechanicalSpecification.Models.Fillers {
         public override void SetParamValue(SpecificationElement specificationElement) {
             string calculatedSystem = GetSystemName(specificationElement);
 
-            if(!(string.IsNullOrEmpty(calculatedSystem))) {
+            if(!(string.IsNullOrWhiteSpace(calculatedSystem))) {
                 TargetParam.Set(calculatedSystem);
             } else {
                 calculatedSystem = Config.GlobalSystem;

--- a/src/RevitMechanicalSpecification/Models/RevitRepository.cs
+++ b/src/RevitMechanicalSpecification/Models/RevitRepository.cs
@@ -126,6 +126,7 @@ namespace RevitMechanicalSpecification.Models {
         /// </summary>
         public void SpecificationRefresh() {
             _elements = _collector.GetElementsByCategories();
+            ReplaceMask(_elements);
             _elementProcessor.ProcessElements(_fillersSpecRefresh, _elements);
         }
 
@@ -150,6 +151,7 @@ namespace RevitMechanicalSpecification.Models {
         /// </summary>
         public void FullRefresh() {
             _elements = _collector.GetElementsByCategories();
+            ReplaceMask(_elements);
             _elementProcessor.ProcessElements(FoldFillerLists(), _elements);
         }
 
@@ -158,6 +160,7 @@ namespace RevitMechanicalSpecification.Models {
         /// </summary>
         public void VisibleFullRefresh() {
             _elements = _collector.GetVisibleElementsByCategories();
+            ReplaceMask(_elements);
             _elementProcessor.ProcessElements(FoldFillerLists(), _elements);
         }
 
@@ -166,6 +169,7 @@ namespace RevitMechanicalSpecification.Models {
         /// </summary>
         public void SelectedFullRefresh() {
             _elements = _collector.GetSelectedElementsByCategories();
+            ReplaceMask(_elements);
             _elementProcessor.ProcessElements(FoldFillerLists(), _elements);
         }
 
@@ -173,9 +177,13 @@ namespace RevitMechanicalSpecification.Models {
         /// Вызов замены маски в шаблонизированных семействах-генериках. Отдельный мини-плагин, который должен вызываться
         /// вместе с спекой, поэтому проще его встроить сюда
         /// </summary>
-        public void ReplaceMask() {
+        public void ReplaceMask(List<Element> elements = null) {
             using(var t = Document.StartTransaction("Сформировать имя")) {
-                foreach(Element element in _elements) {
+
+                if (elements is null) { 
+                    elements = _collector.GetElementsByCategories();
+                }
+                foreach(Element element in elements) {
                     _maskReplacer.ExecuteReplacment(element);
                 }
                 t.Commit();

--- a/src/RevitMechanicalSpecification/Models/RevitRepository.cs
+++ b/src/RevitMechanicalSpecification/Models/RevitRepository.cs
@@ -36,7 +36,7 @@ namespace RevitMechanicalSpecification.Models {
         public RevitRepository(UIApplication uiApplication) {
             UIApplication = uiApplication;
             _elementProcessor = new ElementProcessor(UIApplication.Application.Username, Document);
-            _specConfiguration = new SpecConfiguration(Document.ProjectInformation);
+            _specConfiguration = new SpecConfiguration(Document);
             _collector = new CollectionFactory(Document, _specConfiguration, ActiveUIDocument);
             _calculator = new VisElementsCalculator(_specConfiguration, Document);
             _maskReplacer = new MaskReplacer(_specConfiguration);

--- a/src/RevitMechanicalSpecification/Models/SpecConfiguration.cs
+++ b/src/RevitMechanicalSpecification/Models/SpecConfiguration.cs
@@ -40,7 +40,7 @@ namespace RevitMechanicalSpecification.Models {
         public readonly string ForcedName = SharedParamsConfig.Instance.VISNameForced.Name; //"ФОП_ВИС_Наименование принудительное";
         public readonly string ForcedSystemName = SharedParamsConfig.Instance.VISSystemNameForced.Name; //"ФОП_ВИС_Имя системы принудительное";
         public readonly string ForcedGroup = SharedParamsConfig.Instance.VISGroupingForced.Name; //"ФОП_ВИС_Группирование принудительное";
-        public readonly string ForcedFunction = SharedParamsConfig.Instance.VISEconomicFunction.Name;//"ФОП_ВИС_Экономическая функция" - замена принудительной функции;
+        public readonly string ForcedFunction = SharedParamsConfig.Instance.VISHvacSystemForcedFunction.Name;//"ФОП_ВИС_Экономическая функция" - замена принудительной функции;
 
         
         public readonly string SystemEF = SharedParamsConfig.Instance.VISHvacSystemFunction.Name;//"ФОП_ВИС_ЭФ для системы"
@@ -81,7 +81,14 @@ namespace RevitMechanicalSpecification.Models {
         public readonly string MaskMarkName = "ФОП_ВИС_Маска марки";
         public readonly string MaskNameName = "ФОП_ВИС_Маска наименования";
 
-        public SpecConfiguration(ProjectInfo info) {
+        public SpecConfiguration(Document document) {
+            ProjectInfo info = document.ProjectInformation;
+
+            // Временная проверка пока ФОП_ВИС_Число не ушло из оборота
+            if(document.IsExistsParam(SharedParamsConfig.Instance.VISSpecNumbersCurrency.Name)) {
+                TargetNameNumber = SharedParamsConfig.Instance.VISSpecNumbersCurrency.Name; //"ФОП_ВИС_Число ДЕ";
+            }
+
             GlobalSystem = info.GetParamValueOrDefault(_outSystemNameParam, "!Нет системы");
             OriginalParamNameName = info.GetParamValueOrDefault(_changedNameName, "ADSK_Наименование");
             OriginalParamNameMark = info.GetParamValueOrDefault(_changedNameMark, "ADSK_Марка");

--- a/src/RevitMechanicalSpecification/Models/SpecConfiguration.cs
+++ b/src/RevitMechanicalSpecification/Models/SpecConfiguration.cs
@@ -85,7 +85,7 @@ namespace RevitMechanicalSpecification.Models {
             ProjectInfo info = document.ProjectInformation;
 
             // Временная проверка пока ФОП_ВИС_Число не ушло из оборота
-            if(document.IsExistsParam(SharedParamsConfig.Instance.VISSpecNumbersCurrency.Name)) {
+            if(document.IsExistsParam(SharedParamsConfig.Instance.VISSpecNumbersCurrency)) {
                 TargetNameNumber = SharedParamsConfig.Instance.VISSpecNumbersCurrency.Name; //"ФОП_ВИС_Число ДЕ";
             }
 

--- a/src/RevitMechanicalSpecification/Service/CollectionFactory.cs
+++ b/src/RevitMechanicalSpecification/Service/CollectionFactory.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 using RevitMechanicalSpecification.Entities;
 using RevitMechanicalSpecification.Models;
 using Autodesk.Revit.UI;
+using dosymep.Bim4Everyone.SharedParams;
 
 namespace RevitMechanicalSpecification.Service {
 
@@ -139,10 +140,15 @@ namespace RevitMechanicalSpecification.Service {
                 return false;
             }
 
-            if(element.GroupId.IsNull()) {
-                return true;
+            // временное дополнение. Если в проекте есть ФОП_ВИС_Число ДЕ - группы должны обрабатываться.
+            if(!_document.IsExistsParam(SharedParamsConfig.Instance.VISSpecNumbersCurrency.Name)) {
+                if(element.GroupId.IsNull()) {
+                    return true;
+                }
+                return false;
             }
-            return false;
+
+            return true;
         }
     }
 }

--- a/src/RevitMechanicalSpecification/Service/CollectionFactory.cs
+++ b/src/RevitMechanicalSpecification/Service/CollectionFactory.cs
@@ -66,7 +66,9 @@ namespace RevitMechanicalSpecification.Service {
                 SystemTargetName = element.Name.Split(' ').First(),
 
                 SystemForsedInstanceName = element
-                .GetSharedParamValueOrDefault<string>(_specConfiguration.ForcedSystemName)
+                .GetSharedParamValueOrDefault<string>(_specConfiguration.ForcedSystemName),
+                SystemForcedInstanceFunction = element
+                .GetSharedParamValueOrDefault<string>(_specConfiguration.ForcedFunction)
 
             }));
 

--- a/src/RevitMechanicalSpecification/Service/CollectionFactory.cs
+++ b/src/RevitMechanicalSpecification/Service/CollectionFactory.cs
@@ -11,6 +11,8 @@ using RevitMechanicalSpecification.Entities;
 using RevitMechanicalSpecification.Models;
 using Autodesk.Revit.UI;
 using dosymep.Bim4Everyone.SharedParams;
+using dosymep.Bim4Everyone;
+
 
 namespace RevitMechanicalSpecification.Service {
 
@@ -69,7 +71,6 @@ namespace RevitMechanicalSpecification.Service {
                 .GetSharedParamValueOrDefault<string>(_specConfiguration.ForcedSystemName),
                 SystemForcedInstanceFunction = element
                 .GetSharedParamValueOrDefault<string>(_specConfiguration.ForcedFunction)
-
             }));
 
             return mechanicalSystems;
@@ -143,7 +144,7 @@ namespace RevitMechanicalSpecification.Service {
             }
 
             // временное дополнение. Если в проекте есть ФОП_ВИС_Число ДЕ - группы должны обрабатываться.
-            if(!_document.IsExistsParam(SharedParamsConfig.Instance.VISSpecNumbersCurrency.Name)) {
+            if(!_document.IsExistsParam(SharedParamsConfig.Instance.VISSpecNumbersCurrency)) {
                 if(element.GroupId.IsNull()) {
                     return true;
                 }

--- a/src/RevitMechanicalSpecification/Service/ElementProcessor.cs
+++ b/src/RevitMechanicalSpecification/Service/ElementProcessor.cs
@@ -54,9 +54,6 @@ namespace RevitMechanicalSpecification.Service {
                 foreach(SpecificationElement specificationElement in splitResult.SingleElements) {
                     ProcessElement(specificationElement, fillers);
 
-                    // На арматуре воздуховодов/труб/оборудовании проверяем наличие шаблонизированных семейств-генериков.
-                    // Если встречаем - заполняем все по маске
-                    FillIfGeneric(specificationElement.Element);
                 }
 
                 foreach(SpecificationElement manifoldElement in splitResult.ManifoldElements) {

--- a/src/RevitMechanicalSpecification/Service/ElementProcessor.cs
+++ b/src/RevitMechanicalSpecification/Service/ElementProcessor.cs
@@ -36,7 +36,7 @@ namespace RevitMechanicalSpecification.Service {
             _userName = userName;
             _document = document;
 
-            _specConfiguration = new SpecConfiguration(_document.ProjectInformation);
+            _specConfiguration = new SpecConfiguration(_document);
             _paramChecker = new ParamChecker();
             _maskReplacer = new MaskReplacer(_specConfiguration);
         }

--- a/src/RevitMechanicalSpecification/Service/MaskReplacer.cs
+++ b/src/RevitMechanicalSpecification/Service/MaskReplacer.cs
@@ -56,7 +56,7 @@ namespace RevitMechanicalSpecification.Service {
             Element elemType = element.GetElementType();
 
             if(!elemType.IsExistsParam(maskName)) {
-                return null;
+                return string.Empty;
             }
 
             string mask = elemType.GetSharedParamValueOrDefault<string>(maskName, "ЗАПОЛНИТЕ МАСКУ");

--- a/src/RevitMechanicalSpecification/Service/MaskReplacer.cs
+++ b/src/RevitMechanicalSpecification/Service/MaskReplacer.cs
@@ -54,12 +54,12 @@ namespace RevitMechanicalSpecification.Service {
         /// <returns></returns>
         public string ReplaceMask(Element element, string maskName, string toParamName) {
             Element elemType = element.GetElementType();
-            string mask = element.GetTypeOrInstanceParamStringValue(elemType, maskName);
 
-            // Если мы не нашли маску или у нее нет значение, дальнейшие обработки не имеют смысла
-            if(mask == null) {
+            if(!elemType.IsExistsParam(maskName)) {
                 return null;
             }
+
+            string mask = elemType.GetSharedParamValueOrDefault<string>(maskName, "ЗАПОЛНИТЕ МАСКУ");
 
             string width = GetStringValue(element, elemType, _adskWidth);
             string height = GetStringValue(element, elemType, _adskHeight);

--- a/src/RevitMechanicalSpecification/Service/ParamChecker.cs
+++ b/src/RevitMechanicalSpecification/Service/ParamChecker.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Controls;
 
 using Autodesk.Revit.DB;
@@ -11,6 +12,7 @@ using dosymep.Bim4Everyone;
 using dosymep.Bim4Everyone.SharedParams;
 using dosymep.Bim4Everyone.Templates;
 using dosymep.Revit;
+using dosymep.SimpleServices;
 
 using RevitMechanicalSpecification.Models;
 
@@ -21,6 +23,9 @@ namespace RevitMechanicalSpecification.Service {
             SharedParamsConfig.Instance.VISSystemShortName,
             SharedParamsConfig.Instance.VISOutSystemName,
 
+            SharedParamsConfig.Instance.VISNote,
+            SharedParamsConfig.Instance.VISMass,
+            SharedParamsConfig.Instance.VISPosition,
             SharedParamsConfig.Instance.VISGrouping,
             SharedParamsConfig.Instance.EconomicFunction,
             SharedParamsConfig.Instance.VISSystemName,
@@ -29,12 +34,12 @@ namespace RevitMechanicalSpecification.Service {
             SharedParamsConfig.Instance.VISItemCode,
             SharedParamsConfig.Instance.VISUnit,
             SharedParamsConfig.Instance.VISManufacturer,
-            SharedParamsConfig.Instance.VISSpecNumbers,
+
             SharedParamsConfig.Instance.VISNameAddition,
             SharedParamsConfig.Instance.VISNameForced,
             SharedParamsConfig.Instance.VISSystemNameForced,
             SharedParamsConfig.Instance.VISGroupingForced,
-            SharedParamsConfig.Instance.VISEconomicFunction,
+            SharedParamsConfig.Instance.VISHvacSystemForcedFunction,
 
             SharedParamsConfig.Instance.VISMinDuctThickness,
             SharedParamsConfig.Instance.VISMaxDuctThickness,
@@ -43,7 +48,7 @@ namespace RevitMechanicalSpecification.Service {
             SharedParamsConfig.Instance.VISParamReplacementItemCode,
             SharedParamsConfig.Instance.VISParamReplacementUnit,
             SharedParamsConfig.Instance.VISParamReplacementManufacturer,
-            
+
             SharedParamsConfig.Instance.VISConsiderPipeFittings,
             SharedParamsConfig.Instance.VISConsiderPipeFittingsByType,
             SharedParamsConfig.Instance.VISConsiderDuctFittings,
@@ -66,7 +71,7 @@ namespace RevitMechanicalSpecification.Service {
             double value = _document.ProjectInformation.GetSharedParamValueOrDefault<double>(paraName, 0);
             if(value == 0) {
                 _document.ProjectInformation.GetSharedParam(paraName).Set(defValue);
-            } 
+            }
         }
 
         /// <summary>
@@ -83,6 +88,23 @@ namespace RevitMechanicalSpecification.Service {
             }
         }
 
+        // Временная проверка пока мы не переходим на редактируемые экземпляры групп. Если ФОП_ВИС_Число и ФОП_ВИС_Число ДЕ в проекте вместе - отменяем работу 
+        private void CheckNumberDuplicate(Document document) {
+            if(document.IsExistsParam(SharedParamsConfig.Instance.VISSpecNumbers) &&
+                (document.IsExistsParam(SharedParamsConfig.Instance.VISSpecNumbersCurrency))) {
+
+                MessageBox.Show(
+                    "Работа невозможна при одновременном наличии в проекте параметров ФОП_ВИС_Число и ФОП_ВИС_Число ДЕ");
+                throw new OperationCanceledException();
+            }
+
+            if(!document.IsExistsParam(SharedParamsConfig.Instance.VISSpecNumbersCurrency)) {
+                _revitParams.Add(SharedParamsConfig.Instance.VISSpecNumbers);
+            } else {
+                _revitParams.Add(SharedParamsConfig.Instance.VISSpecNumbersCurrency);
+            }
+        }
+
         /// <summary>
         /// Создать недостающие параметры, устранить расхождения по галочкам
         /// </summary>
@@ -90,6 +112,8 @@ namespace RevitMechanicalSpecification.Service {
         public void ExecuteParamCheck(Document document, SpecConfiguration specConfiguration) {
             _document = document;
             _specConfiguration = specConfiguration;
+
+            CheckNumberDuplicate(document);
             ProjectParameters projectParameters = ProjectParameters.Create(document.Application);
             projectParameters.SetupRevitParams(document, _revitParams);
 

--- a/src/RevitMechanicalSpecification/Service/ParamChecker.cs
+++ b/src/RevitMechanicalSpecification/Service/ParamChecker.cs
@@ -18,6 +18,50 @@ using RevitMechanicalSpecification.Models;
 
 namespace RevitMechanicalSpecification.Service {
     internal class ParamChecker {
+        private readonly List<RevitParam> _paramsToDataGroup = new List<RevitParam>() {
+            SharedParamsConfig.Instance.VISHvacSystemFunction,
+            SharedParamsConfig.Instance.VISSystemShortName,
+            SharedParamsConfig.Instance.VISOutSystemName,
+
+            SharedParamsConfig.Instance.VISNote,
+            SharedParamsConfig.Instance.VISMass,
+            SharedParamsConfig.Instance.VISPosition,
+            SharedParamsConfig.Instance.VISGrouping,
+            SharedParamsConfig.Instance.EconomicFunction,
+            SharedParamsConfig.Instance.VISSystemName,
+            SharedParamsConfig.Instance.VISCombinedName,
+            SharedParamsConfig.Instance.VISMarkNumber,
+            SharedParamsConfig.Instance.VISItemCode,
+            SharedParamsConfig.Instance.VISUnit,
+            SharedParamsConfig.Instance.VISManufacturer,
+
+            SharedParamsConfig.Instance.VISMinDuctThickness,
+            SharedParamsConfig.Instance.VISMaxDuctThickness,
+            SharedParamsConfig.Instance.VISParamReplacementName,
+            SharedParamsConfig.Instance.VISParamReplacementMarkNumber,
+            SharedParamsConfig.Instance.VISParamReplacementItemCode,
+            SharedParamsConfig.Instance.VISParamReplacementUnit,
+            SharedParamsConfig.Instance.VISParamReplacementManufacturer,
+
+            SharedParamsConfig.Instance.VISConsiderPipeFittings,
+            SharedParamsConfig.Instance.VISConsiderPipeFittingsByType,
+            SharedParamsConfig.Instance.VISConsiderDuctFittings,
+            SharedParamsConfig.Instance.VISPipeInsulationReserve,
+            SharedParamsConfig.Instance.VISDuctInsulationReserve,
+            SharedParamsConfig.Instance.VISPipeDuctReserve,
+            SharedParamsConfig.Instance.VISIndividualStock,
+            SharedParamsConfig.Instance.VISJunction,
+            SharedParamsConfig.Instance.VISExcludeFromJunction,
+            SharedParamsConfig.Instance.VISSpecNumbersCurrency,
+            SharedParamsConfig.Instance.VISSpecNumbers
+        };
+        private readonly List<RevitParam> _paramsToConstraints = new List<RevitParam>() {
+            SharedParamsConfig.Instance.VISNameAddition,
+            SharedParamsConfig.Instance.VISNameForced,
+            SharedParamsConfig.Instance.VISSystemNameForced,
+            SharedParamsConfig.Instance.VISGroupingForced,
+            SharedParamsConfig.Instance.VISHvacSystemForcedFunction,
+        };
         private readonly List<RevitParam> _revitParams = new List<RevitParam>() {
             SharedParamsConfig.Instance.VISHvacSystemFunction,
             SharedParamsConfig.Instance.VISSystemShortName,
@@ -88,6 +132,18 @@ namespace RevitMechanicalSpecification.Service {
             }
         }
 
+        // Если параметр существует - назначает его в указанную группу. Работы с шаблоном недостаточно, параметры в итоге оказываются в произвольных группах
+        private void SortParameterToGroup(Document document, string paraname, ForgeTypeId group) {
+            SharedParameterElement param = document.GetSharedParam(paraname);
+            if(param is null) {
+                return;
+            }
+            InternalDefinition definition = param.GetDefinition();
+            if(definition.GetGroupTypeId() != group) {
+                definition.SetGroupTypeId(group);
+            }
+        }
+
         // Временная проверка пока мы не переходим на редактируемые экземпляры групп. Если ФОП_ВИС_Число и ФОП_ВИС_Число ДЕ в проекте вместе - отменяем работу 
         private void CheckNumberDuplicate(Document document) {
             if(document.IsExistsParam(SharedParamsConfig.Instance.VISSpecNumbers) &&
@@ -116,6 +172,14 @@ namespace RevitMechanicalSpecification.Service {
             CheckNumberDuplicate(document);
             ProjectParameters projectParameters = ProjectParameters.Create(document.Application);
             projectParameters.SetupRevitParams(document, _revitParams);
+
+            foreach(RevitParam revitParam in _paramsToDataGroup) {
+                SortParameterToGroup(document, revitParam.Name, GroupTypeId.Data);
+            }
+
+            foreach(RevitParam revitParam in _paramsToConstraints) {
+                SortParameterToGroup(document, revitParam.Name, GroupTypeId.Constraints);
+            }
 
             CheckParamterValues();
         }

--- a/src/RevitMechanicalSpecification/Service/SystemFunctionNameFactory.cs
+++ b/src/RevitMechanicalSpecification/Service/SystemFunctionNameFactory.cs
@@ -69,7 +69,7 @@ namespace RevitMechanicalSpecification.Service {
             VisSystem visSystem = GetVisSystem(element);
 
             if(visSystem == null) {
-                return null;
+                return string.Empty;
             }
 
             if(!string.IsNullOrEmpty(visSystem.SystemForcedInstanceFunction)) {
@@ -77,7 +77,7 @@ namespace RevitMechanicalSpecification.Service {
             }
 
             if(string.IsNullOrEmpty(visSystem.SystemFunction)) {
-                return null;
+                return string.Empty;
             }
 
             return visSystem.SystemFunction;
@@ -95,7 +95,7 @@ namespace RevitMechanicalSpecification.Service {
 
             VisSystem visSystem = GetVisSystem(element);
             if(visSystem is null) {
-                return null;
+                return string.Empty;
             }
 
             if(!string.IsNullOrEmpty(visSystem.SystemForsedInstanceName)) {

--- a/src/RevitMechanicalSpecification/Service/SystemFunctionNameFactory.cs
+++ b/src/RevitMechanicalSpecification/Service/SystemFunctionNameFactory.cs
@@ -67,7 +67,16 @@ namespace RevitMechanicalSpecification.Service {
             }
 
             VisSystem visSystem = GetVisSystem(element);
-            if(visSystem == null || string.IsNullOrEmpty(visSystem.SystemFunction)) {
+
+            if(visSystem == null) {
+                return null;
+            }
+
+            if(!string.IsNullOrEmpty(visSystem.SystemForcedInstanceFunction)) {
+                return visSystem.SystemForcedInstanceFunction;
+            }
+
+            if(string.IsNullOrEmpty(visSystem.SystemFunction)) {
                 return null;
             }
 


### PR DESCRIPTION
В качестве теста добавляем обработку параметра денежной единицы вместо числового. 

Правка бага: из-за некорректного вызова обновления маски элементы обрабатывались со второго раза. Теперь вызываем перед основным процессом заполнения спецификации, передавая список элементов, характерный для конкретной команды. Позволяет во время обработки спецификации выдерживать единую логику и работать с полностью заполненными элементами

Правка бага: если разместить генерик-семейство с маской, а потом маску вычистить - связанный параметр не вычищался

Замена параметра: устаревший параметр ФОП_ВИС_Экономическая функция приведен к стандартному имени (ФОП_ВИС_ЭФ принудительная) и повторяет логику работы ФОП_ВИС_Имя системы принудительная