### PR TITLE
RevitOpeningPlacement: Скорректирована точка вставки объединенных отверстий в перекрытиях

### DIFF
--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/PointFinders/FloorOpeningsGroupPointFinder.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/PointFinders/FloorOpeningsGroupPointFinder.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 
 using Autodesk.Revit.DB;
 
@@ -18,11 +18,15 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PointFinders {
         }
 
         public XYZ GetPoint() {
-            var bb = _group.Elements.Select(item => item.GetSolid().GetTransformedBoundingBox())
+            // получаем трансформацию от начала проекта первого задания
+            var transform = _group.Elements.First().GetFamilyInstance().GetTotalTransform();
+            // находим бокс, ограничивающий все задания из группы в координатах относительно первого задания
+            var bb = _group.Elements.Select(item => SolidUtils.CreateTransformed(item.GetSolid(), transform.Inverse).GetTransformedBoundingBox())
                 .ToList()
                 .CreateUnitedBoundingBox();
             var center = bb.Min + (bb.Max - bb.Min) / 2;
-            return new XYZ(center.X, center.Y, bb.Max.Z);
+            // возвращаем центр верхней грани бокса, но трансформированный в изначальное положение заданий в проекте
+            return transform.OfPoint(new XYZ(center.X, center.Y, bb.Max.Z));
         }
     }
 }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/PointFinders/FloorOpeningsGroupPointFinder.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/PointFinders/FloorOpeningsGroupPointFinder.cs
@@ -21,7 +21,10 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PointFinders {
             // получаем трансформацию от начала проекта первого задания
             var transform = _group.Elements.First().GetFamilyInstance().GetTotalTransform();
             // находим бокс, ограничивающий все задания из группы в координатах относительно первого задания
-            var bb = _group.Elements.Select(item => SolidUtils.CreateTransformed(item.GetSolid(), transform.Inverse).GetTransformedBoundingBox())
+            var bb = _group.Elements
+                .Select(item => SolidUtils
+                    .CreateTransformed(item.GetSolid(), transform.Inverse)
+                    .GetTransformedBoundingBox())
                 .ToList()
                 .CreateUnitedBoundingBox();
             var center = bb.Min + (bb.Max - bb.Min) / 2;


### PR DESCRIPTION
## Скорректирована точка вставки объединенных отверстий в перекрытиях

Было:

![image](https://github.com/user-attachments/assets/eb6b895f-0a0d-40d7-aa9f-26f4fe1a49db)

Стало:

![image](https://github.com/user-attachments/assets/86587faa-233c-4287-928a-f91fbaa273f9)
