### PR TITLE
RevitScheduleImport: Исправлена высота текста

### DIFF
--- a/src/RevitScheduleImport/Services/LengthConverter.cs
+++ b/src/RevitScheduleImport/Services/LengthConverter.cs
@@ -15,6 +15,14 @@ namespace RevitScheduleImport.Services {
         private const double _excelHeightToMm = 0.344086;
         private readonly double _footInMm;
 
+        /// <summary>
+        /// Коэффициент, на который надо умножить количество пунктов высоты текста из Excel,<br/>
+        /// чтобы получить количество пунктов в Revit,<br/>
+        /// чтобы по итогу значение высоты текста в мм было одинаковым.<br/>
+        /// Получен эмпирическим путем из размеров текста при печати из Excel и Revit.
+        /// </summary>
+        private const double _excelPtToRvtPt = 0.842519685;
+
         public LengthConverter() {
             _footInMm = ConvertFromInternal(1);
         }
@@ -58,6 +66,15 @@ namespace RevitScheduleImport.Services {
             // https://github.com/ClosedXML/ClosedXML/wiki/Cell-Dimensions#height
             // поэтому берем коэффициент перевода, полученный из размеров ячеек при печати листа Excel
             return excelRowHeight * _excelHeightToMm / _footInMm;
+        }
+
+        /// <summary>
+        /// Конвертирует высоту текста в пунктах Excel в высоту текста в единицах Revit
+        /// </summary>
+        /// <param name="excelFontSize">Высота текста в пунктах в Excel</param>
+        /// <returns>Высота текста в единицах Revit</returns>
+        public double ConvertExcelFontSizeToInternal(double excelFontSize) {
+            return excelFontSize * _excelPtToRvtPt;
         }
     }
 }

--- a/src/RevitScheduleImport/Services/ScheduleImporter.cs
+++ b/src/RevitScheduleImport/Services/ScheduleImporter.cs
@@ -138,6 +138,7 @@ namespace RevitScheduleImport.Services {
             if(tableSectionData.NeedsRefresh) {
                 tableSectionData.RefreshData();
             }
+            _revitRepository.Document.Regenerate(); // если не вызвать, размер шрифта на листе может не обновиться
         }
 
         private TableSectionData FillTable(TableSectionData tableSectionData, IXLWorksheet worksheet) {
@@ -166,7 +167,7 @@ namespace RevitScheduleImport.Services {
                 BorderBottomLineStyle = ElementId.InvalidElementId,
                 BorderLeftLineStyle = ElementId.InvalidElementId,
                 BorderRightLineStyle = ElementId.InvalidElementId,
-                TextSize = cell.Style.Font.FontSize,
+                TextSize = _lengthConverter.ConvertExcelFontSizeToInternal(cell.Style.Font.FontSize),
                 IsFontItalic = cell.Style.Font.Italic,
                 IsFontBold = cell.Style.Font.Bold,
                 IsFontUnderline = cell.Style.Font.Underline != XLFontUnderlineValues.None,

--- a/src/RevitScheduleImport/Views/MainWindow.xaml
+++ b/src/RevitScheduleImport/Views/MainWindow.xaml
@@ -71,6 +71,7 @@
                 Margin="10"
                 Content="{DynamicResource MainWindow.ButtonOk}"
                 Click="ButtonOk_Click"
+                IsDefault="True"
                 Command="{Binding AcceptViewCommand}" />
 
             <Button


### PR DESCRIPTION
## Обновления

- Теперь высота текста в Revit и в Excel на печати имеет одинаковую высоту
- Исправлен баг с необновлямой высотой текста на спеках, расположенных на листах. Надо вызывать `Document.Regenerate`
- Кнопка "ОК" в GUI автоматом нажимается на Enter