### PR TITLE
RevitOpeningPlacement: Исправление ошибки с определением статуса "Ошибка геометрии"

### DIFF
--- a/src/RevitOpeningPlacement/Services/MepTaskOutcomingInfoUpdater.cs
+++ b/src/RevitOpeningPlacement/Services/MepTaskOutcomingInfoUpdater.cs
@@ -655,6 +655,9 @@ namespace RevitOpeningPlacement.Services {
             var thisBBoxInLinkCoordinates = mepTaskOutcoming.GetTransformedBBoxXYZ()
                 .TransformBoundingBox(link.DocumentTransform.Inverse);
             var openings = link.GetOpeningsReal();
+            if(openings.Count == 0) {
+                return Array.Empty<IOpeningReal>();
+            }
             var candidates = new FilteredElementCollector(link.Document, openings.Select(o => o.Id).ToArray())
                 .WherePasses(new BoundingBoxIntersectsFilter(thisSolidInLinkCoordinates.GetOutline()))
                 .ToElementIds();


### PR DESCRIPTION
Исправлено ложное назначение статуса "Ошибка геометрии", когда возникало исключение в результате фильтрации по пустой коллекции.