### PR TITLE
RevitOpeningPlacement: Добавлена возможность редактировать настройки ВИС из заданного файла

### DIFF
--- a/src/RevitOpeningPlacement/Models/Configs/MepConfigPath.cs
+++ b/src/RevitOpeningPlacement/Models/Configs/MepConfigPath.cs
@@ -1,0 +1,39 @@
+using System;
+
+using Autodesk.Revit.DB;
+
+using dosymep.Bim4Everyone;
+using dosymep.Bim4Everyone.ProjectConfigs;
+
+using pyRevitLabs.Json;
+
+using RevitClashDetective.Models.FilterModel;
+
+namespace RevitOpeningPlacement.Models.Configs {
+    /// <summary>
+    /// Класс для хранения пути к файлу настроек расстановки заданий на отверстия от вИС
+    /// </summary>
+    internal class MepConfigPath : ProjectConfig {
+        public string RevitVersion { get; set; }
+        [JsonIgnore]
+        public override string ProjectConfigPath { get; set; }
+        [JsonIgnore]
+        public override IConfigSerializer Serializer { get; set; }
+
+        /// <summary>
+        /// Путь к файлу настроек расстановки заданий на отверстия от ВИС
+        /// </summary>
+        public string OpeningConfigPath { get; set; }
+
+        public static MepConfigPath GetMepConfigPath(Document document) {
+            if(document is null) { throw new ArgumentNullException(nameof(document)); }
+
+            return new ProjectConfigBuilder()
+                .SetSerializer(new RevitClashConfigSerializer(new OpeningSerializationBinder(), document))
+                .SetPluginName(nameof(RevitOpeningPlacement))
+                .SetRevitVersion(ModuleEnvironment.RevitVersion)
+                .SetProjectConfigName(nameof(MepConfigPath) + ".json")
+                .Build<MepConfigPath>();
+        }
+    }
+}

--- a/src/RevitOpeningPlacement/Models/Configs/OpeningConfig.cs
+++ b/src/RevitOpeningPlacement/Models/Configs/OpeningConfig.cs
@@ -55,7 +55,7 @@ namespace RevitOpeningPlacement.Models.Configs {
         private static ProjectConfigBuilder GetOverriddenBuilder(Document document) {
             var builder = GetDefaultBuilder(document);
             var configPath = MepConfigPath.GetMepConfigPath(document).OpeningConfigPath;
-            if(string.IsNullOrWhiteSpace(configPath) && File.Exists(configPath)) {
+            if(!string.IsNullOrWhiteSpace(configPath) && File.Exists(configPath)) {
                 builder.SetProjectConfigPath(configPath);
             }
             return builder;

--- a/src/RevitOpeningPlacement/Models/Configs/OpeningConfig.cs
+++ b/src/RevitOpeningPlacement/Models/Configs/OpeningConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 
 using Autodesk.Revit.DB;
 
@@ -34,12 +35,14 @@ namespace RevitOpeningPlacement.Models.Configs {
         public static OpeningConfig GetOpeningConfig(Document document) {
             if(document is null) { throw new ArgumentNullException(nameof(document)); }
 
-            var config = new ProjectConfigBuilder()
-                .SetSerializer(new RevitClashConfigSerializer(new OpeningSerializationBinder(), document))
-                .SetPluginName(nameof(RevitOpeningPlacement))
-                .SetRevitVersion(ModuleEnvironment.RevitVersion)
-                .SetProjectConfigName(nameof(OpeningConfig) + ".json")
-                .Build<OpeningConfig>();
+            OpeningConfig config;
+            try {
+                config = GetOverriddenBuilder(document)
+                    .Build<OpeningConfig>();
+            } catch(JsonException) {
+                config = GetDefaultBuilder(document)
+                    .Build<OpeningConfig>();
+            }
             MepCategoryCollection defaultCollection = new MepCategoryCollection();
             if(config.Categories.Count == defaultCollection.Categories.Count) {
                 return config;
@@ -47,6 +50,23 @@ namespace RevitOpeningPlacement.Models.Configs {
                 config.Categories = defaultCollection;
                 return config;
             }
+        }
+
+        private static ProjectConfigBuilder GetOverriddenBuilder(Document document) {
+            var builder = GetDefaultBuilder(document);
+            var configPath = MepConfigPath.GetMepConfigPath(document).OpeningConfigPath;
+            if(string.IsNullOrWhiteSpace(configPath) && File.Exists(configPath)) {
+                builder.SetProjectConfigPath(configPath);
+            }
+            return builder;
+        }
+
+        private static ProjectConfigBuilder GetDefaultBuilder(Document document) {
+            return new ProjectConfigBuilder()
+                 .SetSerializer(new RevitClashConfigSerializer(new OpeningSerializationBinder(), document))
+                 .SetPluginName(nameof(RevitOpeningPlacement))
+                 .SetRevitVersion(ModuleEnvironment.RevitVersion)
+                 .SetProjectConfigName(nameof(OpeningConfig) + ".json");
         }
     }
 }

--- a/src/RevitOpeningPlacement/Services/ConfigFileService.cs
+++ b/src/RevitOpeningPlacement/Services/ConfigFileService.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace RevitOpeningPlacement.Services {
+    internal class ConfigFileService {
+        private const string _explorer = "explorer.exe";
+        private const string _selectMask = "/select,\"{0}\"";
+        public ConfigFileService() { }
+
+        /// <summary>
+        /// Открывает проводник в заданной папке.
+        /// </summary>
+        /// <param name="folderPath">Папка, в которой надо открыть проводник.</param>
+        /// <param name="selectFilePath">Файл, который надо выбрать в проводнике.</param>
+        /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр Null.</exception>
+        /// <exception cref="ArgumentException">Исключение, если передан невалидный параметр.</exception>
+        /// <exception cref="DirectoryNotFoundException">Исключение, если заданная папка не существует.</exception>
+        public void OpenFolder(string folderPath, string selectFilePath = null) {
+            if(folderPath is null) {
+                throw new ArgumentNullException(nameof(folderPath));
+            }
+            if(string.IsNullOrWhiteSpace(folderPath)) {
+                throw new ArgumentException(nameof(folderPath));
+            }
+            if(!Directory.Exists(folderPath)) {
+                throw new DirectoryNotFoundException(nameof(folderPath));
+            }
+
+            if(!string.IsNullOrWhiteSpace(selectFilePath) && File.Exists(selectFilePath)) {
+                Process.Start("explorer.exe", string.Format(_selectMask, Path.GetFullPath(selectFilePath)));
+            } else {
+                Process.Start(Path.GetFullPath(folderPath));
+            }
+        }
+    }
+}

--- a/src/RevitOpeningPlacement/Services/ConfigFileService.cs
+++ b/src/RevitOpeningPlacement/Services/ConfigFileService.cs
@@ -28,7 +28,7 @@ namespace RevitOpeningPlacement.Services {
             }
 
             if(!string.IsNullOrWhiteSpace(selectFilePath) && File.Exists(selectFilePath)) {
-                Process.Start("explorer.exe", string.Format(_selectMask, Path.GetFullPath(selectFilePath)));
+                Process.Start(_explorer, string.Format(_selectMask, Path.GetFullPath(selectFilePath)));
             } else {
                 Process.Start(Path.GetFullPath(folderPath));
             }

--- a/src/RevitOpeningPlacement/SetOpeningTasksPlacementConfigCmd.cs
+++ b/src/RevitOpeningPlacement/SetOpeningTasksPlacementConfigCmd.cs
@@ -15,6 +15,7 @@ using RevitClashDetective.Models.Handlers;
 
 using RevitOpeningPlacement.Models;
 using RevitOpeningPlacement.Models.Configs;
+using RevitOpeningPlacement.Services;
 using RevitOpeningPlacement.ViewModels.OpeningConfig;
 using RevitOpeningPlacement.Views;
 
@@ -64,6 +65,9 @@ namespace RevitOpeningPlacement {
                     .ToMethod(c =>
                         OpeningConfig.GetOpeningConfig(uiApplication.ActiveUIDocument.Document)
                     );
+                kernel.Bind<ConfigFileService>()
+                    .ToSelf()
+                    .InSingletonScope();
 
                 Notification(kernel.Get<MainWindow>());
             }

--- a/src/RevitOpeningPlacement/ViewModels/OpeningConfig/MainViewModel.cs
+++ b/src/RevitOpeningPlacement/ViewModels/OpeningConfig/MainViewModel.cs
@@ -170,7 +170,9 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
         }
 
         private void SaveConfig() {
-            GetOpeningConfig().SaveProjectConfig();
+            var config = GetOpeningConfig();
+            config.SaveProjectConfig();
+            UpdateOpeningConfigPath(config.ProjectConfigPath);
             MessageText = "Файл настроек успешно сохранен.";
             _timer.Start();
         }

--- a/src/RevitOpeningPlacement/ViewModels/OpeningConfig/MainViewModel.cs
+++ b/src/RevitOpeningPlacement/ViewModels/OpeningConfig/MainViewModel.cs
@@ -196,6 +196,7 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
                 SelectedMepCategoryViewModel = MepCategories.FirstOrDefault(category => category.IsSelected)
                     ?? MepCategories.First();
                 ConfigName = config.Name;
+                UpdateOpeningConfigPath(config.ProjectConfigPath);
             }
             MessageText = "Файл настроек успешно загружен.";
             _timer.Start();

--- a/src/RevitOpeningPlacement/ViewModels/OpeningConfig/MainViewModel.cs
+++ b/src/RevitOpeningPlacement/ViewModels/OpeningConfig/MainViewModel.cs
@@ -27,7 +27,6 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
         private DispatcherTimer _timer;
         private readonly RevitRepository _revitRepository;
         private string _configName;
-        private string _configPath;
 
         public MainViewModel(RevitRepository revitRepository, Models.Configs.OpeningConfig openingConfig) {
             _revitRepository = revitRepository ?? throw new ArgumentNullException(nameof(revitRepository));
@@ -40,7 +39,6 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
             MepCategories = new ObservableCollection<MepCategoryViewModel>(
                 openingConfig.Categories.Select(item => new MepCategoryViewModel(_revitRepository, item)));
             ConfigName = openingConfig.Name;
-            ConfigPath = openingConfig.ProjectConfigPath;
 
             InitializeTimer();
 
@@ -58,10 +56,6 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
             }
         }
 
-        public string ConfigPath {
-            get => _configPath;
-            set => RaiseAndSetIfChanged(ref _configPath, value);
-        }
 
         public string ConfigName {
             get => _configName;
@@ -200,7 +194,6 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
             var mepConfigPath = MepConfigPath.GetMepConfigPath(_revitRepository.Doc);
             mepConfigPath.OpeningConfigPath = path;
             mepConfigPath.SaveProjectConfig();
-            ConfigPath = path;
         }
 
         private bool CanSaveConfig() {

--- a/src/RevitOpeningPlacement/ViewModels/Services/ConfigLoaderService.cs
+++ b/src/RevitOpeningPlacement/ViewModels/Services/ConfigLoaderService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using Autodesk.Revit.DB;
 
@@ -14,14 +14,16 @@ namespace RevitOpeningPlacement.ViewModels.Services {
             if(document is null) { throw new ArgumentNullException(nameof(document)); }
 
             var openWindow = GetPlatformService<IOpenFileDialogService>();
-            openWindow.Filter = "ClashConfig |*.json";
+            openWindow.Filter = "OpeningConfig |*.json";
             if(!openWindow.ShowDialog(Environment.GetFolderPath(Environment.SpecialFolder.Desktop))) {
                 throw new OperationCanceledException();
             }
 
             try {
                 var configLoader = new ConfigLoader(document);
-                return configLoader.Load<T>(openWindow.File.FullName);
+                T config = configLoader.Load<T>(openWindow.File.FullName);
+                config.ProjectConfigPath = openWindow.File.FullName;
+                return config;
             } catch(pyRevitLabs.Json.JsonSerializationException) {
                 ShowError();
                 throw new OperationCanceledException();

--- a/src/RevitOpeningPlacement/ViewModels/Services/ConfigSaverService.cs
+++ b/src/RevitOpeningPlacement/ViewModels/Services/ConfigSaverService.cs
@@ -17,7 +17,7 @@ namespace RevitOpeningPlacement.ViewModels.Services {
             saveWindow.AddExtension = true;
             saveWindow.Filter = "OpeningConfig |*.json";
             saveWindow.FilterIndex = 1;
-            if(!saveWindow.ShowDialog(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "config")) {
+            if(!saveWindow.ShowDialog(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "Настройки заданий на отверстия")) {
                 throw new OperationCanceledException();
             }
             var configSaver = new ConfigSaver(document);

--- a/src/RevitOpeningPlacement/ViewModels/Services/ConfigSaverService.cs
+++ b/src/RevitOpeningPlacement/ViewModels/Services/ConfigSaverService.cs
@@ -17,7 +17,8 @@ namespace RevitOpeningPlacement.ViewModels.Services {
             saveWindow.AddExtension = true;
             saveWindow.Filter = "OpeningConfig |*.json";
             saveWindow.FilterIndex = 1;
-            if(!saveWindow.ShowDialog(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "Настройки заданий на отверстия")) {
+            if(!saveWindow.ShowDialog(
+                Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "Настройки заданий на отверстия")) {
                 throw new OperationCanceledException();
             }
             var configSaver = new ConfigSaver(document);

--- a/src/RevitOpeningPlacement/ViewModels/Services/ConfigSaverService.cs
+++ b/src/RevitOpeningPlacement/ViewModels/Services/ConfigSaverService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using Autodesk.Revit.DB;
 
@@ -10,7 +10,7 @@ using RevitClashDetective.Models;
 
 namespace RevitOpeningPlacement.ViewModels.Services {
     internal class ConfigSaverService {
-        public void Save(ProjectConfig config, Document document) {
+        public string Save(ProjectConfig config, Document document) {
             if(document is null) { throw new ArgumentNullException(nameof(document)); }
 
             var saveWindow = GetPlatformService<ISaveFileDialogService>();
@@ -22,6 +22,7 @@ namespace RevitOpeningPlacement.ViewModels.Services {
             }
             var configSaver = new ConfigSaver(document);
             configSaver.Save(config, saveWindow.File.FullName);
+            return saveWindow.File.FullName;
         }
 
         protected T GetPlatformService<T>() {

--- a/src/RevitOpeningPlacement/ViewModels/Services/ConfigSaverService.cs
+++ b/src/RevitOpeningPlacement/ViewModels/Services/ConfigSaverService.cs
@@ -15,7 +15,7 @@ namespace RevitOpeningPlacement.ViewModels.Services {
 
             var saveWindow = GetPlatformService<ISaveFileDialogService>();
             saveWindow.AddExtension = true;
-            saveWindow.Filter = "ClashConfig |*.json";
+            saveWindow.Filter = "OpeningConfig |*.json";
             saveWindow.FilterIndex = 1;
             if(!saveWindow.ShowDialog(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "config")) {
                 throw new OperationCanceledException();

--- a/src/RevitOpeningPlacement/Views/MainWindow.xaml
+++ b/src/RevitOpeningPlacement/Views/MainWindow.xaml
@@ -46,13 +46,20 @@
                              ToolTip="Сохранить как"
                              Command="{Binding SaveAsConfigCommand}"
                              Glyph="{dx:DXImage 'DevAV/Actions/SaveAs_32x32.png'}" />
+
+            <dx:SimpleButton Height="32"
+                             Width="32"
+                             Margin="0 0 10 0"
+                             ToolTip="Открыть папку конфига"
+                             Command="{Binding OpenConfigFolderCommand}"
+                             Glyph="{dx:DXImage 'DevAV/Actions/OpenDoc_32x32.png'}" />
             <DockPanel VerticalAlignment="Center">
                 
             <TextBlock Text="Название настроек: " 
                        VerticalAlignment="Center"/>
             <dxe:TextEdit Width="600"
                           NullText="default"
-                          EditValue="{Binding ConfigName, UpdateSourceTrigger=PropertyChanged}"                          />
+                          EditValue="{Binding ConfigName, UpdateSourceTrigger=PropertyChanged}"/>
             </DockPanel>
         </StackPanel>
 


### PR DESCRIPTION
## Обновления

Настройки расстановки отверстий ВИС теперь при выполнении команды "Сохранить как" сохраняются по заданному пути и становятся редактируемыми в окне. При "Загрузке" настроек из файла также станосится редактируемым этот загруженный файл.
Чтобы посмотреть путь к редактируемому файлу добавлена кнопка в GUI, открывающая окно проводника в папке конфига с выделением редактируемого файла:

![image](https://github.com/user-attachments/assets/f449515d-ff35-499e-b382-4b80e4f10d7f)
