### PR TITLE
RevitServerFolders: Добавлена проверка установки плагина Navisworks NWC Export Utility

### DIFF
--- a/src/RevitServerFolders/NavisworksExportCommand.cs
+++ b/src/RevitServerFolders/NavisworksExportCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Windows;
 
 using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 
 using dosymep.Bim4Everyone;
@@ -24,6 +25,10 @@ namespace RevitServerFolders {
         }
 
         protected override void Execute(UIApplication uiApplication) {
+            if(!OptionalFunctionalityUtils.IsNavisworksExporterAvailable()) {
+                throw new InvalidOperationException(
+                    "Отсутствует плагин Navisworks NWC Export Utility. Необходимо установить его.");
+            }
             using(IKernel kernel = uiApplication.CreatePlatformServices()) {
                 kernel.Bind<RevitRepository>()
                     .ToSelf()


### PR DESCRIPTION
Команда по экспорту в NWC из RVT не работает, если не установлен плагин Navisworks NWC Export Utility. Добавлена проверка на установку этого плагина.