### PR TITLE
Nuke: Обновлены зависимости

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,10 +1,113 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "$ref": "#/definitions/build",
-  "title": "Build Schema",
   "definitions": {
-    "build": {
-      "type": "object",
+    "Host": {
+      "type": "string",
+      "enum": [
+        "AppVeyor",
+        "AzurePipelines",
+        "Bamboo",
+        "Bitbucket",
+        "Bitrise",
+        "GitHubActions",
+        "GitLab",
+        "Jenkins",
+        "Rider",
+        "SpaceAutomation",
+        "TeamCity",
+        "Terminal",
+        "TravisCI",
+        "VisualStudio",
+        "VSCode"
+      ]
+    },
+    "ExecutableTarget": {
+      "type": "string",
+      "enum": [
+        "Clean",
+        "CloneRepos",
+        "Compile",
+        "CreateBranch",
+        "CreateBundle",
+        "CreatePlugin",
+        "CreateProfile",
+        "CreatePullRequest",
+        "CreateWorkflow",
+        "FullClean",
+        "Publish",
+        "PublishArtifacts"
+      ]
+    },
+    "Verbosity": {
+      "type": "string",
+      "description": "",
+      "enum": [
+        "Verbose",
+        "Normal",
+        "Minimal",
+        "Quiet"
+      ]
+    },
+    "NukeBuild": {
+      "properties": {
+        "Continue": {
+          "type": "boolean",
+          "description": "Indicates to continue a previously failed build attempt"
+        },
+        "Help": {
+          "type": "boolean",
+          "description": "Shows the help text for this build assembly"
+        },
+        "Host": {
+          "description": "Host for execution. Default is 'automatic'",
+          "$ref": "#/definitions/Host"
+        },
+        "NoLogo": {
+          "type": "boolean",
+          "description": "Disables displaying the NUKE logo"
+        },
+        "Partition": {
+          "type": "string",
+          "description": "Partition to use on CI"
+        },
+        "Plan": {
+          "type": "boolean",
+          "description": "Shows the execution plan (HTML)"
+        },
+        "Profile": {
+          "type": "array",
+          "description": "Defines the profiles to load",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Root": {
+          "type": "string",
+          "description": "Root directory during build execution"
+        },
+        "Skip": {
+          "type": "array",
+          "description": "List of targets to be skipped. Empty list skips all dependencies",
+          "items": {
+            "$ref": "#/definitions/ExecutableTarget"
+          }
+        },
+        "Target": {
+          "type": "array",
+          "description": "List of targets to be invoked. Default is '{default_target}'",
+          "items": {
+            "$ref": "#/definitions/ExecutableTarget"
+          }
+        },
+        "Verbosity": {
+          "description": "Logging verbosity during build execution. Default is 'Normal'",
+          "$ref": "#/definitions/Verbosity"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
       "properties": {
         "BundleName": {
           "type": "string",
@@ -30,43 +133,15 @@
             "Release"
           ]
         },
-        "Continue": {
-          "type": "boolean",
-          "description": "Indicates to continue a previously failed build attempt"
-        },
         "ExtensionsAppToken": {
           "type": "string",
           "description": "Extensions token value",
           "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
-        "Help": {
-          "type": "boolean",
-          "description": "Shows the help text for this build assembly"
-        },
-        "Host": {
-          "type": "string",
-          "description": "Host for execution. Default is 'automatic'",
-          "enum": [
-            "AppVeyor",
-            "AzurePipelines",
-            "Bamboo",
-            "Bitbucket",
-            "Bitrise",
-            "GitHubActions",
-            "GitLab",
-            "Jenkins",
-            "Rider",
-            "SpaceAutomation",
-            "TeamCity",
-            "Terminal",
-            "TravisCI",
-            "VisualStudio",
-            "VSCode"
-          ]
-        },
         "IconUrl": {
           "type": "string",
-          "description": "Bundle icon url"
+          "description": "Bundle icon url",
+          "format": "uri"
         },
         "MaxVersion": {
           "type": "string",
@@ -80,7 +155,8 @@
             "Rv2021",
             "Rv2022",
             "Rv2023",
-            "Rv2024"
+            "Rv2024",
+            "Rv2025"
           ]
         },
         "MinVersion": {
@@ -95,35 +171,17 @@
             "Rv2021",
             "Rv2022",
             "Rv2023",
-            "Rv2024"
+            "Rv2024",
+            "Rv2025"
           ]
-        },
-        "NoLogo": {
-          "type": "boolean",
-          "description": "Disables displaying the NUKE logo"
         },
         "Output": {
           "type": "string",
           "description": "Output directory"
         },
-        "Partition": {
-          "type": "string",
-          "description": "Partition to use on CI"
-        },
-        "Plan": {
-          "type": "boolean",
-          "description": "Shows the execution plan (HTML)"
-        },
         "PluginName": {
           "type": "string",
           "description": "Project (plugin) name in solution"
-        },
-        "Profile": {
-          "type": "array",
-          "description": "Defines the profiles to load",
-          "items": {
-            "type": "string"
-          }
         },
         "PublishDirectory": {
           "type": "string",
@@ -152,71 +210,19 @@
               "Rv2021",
               "Rv2022",
               "Rv2023",
-              "Rv2024"
-            ]
-          }
-        },
-        "Root": {
-          "type": "string",
-          "description": "Root directory during build execution"
-        },
-        "Skip": {
-          "type": "array",
-          "description": "List of targets to be skipped. Empty list skips all dependencies",
-          "items": {
-            "type": "string",
-            "enum": [
-              "Clean",
-              "CloneRepos",
-              "Compile",
-              "CreateBranch",
-              "CreateBundle",
-              "CreatePlugin",
-              "CreateProfile",
-              "CreatePullRequest",
-              "CreateWorkflow",
-              "FullClean",
-              "Publish",
-              "PublishArtifacts"
+              "Rv2024",
+              "Rv2025"
             ]
           }
         },
         "Solution": {
           "type": "string",
           "description": "Path to a solution file that is automatically loaded"
-        },
-        "Target": {
-          "type": "array",
-          "description": "List of targets to be invoked. Default is '{default_target}'",
-          "items": {
-            "type": "string",
-            "enum": [
-              "Clean",
-              "CloneRepos",
-              "Compile",
-              "CreateBranch",
-              "CreateBundle",
-              "CreatePlugin",
-              "CreateProfile",
-              "CreatePullRequest",
-              "CreateWorkflow",
-              "FullClean",
-              "Publish",
-              "PublishArtifacts"
-            ]
-          }
-        },
-        "Verbosity": {
-          "type": "string",
-          "description": "Logging verbosity during build execution. Default is 'Normal'",
-          "enum": [
-            "Minimal",
-            "Normal",
-            "Quiet",
-            "Verbose"
-          ]
         }
       }
+    },
+    {
+      "$ref": "#/definitions/NukeBuild"
     }
-  }
+  ]
 }

--- a/build/Build.Compile.cs
+++ b/build/Build.Compile.cs
@@ -64,7 +64,6 @@ partial class Build {
 
     Configure<DotNetBuildSettings> CompileSettingsBase => _ => _
         .DisableNoRestore()
-        .SetOutputDirectory(Output)
         .SetCopyright($"Copyright © {DateTime.Now.Year}")
         .When(settings => IsServerBuild,
             _ => _

--- a/build/Build.Compile.cs
+++ b/build/Build.Compile.cs
@@ -3,6 +3,7 @@ using System;
 using Nuke.Common;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
+using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
 using Nuke.Components;
 
@@ -13,25 +14,25 @@ using static Nuke.Common.Tools.DotNet.DotNetTasks;
 partial class Build {
     Target Compile => _ => _
         .DependsOn(Clean)
+        .Requires(() => Output)
         .Requires(() => PluginName)
-        .Requires(() => PublishDirectory)
         .Executes(() => {
-            string publishDirectory = NukeBuildExtensions.GetExtensionsPath(PublishDirectory);
-            Log.Debug("publishDirectory: {PublishDirectory}", publishDirectory);
+            Log.Debug("Params.Output: {Output}", Params.Output);
 
             ReportSummary(_ => _
                 .AddPairWhenValueNotNull(nameof(PluginName), PluginName)
-                .AddPairWhenValueNotNull(nameof(PublishDirectory), PublishDirectory)
+                .AddPairWhenValueNotNull(nameof(Params.Configuration), Params.Configuration)
+                .AddPairWhenValueNotNull(nameof(Params.Output), Params.Output)
             );
 
             DotNetBuild(s => s
                 .Apply(CompileSettingsBase)
                 .SetProjectFile("src/" + PluginName)
-                .SetConfiguration(Configuration.Debug)
-                .SetOutputDirectory(publishDirectory)
+                .SetConfiguration(Params.Configuration)
                 .CombineWith(Params.BuildRevitVersions, (settings, revitVersion) => settings
                     .SetSimpleVersion(Params, revitVersion)
                     .SetProperty("RevitVersion", (int) revitVersion)
+                    .SetProperty("OutputPath", Params.Output)
                     .SetProperty("AssemblyName", $"{PluginName}_{revitVersion}")));
         });
 
@@ -46,17 +47,18 @@ partial class Build {
 
             ReportSummary(_ => _
                 .AddPairWhenValueNotNull(nameof(PluginName), PluginName)
+                .AddPairWhenValueNotNull(nameof(Params.Configuration), Params.Configuration)
                 .AddPairWhenValueNotNull(nameof(PublishDirectory), PublishDirectory)
             );
 
             DotNetBuild(s => s
                 .Apply(CompileSettingsBase)
                 .SetProjectFile("src/" + PluginName)
-                .SetConfiguration(Configuration.Release)
-                .SetOutputDirectory(publishDirectory)
+                .SetConfiguration(Params.Configuration)
                 .CombineWith(Params.BuildRevitVersions, (settings, revitVersion) => settings
                     .SetSimpleVersion(Params, revitVersion)
                     .SetProperty("RevitVersion", (int) revitVersion)
+                    .SetProperty("OutputPath", publishDirectory)
                     .SetProperty("AssemblyName", $"{PluginName}_{revitVersion}")));
         });
 
@@ -64,8 +66,9 @@ partial class Build {
         .DisableNoRestore()
         .SetOutputDirectory(Output)
         .SetCopyright($"Copyright © {DateTime.Now.Year}")
-        .When(IsServerBuild, _ => _
-            .EnableContinuousIntegrationBuild())
+        .When(settings => IsServerBuild,
+            _ => _
+                .EnableContinuousIntegrationBuild())
         .WhenNotNull(this, (_, o) => _
             .SetRepositoryUrl(o.GitRepository.HttpsUrl));
 }

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,11 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dosymep.Nuke.RevitVersions" Version="1.0.0" />
-    <PackageReference Include="Nuke.Common" Version="8.0.0" />
-    <PackageReference Include="Nuke.Components" Version="8.0.0" />
-    <PackageReference Include="Octokit" Version="10.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.3" />
+    <PackageReference Include="dosymep.Nuke.RevitVersions" Version="*" />
+    <PackageReference Include="Nuke.Common" Version="9.0.3" />
+    <PackageReference Include="Nuke.Components" Version="9.0.3" />
+    <PackageReference Include="Octokit" Version="13.0.1" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- обновил зависимости nuke
- изменил логику публикации плагинов
  - `nuke compile` - компиляция в папку `bin`
  - `nuke publish` - компиляция в папку плагина в платформу (на вкладку)
  - локальная сборка - конфигурация выбирается `Debug`, 
  - сборка на сервере - конфигурация выбирается `Release` 

было:
- конфигурация
  - `nuke compile` - Debug
  - `nuke publish` - Release
- output
  - `nuke compile` - компиляция в папку плагина в платформу (на вкладку)
  - `nuke publish` - компиляция в папку плагина в платформу (на вкладку)