### PR TITLE
RevitClashDetective: Отключен выбор параметра фильтра, которого нет в активном документе

### DIFF
--- a/src/RevitClashDetective/ViewModels/FilterCreatorViewModels/CategoriesInfoViewModel.cs
+++ b/src/RevitClashDetective/ViewModels/FilterCreatorViewModels/CategoriesInfoViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -31,9 +31,7 @@ namespace RevitClashDetective.ViewModels.FilterCreatorViewModels {
         }
 
         public void InitializeParameters() {
-            var parameters =
-                _revitRepository.DocInfos
-                .SelectMany(item => _revitRepository.GetParameters(item.Doc, Categories.Select(c => c.Category)))
+            var parameters = _revitRepository.GetParameters(_revitRepository.Doc, Categories.Select(c => c.Category))
                 .Distinct()
                 .Select(item => new ParameterViewModel(item))
                 .ToList();

--- a/src/RevitClashes/Models/FilterGenerators/RevitFilterGenerator.cs
+++ b/src/RevitClashes/Models/FilterGenerators/RevitFilterGenerator.cs
@@ -19,7 +19,7 @@ namespace RevitClashDetective.Models.FilterGenerators {
         protected IFilterGenerator SetRuleFilter(Document doc, Rule rule, bool inverted) {
             var ruleCreator = RuleEvaluatorUtils.GetRevitRuleCreator(rule.Evaluator.Evaluator);
             var providerRule = rule.Provider.GetRule(doc, ruleCreator, rule.Value);
-            var revitRule = inverted
+            var revitRule = (inverted && providerRule != null)
                 ? new FilterInverseRule(providerRule)
                 : providerRule;
             if(revitRule == null) {


### PR DESCRIPTION
## Изменения

- Исключена возможность выбирать параметр для фильтрации при редактировании поискового набора, когда этот параметр отсутствует в активном документе. Ранее было возможно выбрать параметр, который есть в какой-то связи и сохранить изменения. При загрузке конфига происходила ошибка десериализации, т.к. параметра в активном документе нет.
- Исправлена ошибка `ArgumentNullException`, которая возникала при создании `FilterInverseRule` с `null` параметром конструктора.