### PR TITLE
RevitOpeningPlacement: Отключен выбор параметра фильтра, которого нет в активном документе

### DIFF
--- a/src/RevitOpeningPlacement/ViewModels/OpeningConfig/CategoriesInfoViewModel.cs
+++ b/src/RevitOpeningPlacement/ViewModels/OpeningConfig/CategoriesInfoViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -34,11 +34,7 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
         }
 
         public void InitializeParameters() {
-            var parameters =
-                _revitRepository.DocInfos
-                .GroupBy(item => item.Name)
-                .Select(group => group.ToList().First())
-                .SelectMany(item => _revitRepository.GetParameters(item.Doc, Categories))
+            var parameters = _revitRepository.GetParameters(_revitRepository.Doc, Categories)
                 .Distinct()
                 .Select(item => new ParameterViewModel(item))
                 .ToList();


### PR DESCRIPTION
Исключена возможность выбирать параметр для фильтрации при редактировании фильтра, когда этот параметр отсутствует в активном документе. Ранее было возможно выбрать параметр, который есть в какой-то связи и сохранить изменения. При загрузке конфига происходила ошибка десериализации и генерился конфиг по умолчанию, т.к. параметра в активном документе нет.