### PR TITLE
RevitDeclarations: Исправлена ошибка конвертации дат и вывода класса ММ

### DIFF
--- a/src/RevitDeclarations/Models/Export/DeclarationData/CommercialDataTable.cs
+++ b/src/RevitDeclarations/Models/Export/DeclarationData/CommercialDataTable.cs
@@ -38,7 +38,7 @@ namespace RevitDeclarations.Models {
                 _mainTable.Rows[rowNumber][7] = commercialRooms.AreaMain;
                 _mainTable.Rows[rowNumber][8] = commercialRooms.RoomsHeight;
                 _mainTable.Rows[rowNumber][9] = "";
-                _mainTable.Rows[rowNumber][10] = "";
+                _mainTable.Rows[rowNumber][10] = commercialRooms.ParkingSpaceClass ?? "";
                 _mainTable.Rows[rowNumber][11] = commercialRooms.GroupName ?? "";
                 _mainTable.Rows[rowNumber][12] = _settings.ProjectName ?? "";
 

--- a/src/RevitDeclarations/Models/Export/Exporters/ExcelExporter.cs
+++ b/src/RevitDeclarations/Models/Export/Exporters/ExcelExporter.cs
@@ -45,6 +45,8 @@ namespace RevitDeclarations.Models {
                 workSheet = (Worksheet) workSheets["Лист1"];
                 workSheet.Name = "Помещения";
 
+                SetMainSheetGraphicSettings(workSheet, declarationTable.TableInfo);
+
                 DataTable headerTable = declarationTable.HeaderDataTable;
                 for(int i = 0; i < headerTable.Columns.Count; i++) {
                     workSheet.Cells[1, i + 1] = headerTable.Rows[0][i];
@@ -57,7 +59,6 @@ namespace RevitDeclarations.Models {
                     }
                 }
 
-                SetMainSheetGraphicSettings(workSheet, declarationTable.TableInfo);
 
                 int counter = 1;
                 if(declarationTable.SubTables.Any()) {

--- a/src/RevitDeclarations/Models/Rooms/CommercialRooms.cs
+++ b/src/RevitDeclarations/Models/Rooms/CommercialRooms.cs
@@ -29,6 +29,7 @@ namespace RevitDeclarations.Models {
 
         [JsonProperty("type")]
         public override string Department => _paramProvider.GetDepartment(_firstRoom, "Нежилые помещения");
+        public string ParkingSpaceClass => _firstRoom.GetTextParamValue(_settings.ParkingSpaceClass);
 
         public string DeclarationNumber =>
             _paramProvider.GetTwoParamsWithHyphen(_firstRoom, _settings.AddPrefixToNumber);


### PR DESCRIPTION
Исправлены ошибки:
- конвертации числа в дату в Excel
- отсутствия параметра класса машино-места в итоговой таблице