### PR TITLE
RevitOpeningPlacement: В окне выбора связей добавлена возможность включать-выключать сразу несколько чекбоксов

### DIFF
--- a/src/RevitOpeningPlacement/ViewModels/Links/LinkViewModel.cs
+++ b/src/RevitOpeningPlacement/ViewModels/Links/LinkViewModel.cs
@@ -1,9 +1,12 @@
+using System;
+using System.Collections.Generic;
+
 using Autodesk.Revit.DB;
 
 using dosymep.WPF.ViewModels;
 
 namespace RevitOpeningPlacement.ViewModels.Links {
-    internal class LinkViewModel : BaseViewModel {
+    internal class LinkViewModel : BaseViewModel, IEquatable<LinkViewModel> {
         private readonly RevitLinkType _linkType;
         private string _futureStatus;
         private bool _isSelected;
@@ -41,6 +44,24 @@ namespace RevitOpeningPlacement.ViewModels.Links {
         public string FutureStatus {
             get => _futureStatus;
             private set => RaiseAndSetIfChanged(ref _futureStatus, value);
+        }
+
+        public override bool Equals(object obj) {
+            return Equals(obj as LinkViewModel);
+        }
+
+        public bool Equals(LinkViewModel other) {
+            if(ReferenceEquals(null, other)) {
+                return false;
+            }
+            if(ReferenceEquals(this, other)) {
+                return true;
+            }
+            return _linkType.Id == other._linkType.Id;
+        }
+
+        public override int GetHashCode() {
+            return -1154484602 + EqualityComparer<ElementId>.Default.GetHashCode(_linkType?.Id);
         }
 
         public RevitLinkType GetLinkType() {

--- a/src/RevitOpeningPlacement/ViewModels/Links/LinksSelectorViewModel.cs
+++ b/src/RevitOpeningPlacement/ViewModels/Links/LinksSelectorViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Windows.Input;
 
@@ -31,6 +32,8 @@ namespace RevitOpeningPlacement.ViewModels.Links {
                 .Where(doc => _docTypesProvider.GetDocTypes().Contains(_bimModelPartsHandler.GetDocType(doc)))
                 .Select(link => new LinkViewModel(link))
                 .OrderBy(vm => vm.Name));
+            SelectedLinks = new ObservableCollection<LinkViewModel>(Links.Where(link => link.IsSelected));
+            SelectedLinks.CollectionChanged += OnCollectionChanged;
 
             ApplyUserSelectionCommand = RelayCommand.Create(ApplyUserSelection);
         }
@@ -39,6 +42,19 @@ namespace RevitOpeningPlacement.ViewModels.Links {
         public ICommand ApplyUserSelectionCommand { get; }
 
         public ObservableCollection<LinkViewModel> Links { get; }
+
+        public ObservableCollection<LinkViewModel> SelectedLinks { get; }
+
+
+        private void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e) {
+            UpdateSelection();
+        }
+
+        private void UpdateSelection() {
+            foreach(var link in Links) {
+                link.IsSelected = SelectedLinks.Contains(link);
+            }
+        }
 
         private void ApplyUserSelection() {
             _revitRepository.SetRevitLinkTypesToUse(Links

--- a/src/RevitOpeningPlacement/Views/LinksSelectorWindow.xaml
+++ b/src/RevitOpeningPlacement/Views/LinksSelectorWindow.xaml
@@ -29,17 +29,19 @@
             x:Name="LeftGrid"
             Grid.Row="0"
             Margin="10 10 10 0"
-            SelectionMode="Cell"
+            SelectionMode="Row"
             DefaultSorting="Level"
             AutoGenerateColumns="None"
             VirtualizingPanel.IsVirtualizing="True"
             VirtualizingPanel.VirtualizationMode="Recycling"
             VirtualizingPanel.IsVirtualizingWhenGrouping="True"
-            ItemsSource="{Binding Links}">
+            ItemsSource="{Binding Links}"
+            SelectedItems="{Binding SelectedLinks}">
             <dxg:GridControl.View>
                 <dxg:TableView
                     VerticalScrollbarVisibility="Auto"
                     HorizontalScrollbarVisibility="Auto"
+                    ShowCheckBoxSelectorColumn="True"
                     ShowGroupPanel="False">
                 </dxg:TableView>
             </dxg:GridControl.View>
@@ -56,20 +58,6 @@
                     FieldName="CurrentStatus"
                     ReadOnly="True"
                     AllowEditing="False" />
-                <dxg:GridColumn
-                    Header="Обрабатывать"
-                    FieldName="DeleteGroup"
-                    Width="100"
-                    ReadOnly="False">
-                    <dxg:GridColumn.CellTemplate>
-                        <DataTemplate>
-                            <dxe:CheckEdit
-                                IsChecked="{Binding RowData.Row.IsSelected}"
-                                VerticalAlignment="Center"
-                                HorizontalAlignment="Center" />
-                        </DataTemplate>
-                    </dxg:GridColumn.CellTemplate>
-                </dxg:GridColumn>
                 <dxg:GridColumn
                     Header="Новый статус"
                     Width="100"


### PR DESCRIPTION
Теперь в окне выбора связей можно включить/выключить выделение сразу всех строк, и выделять несколько строк через shift и ctrl:
![image](https://github.com/user-attachments/assets/1011015a-4f23-49eb-a662-ff6d59154120)
