### PR TITLE
RevitOpeningPlacement: Обновлен алгоритм определения солида отверстий АР и КР

### DIFF
--- a/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/RealOpeningArPlacer.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/RealOpeningArPlacer.cs
@@ -25,6 +25,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement {
         public const string RealOpeningArDiameter = "ФОП_РАЗМ_Диаметр";
         public const string RealOpeningArWidth = "ФОП_РАЗМ_Ширина проёма";
         public const string RealOpeningArHeight = "ФОП_РАЗМ_Высота проёма";
+        public const string RealOpeningArThickness = "ФОП_РАЗМ_Глубина проёма";
         public const string RealOpeningIsEom = "ЭОМ";
         public const string RealOpeningIsSs = "СС";
         public const string RealOpeningIsOv = "ОВ";

--- a/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/RealOpeningKrPlacer.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/RealOpeningKrPlacer.cs
@@ -27,6 +27,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         public const string RealOpeningKrDiameter = "ФОП_РАЗМ_Диаметр";
         public const string RealOpeningKrInWallWidth = "ФОП_РАЗМ_Ширина";
         public const string RealOpeningKrInWallHeight = "ФОП_РАЗМ_Высота";
+        public const string RealOpeningKrThickness = "ФОП_РАЗМ_Глубина";
         public const string RealOpeningKrInFloorHeight = "мод_ФОП_Габарит А";
         public const string RealOpeningKrInFloorWidth = "мод_ФОП_Габарит Б";
         public const string RealOpeningTaskId = "ФОП_ID задания";

--- a/src/RevitOpeningPlacement/OpeningModels/OpeningRealBase.cs
+++ b/src/RevitOpeningPlacement/OpeningModels/OpeningRealBase.cs
@@ -133,6 +133,8 @@ namespace RevitOpeningPlacement.OpeningModels {
                 solid = GetSolidByFamily(_familyInstance.Symbol.FamilyName);
             } catch(Exception ex) when(
             ex is NullReferenceException
+            || ex is ArgumentNullException
+            || ex is ArgumentException
             || ex is InvalidOperationException
             || ex is Autodesk.Revit.Exceptions.ApplicationException) {
                 solid = GetSolidByCut();


### PR DESCRIPTION
## Зачем вообще нужен отдельный алгоритм определения солида отверситй АР и КР?

Семейства отверстий АР и КР - это полые семейства вырезания. У них нет твердотельной геометрии, поэтому обычное использование `GetSolid` ничего не даст.

## Старый алгоритм

Брался экземпляр семейства отверстия (АР/КР), бралась его основа. Производилась попытка построить исходную геометрию (solid) основы до вырезания отверстия в ней. Из исходной геометрии основы вырезалась текущая геометрия (solid) основы. По разнице солидов получались солиды отверстий. Из этих солидов, если их получилось несколько, выбирался ближайший.

Плюсы:

- алгоритм не зависит от формы/названия/параметров элементов

Минусы:

- сложно определять исходную геометрию основы. Особенно это касается случаев, когда отверстие примыкает к торцу основы, что сейчас вообще работает неправильно
- алгоритм долго работает
- можно неправильно определить ближайший солид для отверстия, когда в одной основе находится больше 1 отвертсия

## Новый алгоритм

Опираясь на то, что плагин работает с определенными типоразмерами определенных семейств с определенным списком параметров и на то, что форма семейств и расположение точки вставки не меняется, геометрия отверстий строится путем выдавливания солидов. То есть берется точка вставки, которая преобразуется при необходимости, и из нее выдавливается тело отверстия - прямой цилиндр или прямоугольный параллелепипед.
**Если произошла какая-то ошибка, то используется старый алгоритм**.

Плюсы:

- быстро работает
- исключены ошибки обработки геометрии в тех случаях, когда старый алгоритм не работал

Минусы:

- полностью зависит от формы/названия/параметров семейств отверстий АР/КР