### PR TITLE
RevitDeclarations: Обновлены правила расчета УТП "Мастер-спальня"

### DIFF
--- a/src/RevitDeclarations/Models/DeclarationProjects/ApartmentsProject.cs
+++ b/src/RevitDeclarations/Models/DeclarationProjects/ApartmentsProject.cs
@@ -85,6 +85,11 @@ namespace RevitDeclarations.Models {
                 .GetDoorsOnPhase(_document.Document, _phase);
         }
 
+        public IReadOnlyCollection<CurveElement> GetCurveSeparators() {
+            return _revitRepository
+                .GetRoomSeparationLinesOnPhase(_document.Document, _phase);
+        }
+
         public IReadOnlyCollection<FamilyInstance> GetBathInstances() {
             return _revitRepository.
                 GetBathInstancesOnPhase(_document.Document, _phase);

--- a/src/RevitDeclarations/Models/Priorities/RoomPriority.cs
+++ b/src/RevitDeclarations/Models/Priorities/RoomPriority.cs
@@ -1,5 +1,7 @@
 using System;
 
+using Microsoft.Office.Interop.Excel;
+
 using pyRevitLabs.Json;
 
 namespace RevitDeclarations.Models
@@ -29,6 +31,19 @@ namespace RevitDeclarations.Models
                 return true;
             }
             return false;
+        }
+
+        public override bool Equals(object obj) {
+            if(obj == null || GetType() != obj.GetType()) {
+                return false;
+            }
+
+            RoomPriority priority = (RoomPriority)obj;
+            return string.Equals(priority.Name, Name, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override int GetHashCode() {
+            return Name?.GetHashCode() ?? 0;
         }
     }
 }

--- a/src/RevitDeclarations/Models/Priorities/RoomPriority.cs
+++ b/src/RevitDeclarations/Models/Priorities/RoomPriority.cs
@@ -1,11 +1,8 @@
 using System;
 
-using Microsoft.Office.Interop.Excel;
-
 using pyRevitLabs.Json;
 
-namespace RevitDeclarations.Models
-{
+namespace RevitDeclarations.Models {
     public class RoomPriority {
         public RoomPriority(int number, string name) {
             OrdinalNumber = number;
@@ -27,7 +24,7 @@ namespace RevitDeclarations.Models
         public int MaxRoomAmount { get; set; }
 
         public bool CheckName(string name) {
-            if(string.Equals(name, this.Name, StringComparison.OrdinalIgnoreCase)) {
+            if(string.Equals(name, Name, StringComparison.OrdinalIgnoreCase)) {
                 return true;
             }
             return false;
@@ -39,7 +36,7 @@ namespace RevitDeclarations.Models
             }
 
             RoomPriority priority = (RoomPriority)obj;
-            return string.Equals(priority.Name, Name, StringComparison.OrdinalIgnoreCase);
+            return CheckName(priority.Name);
         }
 
         public override int GetHashCode() {

--- a/src/RevitDeclarations/Models/Priorities/RoomPriority.cs
+++ b/src/RevitDeclarations/Models/Priorities/RoomPriority.cs
@@ -3,7 +3,7 @@ using System;
 using pyRevitLabs.Json;
 
 namespace RevitDeclarations.Models {
-    public class RoomPriority {
+    public class RoomPriority : IEquatable<RoomPriority> {
         public RoomPriority(int number, string name) {
             OrdinalNumber = number;
             Name = name;
@@ -30,14 +30,17 @@ namespace RevitDeclarations.Models {
             return false;
         }
 
-        public override bool Equals(object obj) {
-            if(obj == null || GetType() != obj.GetType()) {
-                return false;
-            }
+        public bool Equals(RoomPriority other) {
+            if(ReferenceEquals(null, other)) { return false; }
+            if(ReferenceEquals(this, other)) { return true; }
 
-            RoomPriority priority = (RoomPriority)obj;
-            return CheckName(priority.Name);
+            return CheckName(other.Name);
         }
+
+        public override bool Equals(object obj) {
+            return Equals(obj as RoomPriority);
+        }
+
 
         public override int GetHashCode() {
             return Name?.GetHashCode() ?? 0;

--- a/src/RevitDeclarations/Models/Priorities/RoomPriority.cs
+++ b/src/RevitDeclarations/Models/Priorities/RoomPriority.cs
@@ -24,10 +24,7 @@ namespace RevitDeclarations.Models {
         public int MaxRoomAmount { get; set; }
 
         public bool CheckName(string name) {
-            if(string.Equals(name, Name, StringComparison.OrdinalIgnoreCase)) {
-                return true;
-            }
-            return false;
+            return string.Equals(name, Name, StringComparison.OrdinalIgnoreCase);
         }
 
         public bool Equals(RoomPriority other) {

--- a/src/RevitDeclarations/Models/RevitRepository.cs
+++ b/src/RevitDeclarations/Models/RevitRepository.cs
@@ -87,6 +87,24 @@ namespace RevitDeclarations.Models {
                 .ToList();
         }
 
+        public IReadOnlyCollection<CurveElement> GetRoomSeparationLinesOnPhase(Document document, Phase phase) {
+            List<ElementOnPhaseStatus> statuses = new List<ElementOnPhaseStatus>() {
+                ElementOnPhaseStatus.Existing,
+                ElementOnPhaseStatus.Demolished,
+                ElementOnPhaseStatus.New,
+                ElementOnPhaseStatus.Temporary
+            };
+
+            ElementPhaseStatusFilter phaseFilter = new ElementPhaseStatusFilter(phase.Id, statuses);
+
+            return new FilteredElementCollector(document)
+                .WhereElementIsNotElementType()
+                .OfCategory(BuiltInCategory.OST_RoomSeparationLines)
+                .WherePasses(phaseFilter)
+                .OfType<CurveElement>()
+                .ToList();
+        }
+
         public IReadOnlyCollection<FamilyInstance> GetBathInstancesOnPhase(Document document, Phase phase) {
             ElementCategoryFilter notDoorsFilter = new ElementCategoryFilter(BuiltInCategory.OST_Doors, true);
             ElementCategoryFilter notWindowsFilter = new ElementCategoryFilter(BuiltInCategory.OST_Windows, true);

--- a/src/RevitDeclarations/Models/RevitRepository.cs
+++ b/src/RevitDeclarations/Models/RevitRepository.cs
@@ -12,6 +12,13 @@ using RevitDeclarations.ViewModels;
 
 namespace RevitDeclarations.Models {
     internal class RevitRepository {
+        private readonly List<ElementOnPhaseStatus> _statuses = new List<ElementOnPhaseStatus>() {
+                ElementOnPhaseStatus.Existing,
+                ElementOnPhaseStatus.Demolished,
+                ElementOnPhaseStatus.New,
+                ElementOnPhaseStatus.Temporary
+            };
+
         public RevitRepository(UIApplication uiApplication) {
             UIApplication = uiApplication;
         }
@@ -69,7 +76,7 @@ namespace RevitDeclarations.Models {
         }
 
         public IReadOnlyCollection<FamilyInstance> GetDoorsOnPhase(Document document, Phase phase) {
-            ElementPhaseStatusFilter phaseFilter = GetPhaseFilter(phase);
+            var phaseFilter = new ElementPhaseStatusFilter(phase.Id, _statuses);
 
             return new FilteredElementCollector(document)
                 .OfCategory(BuiltInCategory.OST_Doors)
@@ -80,7 +87,7 @@ namespace RevitDeclarations.Models {
         }
 
         public IReadOnlyCollection<CurveElement> GetRoomSeparationLinesOnPhase(Document document, Phase phase) {
-            ElementPhaseStatusFilter phaseFilter = GetPhaseFilter(phase);
+            var phaseFilter = new ElementPhaseStatusFilter(phase.Id, _statuses);
 
             return new FilteredElementCollector(document)
                 .WhereElementIsNotElementType()
@@ -93,7 +100,7 @@ namespace RevitDeclarations.Models {
         public IReadOnlyCollection<FamilyInstance> GetBathInstancesOnPhase(Document document, Phase phase) {
             ElementCategoryFilter notDoorsFilter = new ElementCategoryFilter(BuiltInCategory.OST_Doors, true);
             ElementCategoryFilter notWindowsFilter = new ElementCategoryFilter(BuiltInCategory.OST_Windows, true);
-            ElementPhaseStatusFilter phaseFilter = GetPhaseFilter(phase);
+            var phaseFilter = new ElementPhaseStatusFilter(phase.Id, _statuses);
 
             /// Поиск семейств ванн и душевых кабин по наличию "ванна" или "душев" в имени семейства.
             /// Также исключается семейства с суффиксом "ова", например, заканчиваюищеся на "ованная"
@@ -147,17 +154,6 @@ namespace RevitDeclarations.Models {
                 .GetOrderedParameters()
                 .Where(x => x.StorageType == storageType)
                 .ToList();
-        }
-
-        private ElementPhaseStatusFilter GetPhaseFilter(Phase phase) {
-            List<ElementOnPhaseStatus> statuses = new List<ElementOnPhaseStatus>() {
-                ElementOnPhaseStatus.Existing,
-                ElementOnPhaseStatus.Demolished,
-                ElementOnPhaseStatus.New,
-                ElementOnPhaseStatus.Temporary
-            };
-
-            return new ElementPhaseStatusFilter(phase.Id, statuses);
         }
     }
 }

--- a/src/RevitDeclarations/Models/RoomConnectionAnalyzer.cs
+++ b/src/RevitDeclarations/Models/RoomConnectionAnalyzer.cs
@@ -14,16 +14,15 @@ namespace RevitDeclarations.Models {
         private readonly ApartmentsSettings _settings;
         private readonly PrioritiesConfig _priorities;
 
-        private readonly StringComparer _strComparer = StringComparer.OrdinalIgnoreCase;
-        private readonly StringComparison _strComparison = StringComparison.OrdinalIgnoreCase;
+        private readonly BuiltInParameter _bltNameParam = BuiltInParameter.ROOM_NAME;
 
 
-        // Гардеробные с дверью в жилую комнату. Для УТП Гардеробная
-        private IEnumerable<ElementId> _pantriesWithBedroom;
         // Мастер-спальни 
         private IEnumerable<ElementId> _masterBedrooms;
         // Санузлы, относящиеся к мастер спальням
         private IEnumerable<ElementId> _masterBathrooms;
+        // Гардеробные с дверью (разделителем) в жилую комнату. Для УТП Гардеробная
+        private IEnumerable<ElementId> _pantriesWithBedroom;
 
         public RoomConnectionAnalyzer(ApartmentsProject project, ApartmentsSettings settings) {
             _project = project;
@@ -45,32 +44,33 @@ namespace RevitDeclarations.Models {
         }
 
         public void FindConnections() {
+            // Словарь с жилыми комнатами, соединенными с СУ и этими СУ
             var bedroomBathroom = GetRoomsByDoors(_priorities.LivingRoom, _priorities.Bathroom);
             // Жилые комнаты, соединенные с санузлами
-            List<ElementId> bedroomsWithBathroom = bedroomBathroom[_priorities.LivingRoom.Name];
+            List<ElementId> bedroomsWithBathroom = bedroomBathroom[_priorities.LivingRoom];
 
             var pantryBedroom = GetRoomsByDoors(_priorities.Pantry, _priorities.LivingRoom);
             var pantryBathroom = GetRoomsByDoors(_priorities.Pantry, _priorities.Bathroom);
             // Гардеробные, соединенные с жилыми комнатами (не учитываются для УТП Гардеробная)
-            _pantriesWithBedroom = pantryBedroom[_priorities.Pantry.Name];
+            _pantriesWithBedroom = pantryBedroom[_priorities.Pantry];
             // Гардеробные, соединенные с санузлами
-            List<ElementId> pantriesWithBathroom = pantryBathroom[_priorities.Pantry.Name];
+            List<ElementId> pantriesWithBathroom = pantryBathroom[_priorities.Pantry];
             // Мастер-гардеробные (имеющие дверь в санузел) для определения мастер-спален
             List<ElementId> masterPantries = _pantriesWithBedroom.Intersect(pantriesWithBathroom).ToList();
 
             var bedroomPantry = GetRoomsByDoors(_priorities.LivingRoom, masterPantries);
             // Жилые комнаты, соединенные с мастер-гардеробными
-            var bedroomsWithPantryAndBathroom = bedroomPantry[_priorities.LivingRoom.Name];
+            var bedroomsWithPantryAndBathroom = bedroomPantry[_priorities.LivingRoom];
 
             // Итоговый список мастер-спален
             _masterBedrooms = bedroomsWithBathroom
                 .Concat(bedroomsWithPantryAndBathroom)
                 .ToList();
 
-            List<ElementId> bathroomsWithBedroom = bedroomBathroom[_priorities.Bathroom.Name];
+            List<ElementId> bathroomsWithBedroom = bedroomBathroom[_priorities.Bathroom];
             var bathroomPantry = GetRoomsByDoors(_priorities.Bathroom, masterPantries);
             // Санузлы, соединенные с мастер-гардеробными
-            var bathroomsWithMasterPantry = bathroomPantry[_priorities.Bathroom.Name];
+            var bathroomsWithMasterPantry = bathroomPantry[_priorities.Bathroom];
 
             // Санузлы, относящиеся к мастер-спальням для определение УТП Две ванны
             _masterBathrooms = bathroomsWithBedroom
@@ -78,15 +78,12 @@ namespace RevitDeclarations.Models {
                 .ToList();
         }
 
-        private Dictionary<string, List<ElementId>> GetRoomsByDoors(RoomPriority priority1, RoomPriority priority2) {
-            string name1 = priority1.Name;
-            string name2 = priority2.Name;
-            BuiltInParameter bltParam = BuiltInParameter.ROOM_NAME;
+        private Dictionary<RoomPriority, List<ElementId>> GetRoomsByDoors(RoomPriority priority1, RoomPriority priority2) {
             IReadOnlyCollection<FamilyInstance> doors = _project.GetDoors();
 
-            Dictionary<string, List<ElementId>> roomByNames = new Dictionary<string, List<ElementId>>(_strComparer) {
-                [name1] = new List<ElementId>(),
-                [name2] = new List<ElementId>()
+            var roomByNames = new Dictionary<RoomPriority, List<ElementId>>() {
+                [priority1] = new List<ElementId>(),
+                [priority2] = new List<ElementId>()
             };
 
             foreach(var door in doors) {
@@ -94,19 +91,17 @@ namespace RevitDeclarations.Models {
                 Room room2 = door.get_ToRoom(_project.Phase);
                 // У дверей может не быть помещения с одной стороны
                 if(room1 != null && room2 != null) {
-                    string roomName1 = room1.get_Parameter(bltParam).AsString().ToLower();
-                    string roomName2 = room2.get_Parameter(bltParam).AsString().ToLower();
+                    string roomName1 = room1.get_Parameter(_bltNameParam).AsString();
+                    string roomName2 = room2.get_Parameter(_bltNameParam).AsString();
 
-                    if(string.Equals(roomName1, name1, _strComparison) &&
-                       string.Equals(roomName2, name2, _strComparison)) {
-                        roomByNames[name1].Add(room1.Id);
-                        roomByNames[name2].Add(room2.Id);
+                    if(priority1.CheckName(roomName1) && priority2.CheckName(roomName2)) {
+                        roomByNames[priority1].Add(room1.Id);
+                        roomByNames[priority2].Add(room2.Id);
                     }
 
-                    if(string.Equals(roomName1, name2, _strComparison) &&
-                       string.Equals(roomName2, name1, _strComparison)) {
-                        roomByNames[name1].Add(room2.Id);
-                        roomByNames[name2].Add(room1.Id);
+                    if(priority1.CheckName(roomName2) && priority2.CheckName(roomName1)) {
+                        roomByNames[priority1].Add(room2.Id);
+                        roomByNames[priority2].Add(room1.Id);
                     }
                 }
             }
@@ -114,13 +109,11 @@ namespace RevitDeclarations.Models {
             return roomByNames;
         }
 
-        private Dictionary<string, List<ElementId>> GetRoomsByDoors(RoomPriority priority1, List<ElementId> rooms) {
-            string name1 = priority1.Name;
-            BuiltInParameter bltParam = BuiltInParameter.ROOM_NAME;
+        private Dictionary<RoomPriority, List<ElementId>> GetRoomsByDoors(RoomPriority priority, List<ElementId> rooms) {
             IReadOnlyCollection<FamilyInstance> doors = _project.GetDoors();
 
-            Dictionary<string, List<ElementId>> roomByNames = new Dictionary<string, List<ElementId>>(_strComparer) {
-                [name1] = new List<ElementId>(),
+            var roomByNames = new Dictionary<RoomPriority, List<ElementId>>() {
+                [priority] = new List<ElementId>()
             };
 
             foreach(var door in doors) {
@@ -128,15 +121,15 @@ namespace RevitDeclarations.Models {
                 Room room2 = door.get_ToRoom(_project.Phase);
                 // У дверей может не быть помещения с одной стороны
                 if(room1 != null && room2 != null) {
-                    string roomName1 = room1.get_Parameter(bltParam).AsString().ToLower();
-                    string roomName2 = room2.get_Parameter(bltParam).AsString().ToLower();
+                    string roomName1 = room1.get_Parameter(_bltNameParam).AsString();
+                    string roomName2 = room2.get_Parameter(_bltNameParam).AsString();
 
-                    if(string.Equals(roomName1, name1, _strComparison) && rooms.Contains(room2.Id)) {
-                        roomByNames[name1].Add(room1.Id);
+                    if(priority.CheckName(roomName1) && rooms.Contains(room2.Id)) {
+                        roomByNames[priority].Add(room1.Id);
                     }
 
-                    if(string.Equals(roomName2, name1, _strComparison) && rooms.Contains(room1.Id)) {
-                        roomByNames[name1].Add(room2.Id);
+                    if(priority.CheckName(roomName2) && rooms.Contains(room1.Id)) {
+                        roomByNames[priority].Add(room2.Id);
                     }
                 }
             }

--- a/src/RevitDeclarations/Models/RoomConnectionAnalyzer.cs
+++ b/src/RevitDeclarations/Models/RoomConnectionAnalyzer.cs
@@ -1,11 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Runtime;
 
-using Autodesk.Revit.DB.Architecture;
 using Autodesk.Revit.DB;
 
 namespace RevitDeclarations.Models {
@@ -15,11 +11,11 @@ namespace RevitDeclarations.Models {
         private readonly PrioritiesConfig _priorities;
 
         // Мастер-спальни 
-        private IEnumerable<ElementId> _masterBedrooms;
+        private IEnumerable<ElementId> _masterBedrooms = new List<ElementId>();
         // Санузлы, относящиеся к мастер спальням
-        private IEnumerable<ElementId> _masterBathrooms;
+        private IEnumerable<ElementId> _masterBathrooms = new List<ElementId>();
         // Гардеробные с дверью (разделителем) в жилую комнату. Для УТП Гардеробная
-        private IEnumerable<ElementId> _pantriesWithBedroom;
+        private IEnumerable<ElementId> _pantriesWithBedroom = new List<ElementId>();
 
         public RoomConnectionAnalyzer(ApartmentsProject project, ApartmentsSettings settings) {
             _project = project;

--- a/src/RevitDeclarations/Models/RoomConnectionAnalyzer.cs
+++ b/src/RevitDeclarations/Models/RoomConnectionAnalyzer.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime;
 
 using Autodesk.Revit.DB.Architecture;
 using Autodesk.Revit.DB;
-using System.Runtime;
 
 namespace RevitDeclarations.Models {
     internal class RoomConnectionAnalyzer {
@@ -44,13 +44,15 @@ namespace RevitDeclarations.Models {
         }
 
         public void FindConnections() {
+            IReadOnlyCollection<FamilyInstance> doors = _project.GetDoors();
+
             // Словарь с жилыми комнатами, соединенными с СУ и этими СУ
-            var bedroomBathroom = GetRoomsByDoors(_priorities.LivingRoom, _priorities.Bathroom);
+            var bedroomBathroom = GetRoomsByDoors(doors, _priorities.LivingRoom, _priorities.Bathroom);
             // Жилые комнаты, соединенные с санузлами
             List<ElementId> bedroomsWithBathroom = bedroomBathroom[_priorities.LivingRoom];
 
-            var pantryBedroom = GetRoomsByDoors(_priorities.Pantry, _priorities.LivingRoom);
-            var pantryBathroom = GetRoomsByDoors(_priorities.Pantry, _priorities.Bathroom);
+            var pantryBedroom = GetRoomsByDoors(doors, _priorities.Pantry, _priorities.LivingRoom);
+            var pantryBathroom = GetRoomsByDoors(doors, _priorities.Pantry, _priorities.Bathroom);
             // Гардеробные, соединенные с жилыми комнатами (не учитываются для УТП Гардеробная)
             _pantriesWithBedroom = pantryBedroom[_priorities.Pantry];
             // Гардеробные, соединенные с санузлами
@@ -58,7 +60,7 @@ namespace RevitDeclarations.Models {
             // Мастер-гардеробные (имеющие дверь в санузел) для определения мастер-спален
             List<ElementId> masterPantries = _pantriesWithBedroom.Intersect(pantriesWithBathroom).ToList();
 
-            var bedroomPantry = GetRoomsByDoors(_priorities.LivingRoom, masterPantries);
+            var bedroomPantry = GetRoomsByDoors(doors, _priorities.LivingRoom, masterPantries);
             // Жилые комнаты, соединенные с мастер-гардеробными
             var bedroomsWithPantryAndBathroom = bedroomPantry[_priorities.LivingRoom];
 
@@ -68,7 +70,7 @@ namespace RevitDeclarations.Models {
                 .ToList();
 
             List<ElementId> bathroomsWithBedroom = bedroomBathroom[_priorities.Bathroom];
-            var bathroomPantry = GetRoomsByDoors(_priorities.Bathroom, masterPantries);
+            var bathroomPantry = GetRoomsByDoors(doors, _priorities.Bathroom, masterPantries);
             // Санузлы, соединенные с мастер-гардеробными
             var bathroomsWithMasterPantry = bathroomPantry[_priorities.Bathroom];
 
@@ -78,9 +80,9 @@ namespace RevitDeclarations.Models {
                 .ToList();
         }
 
-        private Dictionary<RoomPriority, List<ElementId>> GetRoomsByDoors(RoomPriority priority1, RoomPriority priority2) {
-            IReadOnlyCollection<FamilyInstance> doors = _project.GetDoors();
-
+        private Dictionary<RoomPriority, List<ElementId>> GetRoomsByDoors(IReadOnlyCollection<FamilyInstance> doors, 
+                                                                          RoomPriority priority1, 
+                                                                          RoomPriority priority2) {
             var roomByNames = new Dictionary<RoomPriority, List<ElementId>>() {
                 [priority1] = new List<ElementId>(),
                 [priority2] = new List<ElementId>()
@@ -109,9 +111,9 @@ namespace RevitDeclarations.Models {
             return roomByNames;
         }
 
-        private Dictionary<RoomPriority, List<ElementId>> GetRoomsByDoors(RoomPriority priority, List<ElementId> rooms) {
-            IReadOnlyCollection<FamilyInstance> doors = _project.GetDoors();
-
+        private Dictionary<RoomPriority, List<ElementId>> GetRoomsByDoors(IReadOnlyCollection<FamilyInstance> doors, 
+                                                                          RoomPriority priority, 
+                                                                          List<ElementId> rooms) {
             var roomByNames = new Dictionary<RoomPriority, List<ElementId>>() {
                 [priority] = new List<ElementId>()
             };
@@ -137,9 +139,9 @@ namespace RevitDeclarations.Models {
             return roomByNames;
         }
 
-        //private Dictionary<string, List<ElementId>> GetRoomsBySeparators(RoomPriority priority1,
-        //                                                                 RoomPriority priority2) {
+        private Dictionary<string, List<ElementId>> GetRoomsBySeparators(RoomPriority priority1,
+                                                                         RoomPriority priority2) {
 
-        //}
+        }
     }
 }

--- a/src/RevitDeclarations/Models/RoomConnectionAnalyzer.cs
+++ b/src/RevitDeclarations/Models/RoomConnectionAnalyzer.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Autodesk.Revit.DB.Architecture;
+using Autodesk.Revit.DB;
+using System.Runtime;
+
+namespace RevitDeclarations.Models {
+    internal class RoomConnectionAnalyzer {
+        private readonly ApartmentsProject _project;
+        private readonly ApartmentsSettings _settings;
+        private readonly PrioritiesConfig _priorities;
+
+        private readonly StringComparer _strComparer = StringComparer.OrdinalIgnoreCase;
+        private readonly StringComparison _strComparison = StringComparison.OrdinalIgnoreCase;
+
+
+        // Гардеробные с дверью в жилую комнату. Для УТП Гардеробная
+        private IEnumerable<ElementId> _pantriesWithBedroom;
+        // Мастер-спальни 
+        private IEnumerable<ElementId> _masterBedrooms;
+        // Санузлы, относящиеся к мастер спальням
+        private IEnumerable<ElementId> _masterBathrooms;
+
+        public RoomConnectionAnalyzer(ApartmentsProject project, ApartmentsSettings settings) {
+            _project = project;
+            _settings = settings;
+
+            _priorities = _settings.PrioritiesConfig;
+        }
+
+        public bool CheckIsMasterBathroom(ElementId roomId) {
+            return _masterBathrooms.Contains(roomId);
+        }
+
+        public bool CheckIsMasterBedroom(ElementId roomId) {
+            return _masterBedrooms.Contains(roomId);
+        }
+
+        public bool CheckIsPantryWithBedroom(ElementId roomId) {
+            return _pantriesWithBedroom.Contains(roomId);
+        }
+
+        public void FindConnections() {
+            var bedroomBathroom = GetRoomsByDoors(_priorities.LivingRoom, _priorities.Bathroom);
+            // Жилые комнаты, соединенные с санузлами
+            List<ElementId> bedroomsWithBathroom = bedroomBathroom[_priorities.LivingRoom.Name];
+
+            var pantryBedroom = GetRoomsByDoors(_priorities.Pantry, _priorities.LivingRoom);
+            var pantryBathroom = GetRoomsByDoors(_priorities.Pantry, _priorities.Bathroom);
+            // Гардеробные, соединенные с жилыми комнатами (не учитываются для УТП Гардеробная)
+            _pantriesWithBedroom = pantryBedroom[_priorities.Pantry.Name];
+            // Гардеробные, соединенные с санузлами
+            List<ElementId> pantriesWithBathroom = pantryBathroom[_priorities.Pantry.Name];
+            // Мастер-гардеробные (имеющие дверь в санузел) для определения мастер-спален
+            List<ElementId> masterPantries = _pantriesWithBedroom.Intersect(pantriesWithBathroom).ToList();
+
+            var bedroomPantry = GetRoomsByDoors(_priorities.LivingRoom, masterPantries);
+            // Жилые комнаты, соединенные с мастер-гардеробными
+            var bedroomsWithPantryAndBathroom = bedroomPantry[_priorities.LivingRoom.Name];
+
+            // Итоговый список мастер-спален
+            _masterBedrooms = bedroomsWithBathroom
+                .Concat(bedroomsWithPantryAndBathroom)
+                .ToList();
+
+            List<ElementId> bathroomsWithBedroom = bedroomBathroom[_priorities.Bathroom.Name];
+            var bathroomPantry = GetRoomsByDoors(_priorities.Bathroom, masterPantries);
+            // Санузлы, соединенные с мастер-гардеробными
+            var bathroomsWithMasterPantry = bathroomPantry[_priorities.Bathroom.Name];
+
+            // Санузлы, относящиеся к мастер-спальням для определение УТП Две ванны
+            _masterBathrooms = bathroomsWithBedroom
+                .Concat(bathroomsWithMasterPantry)
+                .ToList();
+        }
+
+        private Dictionary<string, List<ElementId>> GetRoomsByDoors(RoomPriority priority1, RoomPriority priority2) {
+            string name1 = priority1.Name;
+            string name2 = priority2.Name;
+            BuiltInParameter bltParam = BuiltInParameter.ROOM_NAME;
+            IReadOnlyCollection<FamilyInstance> doors = _project.GetDoors();
+
+            Dictionary<string, List<ElementId>> roomByNames = new Dictionary<string, List<ElementId>>(_strComparer) {
+                [name1] = new List<ElementId>(),
+                [name2] = new List<ElementId>()
+            };
+
+            foreach(var door in doors) {
+                Room room1 = door.get_FromRoom(_project.Phase);
+                Room room2 = door.get_ToRoom(_project.Phase);
+                // У дверей может не быть помещения с одной стороны
+                if(room1 != null && room2 != null) {
+                    string roomName1 = room1.get_Parameter(bltParam).AsString().ToLower();
+                    string roomName2 = room2.get_Parameter(bltParam).AsString().ToLower();
+
+                    if(string.Equals(roomName1, name1, _strComparison) &&
+                       string.Equals(roomName2, name2, _strComparison)) {
+                        roomByNames[name1].Add(room1.Id);
+                        roomByNames[name2].Add(room2.Id);
+                    }
+
+                    if(string.Equals(roomName1, name2, _strComparison) &&
+                       string.Equals(roomName2, name1, _strComparison)) {
+                        roomByNames[name1].Add(room2.Id);
+                        roomByNames[name2].Add(room1.Id);
+                    }
+                }
+            }
+
+            return roomByNames;
+        }
+
+        private Dictionary<string, List<ElementId>> GetRoomsByDoors(RoomPriority priority1, List<ElementId> rooms) {
+            string name1 = priority1.Name;
+            BuiltInParameter bltParam = BuiltInParameter.ROOM_NAME;
+            IReadOnlyCollection<FamilyInstance> doors = _project.GetDoors();
+
+            Dictionary<string, List<ElementId>> roomByNames = new Dictionary<string, List<ElementId>>(_strComparer) {
+                [name1] = new List<ElementId>(),
+            };
+
+            foreach(var door in doors) {
+                Room room1 = door.get_FromRoom(_project.Phase);
+                Room room2 = door.get_ToRoom(_project.Phase);
+                // У дверей может не быть помещения с одной стороны
+                if(room1 != null && room2 != null) {
+                    string roomName1 = room1.get_Parameter(bltParam).AsString().ToLower();
+                    string roomName2 = room2.get_Parameter(bltParam).AsString().ToLower();
+
+                    if(string.Equals(roomName1, name1, _strComparison) && rooms.Contains(room2.Id)) {
+                        roomByNames[name1].Add(room1.Id);
+                    }
+
+                    if(string.Equals(roomName2, name1, _strComparison) && rooms.Contains(room1.Id)) {
+                        roomByNames[name1].Add(room2.Id);
+                    }
+                }
+            }
+
+            return roomByNames;
+        }
+
+        //private Dictionary<string, List<ElementId>> GetRoomsBySeparators(RoomPriority priority1,
+        //                                                                 RoomPriority priority2) {
+
+        //}
+    }
+}

--- a/src/RevitDeclarations/Models/RoomConnectionAnalyzer.cs
+++ b/src/RevitDeclarations/Models/RoomConnectionAnalyzer.cs
@@ -14,9 +14,6 @@ namespace RevitDeclarations.Models {
         private readonly ApartmentsSettings _settings;
         private readonly PrioritiesConfig _priorities;
 
-        private readonly BuiltInParameter _bltNameParam = BuiltInParameter.ROOM_NAME;
-
-
         // Мастер-спальни 
         private IEnumerable<ElementId> _masterBedrooms;
         // Санузлы, относящиеся к мастер спальням
@@ -44,23 +41,34 @@ namespace RevitDeclarations.Models {
         }
 
         public void FindConnections() {
-            IReadOnlyCollection<FamilyInstance> doors = _project.GetDoors();
+            IEnumerable<RoomSeparator> doorSeparators = _project
+                .GetDoors()
+                .Select(x => new FamInstanceRoomSeparator(_project, x));
+
+            IEnumerable<RoomSeparator> curveSeparators = _project
+                .GetCurveSeparators()
+                .Select(x => new CurveRoomSeparator(_project, x));
+
+            IEnumerable<RoomSeparator> separators = doorSeparators
+                .Concat(curveSeparators)
+                .Where(x => x.CheckIsValid());
 
             // Словарь с жилыми комнатами, соединенными с СУ и этими СУ
-            var bedroomBathroom = GetRoomsByDoors(doors, _priorities.LivingRoom, _priorities.Bathroom);
+            var bedroomBathroom = GetRoomsBySeparators(separators, _priorities.LivingRoom, _priorities.Bathroom);
             // Жилые комнаты, соединенные с санузлами
             List<ElementId> bedroomsWithBathroom = bedroomBathroom[_priorities.LivingRoom];
 
-            var pantryBedroom = GetRoomsByDoors(doors, _priorities.Pantry, _priorities.LivingRoom);
-            var pantryBathroom = GetRoomsByDoors(doors, _priorities.Pantry, _priorities.Bathroom);
+            var pantryBedroom = GetRoomsBySeparators(separators, _priorities.Pantry, _priorities.LivingRoom);
+            var pantryBathroom = GetRoomsBySeparators(separators, _priorities.Pantry, _priorities.Bathroom);
             // Гардеробные, соединенные с жилыми комнатами (не учитываются для УТП Гардеробная)
             _pantriesWithBedroom = pantryBedroom[_priorities.Pantry];
             // Гардеробные, соединенные с санузлами
             List<ElementId> pantriesWithBathroom = pantryBathroom[_priorities.Pantry];
+
             // Мастер-гардеробные (имеющие дверь в санузел) для определения мастер-спален
             List<ElementId> masterPantries = _pantriesWithBedroom.Intersect(pantriesWithBathroom).ToList();
 
-            var bedroomPantry = GetRoomsByDoors(doors, _priorities.LivingRoom, masterPantries);
+            var bedroomPantry = GetRoomsBySeparators(separators, _priorities.LivingRoom, masterPantries);
             // Жилые комнаты, соединенные с мастер-гардеробными
             var bedroomsWithPantryAndBathroom = bedroomPantry[_priorities.LivingRoom];
 
@@ -70,7 +78,7 @@ namespace RevitDeclarations.Models {
                 .ToList();
 
             List<ElementId> bathroomsWithBedroom = bedroomBathroom[_priorities.Bathroom];
-            var bathroomPantry = GetRoomsByDoors(doors, _priorities.Bathroom, masterPantries);
+            var bathroomPantry = GetRoomsBySeparators(separators, _priorities.Bathroom, masterPantries);
             // Санузлы, соединенные с мастер-гардеробными
             var bathroomsWithMasterPantry = bathroomPantry[_priorities.Bathroom];
 
@@ -80,68 +88,43 @@ namespace RevitDeclarations.Models {
                 .ToList();
         }
 
-        private Dictionary<RoomPriority, List<ElementId>> GetRoomsByDoors(IReadOnlyCollection<FamilyInstance> doors, 
-                                                                          RoomPriority priority1, 
-                                                                          RoomPriority priority2) {
+        private Dictionary<RoomPriority, List<ElementId>> GetRoomsBySeparators(IEnumerable<RoomSeparator> separators, 
+                                                                               RoomPriority priority1, 
+                                                                               RoomPriority priority2) {
             var roomByNames = new Dictionary<RoomPriority, List<ElementId>>() {
                 [priority1] = new List<ElementId>(),
                 [priority2] = new List<ElementId>()
             };
 
-            foreach(var door in doors) {
-                Room room1 = door.get_FromRoom(_project.Phase);
-                Room room2 = door.get_ToRoom(_project.Phase);
-                // У дверей может не быть помещения с одной стороны
+            foreach(var separator in separators) {                
+                var room1 = separator.GetRoom(priority1);
+                var room2 = separator.GetRoom(priority2);
                 if(room1 != null && room2 != null) {
-                    string roomName1 = room1.get_Parameter(_bltNameParam).AsString();
-                    string roomName2 = room2.get_Parameter(_bltNameParam).AsString();
-
-                    if(priority1.CheckName(roomName1) && priority2.CheckName(roomName2)) {
-                        roomByNames[priority1].Add(room1.Id);
-                        roomByNames[priority2].Add(room2.Id);
-                    }
-
-                    if(priority1.CheckName(roomName2) && priority2.CheckName(roomName1)) {
-                        roomByNames[priority1].Add(room2.Id);
-                        roomByNames[priority2].Add(room1.Id);
-                    }
+                    roomByNames[priority1].Add(room1.Id);
+                    roomByNames[priority2].Add(room2.Id);
                 }
             }
 
             return roomByNames;
         }
 
-        private Dictionary<RoomPriority, List<ElementId>> GetRoomsByDoors(IReadOnlyCollection<FamilyInstance> doors, 
-                                                                          RoomPriority priority, 
-                                                                          List<ElementId> rooms) {
+        private Dictionary<RoomPriority, List<ElementId>> GetRoomsBySeparators(IEnumerable<RoomSeparator> separators, 
+                                                                               RoomPriority priority, 
+                                                                               List<ElementId> rooms) {
             var roomByNames = new Dictionary<RoomPriority, List<ElementId>>() {
                 [priority] = new List<ElementId>()
             };
 
-            foreach(var door in doors) {
-                Room room1 = door.get_FromRoom(_project.Phase);
-                Room room2 = door.get_ToRoom(_project.Phase);
-                // У дверей может не быть помещения с одной стороны
-                if(room1 != null && room2 != null) {
-                    string roomName1 = room1.get_Parameter(_bltNameParam).AsString();
-                    string roomName2 = room2.get_Parameter(_bltNameParam).AsString();
-
-                    if(priority.CheckName(roomName1) && rooms.Contains(room2.Id)) {
-                        roomByNames[priority].Add(room1.Id);
-                    }
-
-                    if(priority.CheckName(roomName2) && rooms.Contains(room1.Id)) {
-                        roomByNames[priority].Add(room2.Id);
+            foreach(var separator in separators) {
+                if(separator.Rooms.Where(x => rooms.Contains(x.Id)).Any()) {
+                    var room = separator.GetRoom(priority);
+                    if(room != null) {
+                        roomByNames[priority].Add(room.Id);
                     }
                 }
             }
 
             return roomByNames;
-        }
-
-        private Dictionary<string, List<ElementId>> GetRoomsBySeparators(RoomPriority priority1,
-                                                                         RoomPriority priority2) {
-
         }
     }
 }

--- a/src/RevitDeclarations/Models/RoomConnectionAnalyzer.cs
+++ b/src/RevitDeclarations/Models/RoomConnectionAnalyzer.cs
@@ -7,7 +7,6 @@ using Autodesk.Revit.DB;
 namespace RevitDeclarations.Models {
     internal class RoomConnectionAnalyzer {
         private readonly ApartmentsProject _project;
-        private readonly ApartmentsSettings _settings;
         private readonly PrioritiesConfig _priorities;
 
         // Мастер-спальни 
@@ -17,11 +16,9 @@ namespace RevitDeclarations.Models {
         // Гардеробные с дверью (разделителем) в жилую комнату. Для УТП Гардеробная
         private IEnumerable<ElementId> _pantriesWithBedroom = new List<ElementId>();
 
-        public RoomConnectionAnalyzer(ApartmentsProject project, ApartmentsSettings settings) {
+        public RoomConnectionAnalyzer(ApartmentsProject project, PrioritiesConfig priorities) {
             _project = project;
-            _settings = settings;
-
-            _priorities = _settings.PrioritiesConfig;
+            _priorities = priorities;
         }
 
         public bool CheckIsMasterBathroom(ElementId roomId) {
@@ -104,7 +101,7 @@ namespace RevitDeclarations.Models {
             return roomByNames;
         }
 
-        private Dictionary<RoomPriority, List<ElementId>> GetRoomsBySeparators(IEnumerable<RoomSeparator> separators, 
+        private Dictionary<RoomPriority, List<ElementId>> GetRoomsBySeparators(IEnumerable<RoomSeparator> separators,
                                                                                RoomPriority priority, 
                                                                                List<ElementId> rooms) {
             var roomByNames = new Dictionary<RoomPriority, List<ElementId>>() {

--- a/src/RevitDeclarations/Models/Rooms/RoomElement.cs
+++ b/src/RevitDeclarations/Models/Rooms/RoomElement.cs
@@ -5,7 +5,6 @@ using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Architecture;
 
 using dosymep.Bim4Everyone;
-using dosymep.Bim4Everyone.SharedParams;
 using dosymep.Revit;
 
 using pyRevitLabs.Json;

--- a/src/RevitDeclarations/Models/Rooms/RoomElement.cs
+++ b/src/RevitDeclarations/Models/Rooms/RoomElement.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Architecture;
 
@@ -77,6 +80,13 @@ namespace RevitDeclarations.Models
 
         public int GetIntParamValue(Parameter parameter) {
             return RevitRoom.GetParamValueOrDefault<int>(parameter.Definition.Name);
+        }
+
+        public IReadOnlyList<ElementId> GetBoundaries() {
+            return _revitRoom.GetBoundarySegments(SpatialElementExtensions.DefaultBoundaryOptions)
+                .SelectMany(item => item)
+                .Select(item => item.ElementId)
+                .ToList();
         }
     }
 }

--- a/src/RevitDeclarations/Models/Rooms/Separators/CurveRoomSeparator.cs
+++ b/src/RevitDeclarations/Models/Rooms/Separators/CurveRoomSeparator.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+
+using dosymep.Revit;
+
+namespace RevitDeclarations.Models {
+    internal class CurveRoomSeparator : RoomSeparator {
+        private readonly CurveElement _curve;
+
+        public CurveRoomSeparator(ApartmentsProject project, CurveElement curve) {
+            _curve = curve;
+
+            foreach(var room in project.Rooms) {
+                AddRoom(room);
+            }
+        }
+
+        private void AddRoom(RoomElement room) {
+            if(room.GetBoundaries().Contains(_curve.Id)) {
+                Rooms.Add(room.RevitRoom);
+            }
+        }
+    }
+}

--- a/src/RevitDeclarations/Models/Rooms/Separators/CurveRoomSeparator.cs
+++ b/src/RevitDeclarations/Models/Rooms/Separators/CurveRoomSeparator.cs
@@ -1,13 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 using Autodesk.Revit.DB;
-using Autodesk.Revit.DB.Architecture;
-
-using dosymep.Revit;
 
 namespace RevitDeclarations.Models {
     internal class CurveRoomSeparator : RoomSeparator {

--- a/src/RevitDeclarations/Models/Rooms/Separators/FamInstanceRoomSeparator.cs
+++ b/src/RevitDeclarations/Models/Rooms/Separators/FamInstanceRoomSeparator.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+
+namespace RevitDeclarations.Models {
+    internal class FamInstanceRoomSeparator : RoomSeparator {
+        private readonly ApartmentsProject _project;
+
+        public FamInstanceRoomSeparator(ApartmentsProject project, FamilyInstance door) {
+            _project = project;
+
+            AddRoom(door.get_FromRoom(_project.Phase));
+            AddRoom(door.get_ToRoom(_project.Phase));
+        }
+
+        private void AddRoom(Room room) {
+            // У дверей может не быть помещения с одной стороны
+            if(room != null) {
+                Rooms.Add(room);
+            }
+        }
+    }
+}

--- a/src/RevitDeclarations/Models/Rooms/Separators/FamInstanceRoomSeparator.cs
+++ b/src/RevitDeclarations/Models/Rooms/Separators/FamInstanceRoomSeparator.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Architecture;

--- a/src/RevitDeclarations/Models/Rooms/Separators/RoomSeparator.cs
+++ b/src/RevitDeclarations/Models/Rooms/Separators/RoomSeparator.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+
+using dosymep.Bim4Everyone;
+using dosymep.Revit;
+
+namespace RevitDeclarations.Models {
+    internal abstract class RoomSeparator {
+        private readonly BuiltInParameter _bltNameParam = BuiltInParameter.ROOM_NAME;
+
+        public List<Room> Rooms { get; set; } = new List<Room>();
+
+        public bool CheckIsValid() {
+            return Rooms.Count > 1;
+        }
+
+        public Room GetRoom(RoomPriority priority1) {
+            return Rooms
+                .Where(x => priority1.CheckName(x.GetParamValue<string>(_bltNameParam)))
+                .FirstOrDefault();
+        }
+    }
+}

--- a/src/RevitDeclarations/Models/Rooms/Separators/RoomSeparator.cs
+++ b/src/RevitDeclarations/Models/Rooms/Separators/RoomSeparator.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Architecture;
@@ -12,17 +10,15 @@ using dosymep.Revit;
 
 namespace RevitDeclarations.Models {
     internal abstract class RoomSeparator {
-        private readonly BuiltInParameter _bltNameParam = BuiltInParameter.ROOM_NAME;
-
         public List<Room> Rooms { get; set; } = new List<Room>();
 
         public bool CheckIsValid() {
             return Rooms.Count > 1;
         }
 
-        public Room GetRoom(RoomPriority priority1) {
+        public Room GetRoom(RoomPriority priority) {
             return Rooms
-                .Where(x => priority1.CheckName(x.GetParamValue<string>(_bltNameParam)))
+                .Where(x => priority.CheckName(x.GetParamValue<string>(BuiltInParameter.ROOM_NAME)))
                 .FirstOrDefault();
         }
     }

--- a/src/RevitDeclarations/Models/UtpCalculator.cs
+++ b/src/RevitDeclarations/Models/UtpCalculator.cs
@@ -36,7 +36,7 @@ namespace RevitDeclarations.Models {
 
             _priorities = _settings.PrioritiesConfig;
 
-            _roomConnectionAnalyzer = new RoomConnectionAnalyzer(project, _settings);
+            _roomConnectionAnalyzer = new RoomConnectionAnalyzer(project, _priorities);
         }
 
         public void CalculateRoomsForUtp() {

--- a/src/RevitDeclarations/Models/UtpCalculator.cs
+++ b/src/RevitDeclarations/Models/UtpCalculator.cs
@@ -60,16 +60,23 @@ namespace RevitDeclarations.Models {
             List<ElementId> masterPantries = _pantriesWithBedroom.Intersect(pantriesWithBathroom).ToList();
 
             var bedroomPantry = GetRoomsByDoors(_priorities.LivingRoom, masterPantries);
-            // Жилые комнаты, соединенные с мастер-гврдеробными
+            // Жилые комнаты, соединенные с мастер-гардеробными
             var bedroomsWithPantryAndBathroom = bedroomPantry[_priorities.LivingRoom.Name];
-            _masterBedrooms = bedroomsWithBathroom.Concat(bedroomsWithPantryAndBathroom).ToList();
+
+            // Итоговый список мастер-спален
+            _masterBedrooms = bedroomsWithBathroom
+                .Concat(bedroomsWithPantryAndBathroom)
+                .ToList();
 
             List<ElementId> bathroomsWithBedroom = bedroomBathroom[_priorities.Bathroom.Name];
             var bathroomPantry = GetRoomsByDoors(_priorities.Bathroom, masterPantries);
             // Санузлы, соединенные с мастер-гардеробными
             var bathroomsWithMasterPantry = bathroomPantry[_priorities.Bathroom.Name];
+
             // Санузлы, относящиеся к мастер-спальням для определение УТП Две ванны
-            _masterBathrooms = bathroomsWithBedroom.Concat(bathroomsWithMasterPantry).ToList();
+            _masterBathrooms = bathroomsWithBedroom
+                .Concat(bathroomsWithMasterPantry)
+                .ToList();
         }
 
         public IReadOnlyCollection<ErrorsListViewModel> CheckProjectForUtp() {
@@ -346,6 +353,11 @@ namespace RevitDeclarations.Models {
             }
 
             return roomByNames;
+        }
+
+        private Dictionary<string, List<ElementId>> GetRoomsBySeparators(RoomPriority priority1, 
+                                                                         RoomPriority priority2) {
+
         }
 
         private IEnumerable<ElementId> GetRoomsWithBath() {

--- a/src/RevitDeclarations/Models/UtpCalculator.cs
+++ b/src/RevitDeclarations/Models/UtpCalculator.cs
@@ -236,7 +236,6 @@ namespace RevitDeclarations.Models {
             return "Нет";
         }
 
-
         private bool CheckUtpNullAreas() {
             return _project
                 .Rooms

--- a/src/RevitDeclarations/ViewModels/MainViewModels/ApartmentsMainVM.cs
+++ b/src/RevitDeclarations/ViewModels/MainViewModels/ApartmentsMainVM.cs
@@ -145,8 +145,8 @@ namespace RevitDeclarations.ViewModels {
             List<Apartment> apartments = projects
                 .SelectMany(x => x.RoomGroups)
                 .Cast<Apartment>()
-                .OrderBy(x => x.Section, _stringComparer)
-                .ThenBy(x => x.FullNumber, _stringComparer)
+                .OrderBy(x => x.Section ?? "", _stringComparer)
+                .ThenBy(x => x.FullNumber ?? "", _stringComparer)
                 .ToList();
 
             try {

--- a/src/RevitDeclarations/ViewModels/MainViewModels/CommercialMainVM.cs
+++ b/src/RevitDeclarations/ViewModels/MainViewModels/CommercialMainVM.cs
@@ -95,8 +95,8 @@ namespace RevitDeclarations.ViewModels {
             List<CommercialRooms> commercialRooms = projects
                 .SelectMany(x => x.RoomGroups)
                 .Cast<CommercialRooms>()
-                .OrderBy(x => x.Number, _stringComparer)
-                .ThenBy(x => x.Rooms.First().Number, _stringComparer)
+                .OrderBy(x => x.Number ?? "", _stringComparer)
+                .ThenBy(x => x.Rooms.First().Number ?? "", _stringComparer)
                 .ToList();
 
             _selectedFormat.Export(FullPath, commercialRooms);

--- a/src/RevitDeclarations/ViewModels/MainViewModels/PublicAreasMainVM.cs
+++ b/src/RevitDeclarations/ViewModels/MainViewModels/PublicAreasMainVM.cs
@@ -95,7 +95,7 @@ namespace RevitDeclarations.ViewModels {
             List<PublicArea> commercialRooms = projects
                 .SelectMany(x => x.RoomGroups)
                 .Cast<PublicArea>()
-                .OrderBy(x => x.Rooms.First().Number, _stringComparer)
+                .OrderBy(x => x.Rooms.First().Number ?? "", _stringComparer)
                 .ToList();
 
             try {


### PR DESCRIPTION
Для квартир при расчете УТП "Мастер-спальня" должно учитываться соединение спален и СУ.
В предыдущей версии учитывалось соединение помещений только через двери.
Теперь скрипт учитывает соединение помещений через линии разделителей помещений.