### PR TITLE
RevitOpeningPlacement: Добавлены столбцы в окно навигатора КР для входящих заданий

### DIFF
--- a/src/RevitOpeningPlacement/Models/Interfaces/IOpeningTaskHost.cs
+++ b/src/RevitOpeningPlacement/Models/Interfaces/IOpeningTaskHost.cs
@@ -1,0 +1,24 @@
+using Autodesk.Revit.DB;
+
+namespace RevitOpeningPlacement.Models.Interfaces {
+    /// <summary>
+    /// Хост входящего задания на отверстие - элемент из активного файла, 
+    /// в теле которого расположено входящее задание на отверстие из связанного файла с заданиями на отверстия.
+    /// </summary>
+    internal interface IOpeningTaskHost {
+        /// <summary>
+        /// Название хоста
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Id хоста
+        /// </summary>
+        ElementId Id { get; }
+
+        /// <summary>
+        /// Значение параметра хоста "обр_ФОП_Раздел проекта"
+        /// </summary>
+        string KrModelPart { get; }
+    }
+}

--- a/src/RevitOpeningPlacement/Models/Interfaces/IOpeningTaskIncomingForKrViewModel.cs
+++ b/src/RevitOpeningPlacement/Models/Interfaces/IOpeningTaskIncomingForKrViewModel.cs
@@ -40,5 +40,10 @@ namespace RevitOpeningPlacement.Models.Interfaces {
         /// Комментарий задания на отверстие
         /// </summary>
         string Comment { get; }
+
+        /// <summary>
+        /// Хост задания на отверстие из активного файла
+        /// </summary>
+        IOpeningTaskHost Host { get; }
     }
 }

--- a/src/RevitOpeningPlacement/OpeningModels/OpeningArTaskIncoming.cs
+++ b/src/RevitOpeningPlacement/OpeningModels/OpeningArTaskIncoming.cs
@@ -84,7 +84,7 @@ namespace RevitOpeningPlacement.OpeningModels {
 
         /// <summary>
         /// Статус входящего задания на отверстие от АР
-        /// <para>Для обновления использовать метод <see cref="UpdateStatus"/></para>
+        /// <para>Для обновления использовать метод <see cref="UpdateStatusAndHost"/></para>
         /// </summary>
         public OpeningTaskIncomingStatus Status { get; private set; } = OpeningTaskIncomingStatus.New;
 
@@ -117,6 +117,11 @@ namespace RevitOpeningPlacement.OpeningModels {
         /// Высота в единицах ревита или 0, если высоты нет
         /// </summary>
         public double Height { get; } = 0;
+
+        /// <summary>
+        /// Хост входящего задания на отверстие из активного документа
+        /// </summary>
+        public Element Host { get; private set; }
 
 
         public override bool Equals(object obj) {
@@ -154,7 +159,7 @@ namespace RevitOpeningPlacement.OpeningModels {
         /// размещенных в активном КР документе-получателе заданий на отверстия</param>
         /// <param name="constructureElementsIds">
         /// Коллекция элементов конструкций из активного документа-получателя заданий</param>
-        public void UpdateStatus(
+        public void UpdateStatusAndHost(
             ICollection<OpeningRealKr> realOpenings,
             ICollection<ElementId> constructureElementsIds) {
             try {
@@ -165,6 +170,8 @@ namespace RevitOpeningPlacement.OpeningModels {
                     thisOpeningSolid,
                     constructureElementsIds);
                 var intersectingOpenings = GetIntersectingOpeningsIds(realOpenings, thisOpeningSolid, thisOpeningBBox);
+
+                Host = FindHost(thisOpeningSolid, intersectingStructureElements, intersectingOpenings);
 
                 if((intersectingStructureElements.Count == 0) && (intersectingOpenings.Count == 0)) {
                     Status = OpeningTaskIncomingStatus.NoIntersection;
@@ -183,6 +190,62 @@ namespace RevitOpeningPlacement.OpeningModels {
             }
         }
 
+
+        /// <summary>
+        /// Возвращает Id элемента конструкции, который наиболее похож на хост для задания на отверстие.
+        /// <para>Под наиболее подходящим понимается элемент конструкции, с которым пересечение наибольшего объема, 
+        /// либо хост чистового отверстия, с которым пересекается задание на отверстие.</para> 
+        /// </summary>
+        /// <param name="thisOpeningSolid">
+        /// Солид текущего задания на отверстие в координатах активного файла-получателя заданий</param>
+        /// <param name="intersectingStructureElementsIds">
+        /// Коллекция Id элементов конструкций из активного документа, с которыми пересекается задание на отверстие
+        /// </param>
+        /// <param name="intersectingOpeningsIds">
+        /// Коллекция Id чистовых отверстий из активного документа, с которыми пересекается задание на отверсите</param>
+        private Element FindHost(
+            Solid thisOpeningSolid,
+            ICollection<ElementId> intersectingStructureElementsIds,
+            ICollection<ElementId> intersectingOpeningsIds) {
+
+            if((intersectingOpeningsIds != null) && intersectingOpeningsIds.Any()) {
+                return (_revitRepository.GetElement(intersectingOpeningsIds.First()) as FamilyInstance)?.Host;
+
+            } else if((thisOpeningSolid != null)
+                && (thisOpeningSolid.Volume > 0)
+                && (intersectingStructureElementsIds != null)
+                && intersectingStructureElementsIds.Any()) {
+
+                // поиск элемента конструкции, с которым пересечение задания на отверстие имеет наибольший объем
+                double halfOpeningVolume = thisOpeningSolid.Volume / 2;
+                double intersectingVolumePrevious = 0;
+                ElementId hostId = intersectingStructureElementsIds.First();
+                foreach(var structureElementId in intersectingStructureElementsIds) {
+                    var structureSolid = _revitRepository.GetElement(structureElementId)?.GetSolid();
+                    if((structureSolid != null) && (structureSolid.Volume > 0)) {
+                        try {
+                            double intersectingVolumeCurrent
+                                = BooleanOperationsUtils.ExecuteBooleanOperation(
+                                    thisOpeningSolid,
+                                    structureSolid,
+                                    BooleanOperationsType.Intersect)?.Volume ?? 0;
+                            if(intersectingVolumeCurrent >= halfOpeningVolume) {
+                                return _revitRepository.GetElement(structureElementId);
+                            }
+                            if(intersectingVolumeCurrent > intersectingVolumePrevious) {
+                                intersectingVolumePrevious = intersectingVolumeCurrent;
+                                hostId = structureElementId;
+                            }
+                        } catch(Autodesk.Revit.Exceptions.InvalidOperationException) {
+                            continue;
+                        }
+                    }
+                }
+                return _revitRepository.GetElement(hostId);
+            } else {
+                return default;
+            }
+        }
 
         /// <summary>
         /// Возвращает коллекцию элементов конструкций из активного документа, 

--- a/src/RevitOpeningPlacement/OpeningModels/OpeningTaskHost.cs
+++ b/src/RevitOpeningPlacement/OpeningModels/OpeningTaskHost.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+
+using Autodesk.Revit.DB;
+
+using dosymep.Revit;
+
+using RevitClashDetective.Models.Clashes;
+
+using RevitOpeningPlacement.Models.Interfaces;
+
+namespace RevitOpeningPlacement.OpeningModels {
+    internal class OpeningTaskHost : IOpeningTaskHost, ISelectorAndHighlighter, IEquatable<OpeningTaskHost> {
+        private const string _krModelPartParam = "обр_ФОП_Раздел проекта";
+        private readonly Element _element;
+
+        public OpeningTaskHost(Element element) {
+            _element = element ?? throw new ArgumentNullException(nameof(element));
+
+            Name = element.Name;
+            Id = element.Id;
+            KrModelPart = element.GetSharedParamValueOrDefault(_krModelPartParam, string.Empty);
+        }
+
+        /// <summary>
+        /// Создает экземпляр класса с пустыми значениями свойств
+        /// </summary>
+        public OpeningTaskHost() {
+            Name = string.Empty;
+            Id = ElementId.InvalidElementId;
+            KrModelPart = string.Empty;
+        }
+
+
+        public string Name { get; }
+
+        public ElementId Id { get; }
+
+        public string KrModelPart { get; }
+
+        public override bool Equals(object obj) {
+            return Equals(obj as OpeningTaskHost);
+        }
+
+        public bool Equals(OpeningTaskHost other) {
+            if(ReferenceEquals(other, null)) {
+                return false;
+            }
+            if(ReferenceEquals(this, other)) {
+                return true;
+            }
+            return Id == other.Id;
+        }
+
+        public override int GetHashCode() {
+            return 2108858624 + EqualityComparer<ElementId>.Default.GetHashCode(Id);
+        }
+
+        public ICollection<ElementModel> GetElementsToSelect() {
+            return _element is null ? Array.Empty<ElementModel>() : new ElementModel[] { new ElementModel(_element) };
+        }
+
+        public Element GetElementToHighlight() {
+            return _element;
+        }
+    }
+}

--- a/src/RevitOpeningPlacement/ViewModels/Navigator/ConstructureNavigatorForIncomingTasksViewModel.cs
+++ b/src/RevitOpeningPlacement/ViewModels/Navigator/ConstructureNavigatorForIncomingTasksViewModel.cs
@@ -247,7 +247,7 @@ namespace RevitOpeningPlacement.ViewModels.Navigator {
                 foreach(var incomingTask in incomingTasks) {
                     ct.ThrowIfCancellationRequested();
                     progress.Report(i);
-                    incomingTask.UpdateStatus(realOpenings, constructureElementsIds);
+                    incomingTask.UpdateStatusAndHost(realOpenings, constructureElementsIds);
                     incomintTasksViewModels.Add(new OpeningArTaskIncomingViewModel(incomingTask));
                     i++;
                 }

--- a/src/RevitOpeningPlacement/ViewModels/Navigator/OpeningArTaskIncomingViewModel.cs
+++ b/src/RevitOpeningPlacement/ViewModels/Navigator/OpeningArTaskIncomingViewModel.cs
@@ -34,6 +34,7 @@ namespace RevitOpeningPlacement.ViewModels.Navigator {
             Width = _openingTask.DisplayWidth;
             Status = _openingTask.Status.GetDescription();
             Comment = _openingTask.Comment;
+            Host = _openingTask.Host is null ? new OpeningTaskHost() : new OpeningTaskHost(_openingTask.Host);
         }
 
 
@@ -65,6 +66,8 @@ namespace RevitOpeningPlacement.ViewModels.Navigator {
         /// Комментарий экземпляра семейства задания на отверстие
         /// </summary>
         public string Comment { get; } = string.Empty;
+
+        public IOpeningTaskHost Host { get; }
 
         public override bool Equals(object obj) {
             return (obj != null)

--- a/src/RevitOpeningPlacement/ViewModels/Navigator/OpeningMepTaskIncomingViewModel.cs
+++ b/src/RevitOpeningPlacement/ViewModels/Navigator/OpeningMepTaskIncomingViewModel.cs
@@ -43,7 +43,7 @@ namespace RevitOpeningPlacement.ViewModels.Navigator {
             Height = _openingTask.DisplayHeight;
             Thickness = _openingTask.DisplayThickness;
             FamilyShortName = _openingTask.FamilyShortName;
-            HostName = _openingTask.HostName;
+            Host = _openingTask.Host is null ? new OpeningTaskHost() : new OpeningTaskHost(_openingTask.Host);
             Status = _openingTask.Status.GetDescription();
             Comment = _openingTask.Comment;
             Username = _openingTask.Username;
@@ -116,11 +116,6 @@ namespace RevitOpeningPlacement.ViewModels.Navigator {
         public string FamilyShortName { get; } = string.Empty;
 
         /// <summary>
-        /// Название хоста задания на отверстие
-        /// </summary>
-        public string HostName { get; } = string.Empty;
-
-        /// <summary>
         /// Комментарий экземпляра семейства задания на отверстие
         /// </summary>
         public string Comment { get; } = string.Empty;
@@ -130,6 +125,7 @@ namespace RevitOpeningPlacement.ViewModels.Navigator {
         /// </summary>
         public string Username { get; } = string.Empty;
 
+        public IOpeningTaskHost Host { get; }
 
         public override bool Equals(object obj) {
             return (obj != null)

--- a/src/RevitOpeningPlacement/Views/NavigatorArIncomingView.xaml
+++ b/src/RevitOpeningPlacement/Views/NavigatorArIncomingView.xaml
@@ -200,6 +200,31 @@
                                             FieldName="OpeningId" />
                             <dxg:GridColumn ReadOnly="True"
                                             Width="*"
+                                            Header="Основа"
+                                            FieldName="Host.Name" />
+                            <dxg:GridColumn ReadOnly="True"
+                                            Width="60"
+                                            Header="Id основы"
+                                            FieldName="Host.Id" />
+                            <dxg:GridColumn Width="30"
+                                            ReadOnly="True"
+                                            SortMode="Custom"
+                                            AllowResizing="False">
+                                <dxg:GridColumn.CellTemplate>
+                                    <DataTemplate>
+                                            <dx:SimpleButton
+                                                Glyph="{dx:DXImage 'DevAV/Actions/Search_16x16.png'}"
+                                                Command="{Binding ElementName=_this, Path=DataContext.SelectCommand}"
+                                                CommandParameter="{Binding Row.Host}" />
+                                    </DataTemplate>
+                                </dxg:GridColumn.CellTemplate>
+                            </dxg:GridColumn>
+                            <dxg:GridColumn ReadOnly="True"
+                                            Width="70"
+                                            Header="Раздел КР"
+                                            FieldName="Host.KrModelPart" />
+                            <dxg:GridColumn ReadOnly="True"
+                                            Width="60"
                                             Header="Комментарий"
                                             FieldName="Comment" />
                         </dxg:GridControl.Columns>


### PR DESCRIPTION
## Обновления

В окно навигатора по заданиями для КР для входящих заданий добавлены столбцы:

- Основа (Название типоразмера элемента из активного файла, в котором размещено задание на отверстие из связи)
- Id основы (с дополнительной кнопкой для выбора основы)
- Раздел КР (Значение параметра экземпляра основы "**обр_ФОП_Раздел проекта**")

![image](https://github.com/user-attachments/assets/0a1bc86e-7891-4982-be54-7fc91b2e4045)
