### PR TITLE
RevitOpeningPlacement: Исправлено отображение названия основы задания в навигаторе АР

### DIFF
--- a/src/RevitOpeningPlacement/Views/NavigatorMepIncomingView.xaml
+++ b/src/RevitOpeningPlacement/Views/NavigatorMepIncomingView.xaml
@@ -219,7 +219,7 @@
                             <dxg:GridColumn ReadOnly="True"
                                             Width="60"
                                             Header="Основа"
-                                            FieldName="HostName" />
+                                            FieldName="Host.Name" />
                             <dxg:GridColumn ReadOnly="True"
                                             Width="50"
                                             Header="Система ВИС"


### PR DESCRIPTION
В предыдущем #149 свойство `IOpeningTaskIncomingForKrViewModel.HostName` переехало в `IOpeningTaskIncomingForKrViewModel.Host.Name`, что также затронуло окно навигатора АР.