### PR TITLE
RevitOpeningPlacement: Исправлено определение высотных отметок у заданий от ВИС

### DIFF
--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/FloorSolidParameterGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/FloorSolidParameterGetter.cs
@@ -82,8 +82,14 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters {
             yield return new DoubleParameterGetter(RevitRepository.OpeningThickness, thicknessValueGetter).GetParamValue();
 
             //отметки отверстия
-            var bottomOffsetValueGetter = new BottomOffsetOfOpeningInFloorValueGetter(_pointFinder, thicknessValueGetter);
-            var centerOffsetMmValueGetter = new CenterOffsetValueGetter(_pointFinder);
+            ElevationValueGetter elevationGetter;
+            if(_createdByGroup) {
+                elevationGetter = new ElevationValueGetter(_pointFinder, _openingsGroup.Elements.First().GetFamilyInstance().Document);
+            } else {
+                elevationGetter = new ElevationValueGetter(_pointFinder, _mepElement.Document);
+            }
+            var bottomOffsetValueGetter = new BottomOffsetOfOpeningInFloorValueGetter(elevationGetter, thicknessValueGetter);
+            var centerOffsetMmValueGetter = new CenterOffsetValueGetter(elevationGetter);
             yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetBottom, bottomOffsetValueGetter).GetParamValue();
             yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetCenter, centerOffsetMmValueGetter).GetParamValue();
             var offsetFeetFromLevelValueGetter = new OffsetFromLevelValueGetter(centerOffsetMmValueGetter, _levelFinder);

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/InclinedRectangleCurveWallParameterGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/InclinedRectangleCurveWallParameterGetter.cs
@@ -29,8 +29,9 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters {
             yield return new DoubleParameterGetter(RevitRepository.OpeningThickness, new WallThicknessValueGetter(_clash.Element2)).GetParamValue();
 
             //отметки отверстия
-            var bottomOffsetValueGetter = new BottomOffsetOfRectangleOpeningInWallValueGetter(_pointFinder);
-            yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetCenter, new CenterOffsetOfRectangleOpeningInWallValueGetter(_pointFinder, heightValueGetter)).GetParamValue();
+            var elevationGetter = new ElevationValueGetter(_pointFinder, _clash.Element1.Document);
+            var bottomOffsetValueGetter = new BottomOffsetOfRectangleOpeningInWallValueGetter(elevationGetter);
+            yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetCenter, new CenterOffsetOfRectangleOpeningInWallValueGetter(elevationGetter, heightValueGetter)).GetParamValue();
             yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetBottom, bottomOffsetValueGetter).GetParamValue();
             var offsetFeetFromLevelValueGetter = new OffsetFromLevelValueGetter(bottomOffsetValueGetter, _levelFinder);
             var levelFeetOffsetValueGetter = new LevelOffsetValueGetter(_levelFinder);

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/InclinedRoundCurveWallParamGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/InclinedRoundCurveWallParamGetter.cs
@@ -35,8 +35,9 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters {
             yield return new DoubleParameterGetter(RevitRepository.OpeningThickness, new WallThicknessValueGetter(_clash.Element2)).GetParamValue();
 
             //отметки отверстия
-            var bottomOffsetValueGetter = new BottomOffsetOfRectangleOpeningInWallValueGetter(_pointFinder);
-            yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetCenter, new CenterOffsetOfRectangleOpeningInWallValueGetter(_pointFinder, heightValueGetter)).GetParamValue();
+            var elevationGetter = new ElevationValueGetter(_pointFinder, _clash.Element1.Document);
+            var bottomOffsetValueGetter = new BottomOffsetOfRectangleOpeningInWallValueGetter(elevationGetter);
+            yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetCenter, new CenterOffsetOfRectangleOpeningInWallValueGetter(elevationGetter, heightValueGetter)).GetParamValue();
             yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetBottom, bottomOffsetValueGetter).GetParamValue();
             var offsetFeetFromLevelValueGetter = new OffsetFromLevelValueGetter(bottomOffsetValueGetter, _levelFinder);
             var levelFeetOffsetValueGetter = new LevelOffsetValueGetter(_levelFinder);

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/PerpendicularRectangleCurveFloorParamGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/PerpendicularRectangleCurveFloorParamGetter.cs
@@ -29,8 +29,9 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters {
             yield return new DoubleParameterGetter(RevitRepository.OpeningThickness, floorThicknessValueGetter).GetParamValue();
 
             //отметки отверстия
-            var bottomOffsetValueGetter = new BottomOffsetOfOpeningInFloorValueGetter(_pointFinder, floorThicknessValueGetter);
-            var centerOffsetMmValueGetter = new CenterOffsetValueGetter(_pointFinder);
+            var elevationGetter = new ElevationValueGetter(_pointFinder, _clash.Element1.Document);
+            var bottomOffsetValueGetter = new BottomOffsetOfOpeningInFloorValueGetter(elevationGetter, floorThicknessValueGetter);
+            var centerOffsetMmValueGetter = new CenterOffsetValueGetter(elevationGetter);
             yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetBottom, bottomOffsetValueGetter).GetParamValue();
             yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetCenter, centerOffsetMmValueGetter).GetParamValue();
             var offsetFeetFromLevelValueGetter = new OffsetFromLevelValueGetter(centerOffsetMmValueGetter, _levelFinder);

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/PerpendicularRectangleCurveWallParamGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/PerpendicularRectangleCurveWallParamGetter.cs
@@ -29,8 +29,9 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters {
             yield return new DoubleParameterGetter(RevitRepository.OpeningThickness, new WallThicknessValueGetter(_clash.Element2)).GetParamValue();
 
             //отметки отверстия
-            var bottomOffsetValueGetter = new BottomOffsetOfRectangleOpeningInWallValueGetter(_pointFinder);
-            yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetCenter, new CenterOffsetOfRectangleOpeningInWallValueGetter(_pointFinder, heightValueGetter)).GetParamValue();
+            var elevationGetter = new ElevationValueGetter(_pointFinder, _clash.Element1.Document);
+            var bottomOffsetValueGetter = new BottomOffsetOfRectangleOpeningInWallValueGetter(elevationGetter);
+            yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetCenter, new CenterOffsetOfRectangleOpeningInWallValueGetter(elevationGetter, heightValueGetter)).GetParamValue();
             yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetBottom, bottomOffsetValueGetter).GetParamValue();
             var offsetFeetFromLevelValueGetter = new OffsetFromLevelValueGetter(bottomOffsetValueGetter, _levelFinder);
             var levelFeetOffsetValueGeeter = new LevelOffsetValueGetter(_levelFinder);

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/PerpendicularRoundCurveFloorParamGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/PerpendicularRoundCurveFloorParamGetter.cs
@@ -42,8 +42,9 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters {
             yield return new DoubleParameterGetter(RevitRepository.OpeningThickness, floorThicknessValueGetter).GetParamValue();
 
             //отметки отверстия
-            var bottomOffsetMmValueGetter = new BottomOffsetOfOpeningInFloorValueGetter(_pointFinder, floorThicknessValueGetter);
-            IValueGetter<DoubleParamValue> centerOffsetMmValueGetter = new CenterOffsetValueGetter(_pointFinder);
+            var elevationGetter = new ElevationValueGetter(_pointFinder, _clash.Element1.Document);
+            var bottomOffsetMmValueGetter = new BottomOffsetOfOpeningInFloorValueGetter(elevationGetter, floorThicknessValueGetter);
+            IValueGetter<DoubleParamValue> centerOffsetMmValueGetter = new CenterOffsetValueGetter(elevationGetter);
             yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetCenter, centerOffsetMmValueGetter).GetParamValue();
             yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetBottom, bottomOffsetMmValueGetter).GetParamValue();
             var offsetFeetFromLevelValueGetter = new OffsetFromLevelValueGetter(centerOffsetMmValueGetter, _levelFinder);

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/PerpendicularRoundCurveWallParamGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/PerpendicularRoundCurveWallParamGetter.cs
@@ -42,14 +42,15 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters {
             //отметки отверстия
             IValueGetter<DoubleParamValue> bottomOffsetMmValueGetter;
             IValueGetter<DoubleParamValue> centerOffsetMmValueGetter;
+            var elevationGetter = new ElevationValueGetter(_pointFinder, _clash.Element1.Document);
             if(openingTaskIsRound) {
                 //отверстие круглое
-                centerOffsetMmValueGetter = new CenterOffsetValueGetter(_pointFinder);
-                bottomOffsetMmValueGetter = new BottomOffsetValueGetter(_pointFinder, openingSizeGetter);
+                centerOffsetMmValueGetter = new CenterOffsetValueGetter(elevationGetter);
+                bottomOffsetMmValueGetter = new BottomOffsetValueGetter(elevationGetter, openingSizeGetter);
             } else {
                 // отверстие прямоугольное (квадратное)
-                centerOffsetMmValueGetter = new CenterOffsetOfRectangleOpeningInWallValueGetter(_pointFinder, openingSizeGetter);
-                bottomOffsetMmValueGetter = new BottomOffsetOfRectangleOpeningInWallValueGetter(_pointFinder);
+                centerOffsetMmValueGetter = new CenterOffsetOfRectangleOpeningInWallValueGetter(elevationGetter, openingSizeGetter);
+                bottomOffsetMmValueGetter = new BottomOffsetOfRectangleOpeningInWallValueGetter(elevationGetter);
             }
             yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetCenter, centerOffsetMmValueGetter).GetParamValue();
             yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetBottom, bottomOffsetMmValueGetter).GetParamValue();

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/WallSolidParameterGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/WallSolidParameterGetter.cs
@@ -77,12 +77,18 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters {
             //отметки отверстия
             IValueGetter<DoubleParamValue> bottomOffsetMmValueGetter;
             IValueGetter<DoubleParamValue> centerOffsetMmValueGetter;
-            if(isRound) {
-                centerOffsetMmValueGetter = new CenterOffsetValueGetter(_pointFinder);
-                bottomOffsetMmValueGetter = new BottomOffsetValueGetter(_pointFinder, sizeInit.GetHeight());
+            ElevationValueGetter elevationGetter;
+            if(_createdByOpeningGroup) {
+                elevationGetter = new ElevationValueGetter(_pointFinder, _openingsGroup.Elements.First().GetFamilyInstance().Document);
             } else {
-                centerOffsetMmValueGetter = new CenterOffsetOfRectangleOpeningInWallValueGetter(_pointFinder, sizeInit.GetHeight());
-                bottomOffsetMmValueGetter = new BottomOffsetOfRectangleOpeningInWallValueGetter(_pointFinder);
+                elevationGetter = new ElevationValueGetter(_pointFinder, _mepElement.Document);
+            }
+            if(isRound) {
+                centerOffsetMmValueGetter = new CenterOffsetValueGetter(elevationGetter);
+                bottomOffsetMmValueGetter = new BottomOffsetValueGetter(elevationGetter, sizeInit.GetHeight());
+            } else {
+                centerOffsetMmValueGetter = new CenterOffsetOfRectangleOpeningInWallValueGetter(elevationGetter, sizeInit.GetHeight());
+                bottomOffsetMmValueGetter = new BottomOffsetOfRectangleOpeningInWallValueGetter(elevationGetter);
             }
             yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetCenter, centerOffsetMmValueGetter).GetParamValue();
             yield return new DoubleParameterGetter(RevitRepository.OpeningOffsetBottom, bottomOffsetMmValueGetter).GetParamValue();

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/BottomOffsetOfOpeningInFloorValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/BottomOffsetOfOpeningInFloorValueGetter.cs
@@ -6,28 +6,27 @@ using RevitOpeningPlacement.Models.Interfaces;
 
 namespace RevitOpeningPlacement.Models.OpeningPlacement.ValueGetters {
     internal class BottomOffsetOfOpeningInFloorValueGetter : LengthConverter, IValueGetter<DoubleParamValue> {
-        private readonly IPointFinder _pointFinder;
+        private readonly IValueGetter<DoubleParamValue> _elevationGetter;
         private readonly IValueGetter<DoubleParamValue> _thicknessInFeetParamGetter;
 
         /// <summary>
-        /// Конструктор класса, предоставляющего значение высотной отметки низа отверстия в мм от начала проекта, расположенного в перекрытии
+        /// Конструктор класса, предоставляющего значение высотной отметки низа отверстия в мм, расположенного в перекрытии
         /// </summary>
-        /// <param name="pointFinder">Объект, предоставляющий координату центра отверстия в футах</param>
+        /// <param name="elevationGetter">Объект, предоставляющий координату Z центра отверстия в футах</param>
         /// <param name="thicknessInFeetParamGetter">Объект, предоставляющий толщину отверстия в футах</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public BottomOffsetOfOpeningInFloorValueGetter(IPointFinder pointFinder, IValueGetter<DoubleParamValue> thicknessInFeetParamGetter) {
-            if(pointFinder is null) {
-                throw new ArgumentNullException(nameof(pointFinder));
-            }
-            if(thicknessInFeetParamGetter is null) {
-                throw new ArgumentNullException(nameof(thicknessInFeetParamGetter));
-            }
-            _pointFinder = pointFinder;
-            _thicknessInFeetParamGetter = thicknessInFeetParamGetter;
+        public BottomOffsetOfOpeningInFloorValueGetter(
+            IValueGetter<DoubleParamValue> elevationGetter,
+            IValueGetter<DoubleParamValue> thicknessInFeetParamGetter) {
+
+            _elevationGetter = elevationGetter
+                ?? throw new ArgumentNullException(nameof(elevationGetter));
+            _thicknessInFeetParamGetter = thicknessInFeetParamGetter
+                ?? throw new ArgumentNullException(nameof(thicknessInFeetParamGetter));
         }
 
         public DoubleParamValue GetValue() {
-            double offsetInFeet = _pointFinder.GetPoint().Z - _thicknessInFeetParamGetter.GetValue().TValue;
+            double offsetInFeet = _elevationGetter.GetValue().TValue - _thicknessInFeetParamGetter.GetValue().TValue;
             double offsetInMm = ConvertFromInternal(offsetInFeet);
             return new DoubleParamValue(Math.Round(offsetInMm));
         }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/BottomOffsetOfRectangleOpeningInWallValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/BottomOffsetOfRectangleOpeningInWallValueGetter.cs
@@ -6,23 +6,20 @@ using RevitOpeningPlacement.Models.Interfaces;
 
 namespace RevitOpeningPlacement.Models.OpeningPlacement.ValueGetters {
     internal class BottomOffsetOfRectangleOpeningInWallValueGetter : LengthConverter, IValueGetter<DoubleParamValue> {
-        private readonly IPointFinder _pointFinder;
+        private readonly IValueGetter<DoubleParamValue> _elevationGetter;
 
         /// <summary>
-        /// Конструктор класса, предоставляющего значение высотной отметки низа прямоугольного отверстия в стене в мм от начала проекта.
+        /// Конструктор класса, предоставляющего значение высотной отметки низа прямоугольного отверстия в стене в мм.
         /// Класс создан для расчета высотной отметки оси и низа отверстия от нуля для семейства задания прямоугольного отверстия в стене, у которого точка размещения находится у нижней грани.
         /// </summary>
-        /// <param name="pointFinder">Объект, предоставляющий координату центра отверстия в футах</param>
+        /// <param name="elevationGetter">Объект, предоставляющий координату Z центра отверстия в футах</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public BottomOffsetOfRectangleOpeningInWallValueGetter(IPointFinder pointFinder) {
-            if(pointFinder is null) {
-                throw new ArgumentNullException(nameof(pointFinder));
-            }
-            _pointFinder = pointFinder;
+        public BottomOffsetOfRectangleOpeningInWallValueGetter(IValueGetter<DoubleParamValue> elevationGetter) {
+            _elevationGetter = elevationGetter ?? throw new ArgumentNullException(nameof(elevationGetter));
         }
 
         public DoubleParamValue GetValue() {
-            double offsetInFeet = _pointFinder.GetPoint().Z;
+            double offsetInFeet = _elevationGetter.GetValue().TValue;
             double offsetInMm = ConvertFromInternal(offsetInFeet);
             return new DoubleParamValue(Math.Round(offsetInMm));
         }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/BottomOffsetValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/BottomOffsetValueGetter.cs
@@ -6,30 +6,29 @@ using RevitOpeningPlacement.Models.Interfaces;
 
 namespace RevitOpeningPlacement.Models.OpeningPlacement.ValueGetters {
     internal class BottomOffsetValueGetter : LengthConverter, IValueGetter<DoubleParamValue> {
-        private readonly IPointFinder _pointFinder;
+        private readonly IValueGetter<DoubleParamValue> _elevationGetter;
         private readonly IValueGetter<DoubleParamValue> _heightInFeetParamGetter;
 
         /// <summary>
-        /// Конструктор класса, предоставляющего значение высотной отметки низа отверстия в мм от начала проекта для круглых отверстий в стенах
+        /// Конструктор класса, предоставляющего значение высотной отметки низа отверстия в мм для круглых отверстий в стенах
         /// Для прямоугольных отверстий в стенах использовать <see cref="BottomOffsetOfRectangleOpeningInWallValueGetter"/>
         /// Для отверстий в перекрытиях использовать <see cref="BottomOffsetOfOpeningInFloorValueGetter"/>
         /// </summary>
-        /// <param name="pointFinder">Объект, предоставляющий координату центра отверстия в футах</param>
+        /// <param name="elevationGetter">Объект, предоставляющий координату Z центра отверстия в футах</param>
         /// <param name="heightInFeetParamGetter">Объект, предоставляющий высоту отверстия в футах</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public BottomOffsetValueGetter(IPointFinder pointFinder, IValueGetter<DoubleParamValue> heightInFeetParamGetter) {
-            if(pointFinder is null) {
-                throw new ArgumentNullException(nameof(pointFinder));
-            }
-            if(heightInFeetParamGetter is null) {
-                throw new ArgumentNullException(nameof(heightInFeetParamGetter));
-            }
-            _pointFinder = pointFinder;
-            _heightInFeetParamGetter = heightInFeetParamGetter;
+        public BottomOffsetValueGetter(
+            IValueGetter<DoubleParamValue> elevationGetter,
+            IValueGetter<DoubleParamValue> heightInFeetParamGetter) {
+
+            _elevationGetter = elevationGetter
+                ?? throw new ArgumentNullException(nameof(elevationGetter));
+            _heightInFeetParamGetter = heightInFeetParamGetter
+                ?? throw new ArgumentNullException(nameof(heightInFeetParamGetter));
         }
 
         public DoubleParamValue GetValue() {
-            double offsetInFeet = _pointFinder.GetPoint().Z - (_heightInFeetParamGetter.GetValue().TValue / 2);
+            double offsetInFeet = _elevationGetter.GetValue().TValue - (_heightInFeetParamGetter.GetValue().TValue / 2);
             double offsetInMm = ConvertFromInternal(offsetInFeet);
             return new DoubleParamValue(Math.Round(offsetInMm));
         }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/CenterOffsetOfRectangleOpeningInWallValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/CenterOffsetOfRectangleOpeningInWallValueGetter.cs
@@ -6,28 +6,27 @@ using RevitOpeningPlacement.Models.Interfaces;
 
 namespace RevitOpeningPlacement.Models.OpeningPlacement.ValueGetters {
     internal class CenterOffsetOfRectangleOpeningInWallValueGetter : LengthConverter, IValueGetter<DoubleParamValue> {
-        private readonly IPointFinder _pointFinder;
+        private readonly IValueGetter<DoubleParamValue> _elevationGetter;
         private readonly IValueGetter<DoubleParamValue> _heightInFeetParamGetter;
 
         /// <summary>
-        /// Конструктор класса, предоставляющего значение высотной отметки оси отверстия в мм от начала проекта для прямоугольных отверстий в стенах.
+        /// Конструктор класса, предоставляющего значение высотной отметки оси отверстия в мм для прямоугольных отверстий в стенах.
         /// </summary>
-        /// <param name="pointFinder">Объект, предоставляющий координату центра отверстия в футах</param>
+        /// <param name="elevationGetter">Объект, предоставляющий координату Z центра отверстия в футах</param>
         /// <param name="heightInFeetParamGetter">Объект, предоставляющий высоту отверстия в футах</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public CenterOffsetOfRectangleOpeningInWallValueGetter(IPointFinder pointFinder, IValueGetter<DoubleParamValue> heightInFeetParamGetter) {
-            if(pointFinder is null) {
-                throw new ArgumentNullException(nameof(pointFinder));
-            }
-            if(heightInFeetParamGetter is null) {
-                throw new ArgumentNullException(nameof(heightInFeetParamGetter));
-            }
-            _pointFinder = pointFinder;
-            _heightInFeetParamGetter = heightInFeetParamGetter;
+        public CenterOffsetOfRectangleOpeningInWallValueGetter(
+            IValueGetter<DoubleParamValue> elevationGetter,
+            IValueGetter<DoubleParamValue> heightInFeetParamGetter) {
+
+            _elevationGetter = elevationGetter
+                ?? throw new ArgumentNullException(nameof(elevationGetter));
+            _heightInFeetParamGetter = heightInFeetParamGetter
+                ?? throw new ArgumentNullException(nameof(heightInFeetParamGetter));
         }
 
         public DoubleParamValue GetValue() {
-            double offsetInFeet = _pointFinder.GetPoint().Z + (_heightInFeetParamGetter.GetValue().TValue / 2);
+            double offsetInFeet = _elevationGetter.GetValue().TValue + (_heightInFeetParamGetter.GetValue().TValue / 2);
             double offsetInMm = ConvertFromInternal(offsetInFeet);
             return new DoubleParamValue(Math.Round(offsetInMm));
         }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/CenterOffsetValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/CenterOffsetValueGetter.cs
@@ -6,25 +6,22 @@ using RevitOpeningPlacement.Models.Interfaces;
 
 namespace RevitOpeningPlacement.Models.OpeningPlacement.ValueGetters {
     internal class CenterOffsetValueGetter : LengthConverter, IValueGetter<DoubleParamValue> {
-        private readonly IPointFinder _pointFinder;
+        private readonly IValueGetter<DoubleParamValue> _elevationGetter;
 
         /// <summary>
         /// Конструктор класса, предоставляющего значение высотной отметки центра отверстия в мм<br/>
-        /// от начала проекта для круглых отверстиях в стенах и перекрытиях и для прямоугольных отверстий в перекрытиях<br/>
+        /// для круглых отверстиях в стенах и перекрытиях и для прямоугольных отверстий в перекрытиях<br/>
         /// Для прямоугольных отверстий в стенах использовать <see cref="CenterOffsetOfRectangleOpeningInWallValueGetter"/>
         /// </summary>
-        /// <param name="pointFinder">Объект, предоставляющий координату центра отверстия</param>
-        /// <exception cref="ArgumentNullException">Исключение, если <paramref name="pointFinder"/> null</exception>
-        public CenterOffsetValueGetter(IPointFinder pointFinder) {
-            if(pointFinder is null) {
-                throw new ArgumentNullException(nameof(pointFinder));
-            }
-            _pointFinder = pointFinder;
+        /// <param name="elevationGetter">Объект, предоставляющий Z координату центра отверстия</param>
+        /// <exception cref="ArgumentNullException">Исключение, если <paramref name="elevationGetter"/> null</exception>
+        public CenterOffsetValueGetter(IValueGetter<DoubleParamValue> elevationGetter) {
+            _elevationGetter = elevationGetter ?? throw new ArgumentNullException(nameof(elevationGetter));
         }
 
 
         public DoubleParamValue GetValue() {
-            var offsetInFeet = _pointFinder.GetPoint().Z;
+            var offsetInFeet = _elevationGetter.GetValue().TValue;
             return new DoubleParamValue(Math.Round(ConvertFromInternal(offsetInFeet)));
         }
     }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/ElevationValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/ElevationValueGetter.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Linq;
+
+using Autodesk.Revit.DB;
+
+using RevitClashDetective.Models.Value;
+
+using RevitOpeningPlacement.Models.Interfaces;
+
+namespace RevitOpeningPlacement.Models.OpeningPlacement.ValueGetters {
+    /// <summary>
+    /// Класс для нахождения высотной отметки относительно базовой точки проекта.
+    /// </summary>
+    internal class ElevationValueGetter : IValueGetter<DoubleParamValue> {
+        private readonly IPointFinder _point;
+        private readonly Document _activeDoc;
+
+        /// <summary>
+        /// Конструирует экземпляр класса для нахождения высотной отметки относительно базовой точки проекта.
+        /// </summary>
+        /// <param name="point">Провайдер точки относительно внутреннего начала проекта</param>
+        /// <param name="activeDoc">Документ для получения базовой точки</param>
+        /// <exception cref="ArgumentNullException">Исключение, если один из обязательных параметров null</exception>
+        public ElevationValueGetter(IPointFinder point, Document activeDoc) {
+            _point = point ?? throw new ArgumentNullException(nameof(point));
+            _activeDoc = activeDoc ?? throw new ArgumentNullException(nameof(activeDoc));
+        }
+
+
+        public DoubleParamValue GetValue() {
+            var basePoint = GetBasePoint();
+            return new DoubleParamValue(_point.GetPoint().Z - basePoint.Position.Z);
+        }
+
+
+        private BasePoint GetBasePoint() {
+#if REVIT_2020_OR_LESS
+            return new FilteredElementCollector(_activeDoc)
+                .WhereElementIsNotElementType()
+                .OfClass(typeof(BasePoint))
+                .OfType<BasePoint>()
+                .First(p => !p.IsShared);
+#else
+            return BasePoint.GetProjectBasePoint(_activeDoc);
+#endif
+        }
+    }
+}

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/OffsetFromLevelValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/OffsetFromLevelValueGetter.cs
@@ -13,7 +13,7 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ValueGetters {
         /// <summary>
         /// Класс, предоставляющий значение отметки низа отверстия от уровня в единицах Revit
         /// </summary>
-        /// <param name="offsetMmValueGetter">Провайдер отметки низа отверстия в мм от начала проекта</param>
+        /// <param name="offsetMmValueGetter">Провайдер отметки низа отверстия в мм</param>
         /// <param name="levelFinder">Провайдер уровня, на котором размещается отверстие</param>
         /// <exception cref="System.ArgumentNullException">Исключение, если обязательный параметр null</exception>
         public OffsetFromLevelValueGetter(

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/OffsetInFeetValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/OffsetInFeetValueGetter.cs
@@ -9,9 +9,9 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ValueGetters {
         private readonly IValueGetter<DoubleParamValue> _offsetInMmValueGetter;
 
         /// <summary>
-        /// Класс, предоставляющий значение отметки отверстия в футах от начала проекта
+        /// Класс, предоставляющий значение отметки отверстия в футах
         /// </summary>
-        /// <param name="offsetInMmValueGetter">Провайдер отметки отверстия в мм от начала проекта</param>
+        /// <param name="offsetInMmValueGetter">Провайдер отметки отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
         public OffsetInFeetValueGetter(IValueGetter<DoubleParamValue> offsetInMmValueGetter) {
             _offsetInMmValueGetter = offsetInMmValueGetter ?? throw new ArgumentNullException(nameof(offsetInMmValueGetter));

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/OffsetInMmValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/OffsetInMmValueGetter.cs
@@ -9,9 +9,9 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ValueGetters {
         private readonly IValueGetter<DoubleParamValue> _offsetInFeetValueGetter;
 
         /// <summary>
-        /// Класс, предоставляющий значение отметки отверстия в мм от начала проекта
+        /// Класс, предоставляющий значение отметки отверстия в мм
         /// </summary>
-        /// <param name="offsetInFeetValueGetter">Провайдер отметки отверстия в футах от начала проекта</param>
+        /// <param name="offsetInFeetValueGetter">Провайдер отметки отверстия в футах</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
         public OffsetInMmValueGetter(IValueGetter<DoubleParamValue> offsetInFeetValueGetter) {
             _offsetInFeetValueGetter = offsetInFeetValueGetter ?? throw new ArgumentNullException(nameof(offsetInFeetValueGetter));


### PR DESCRIPTION
## Исправления

Определение высотных отметок заданий на отверстия от ВИС сделано от базовой точки проекта, а не от внутреннего начала проекта, как было ранее.