### PR TITLE
RevitOpeningPlacement: Исправлена ошибка определения точки вставки, прерывающая выполнение команды

### DIFF
--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/OpeningPlacer.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/OpeningPlacer.cs
@@ -42,7 +42,7 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement {
             ex is IntersectionNotFoundException
             || ex is NullReferenceException
             || ex is ArgumentNullException
-            || ex is Autodesk.Revit.Exceptions.ArgumentNullException) {
+            || ex is Autodesk.Revit.Exceptions.ApplicationException) {
 
                 throw new OpeningNotPlacedException("Не удалось найти точку вставки");
             }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/OpeningPlacer.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/OpeningPlacer.cs
@@ -42,7 +42,7 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement {
             ex is IntersectionNotFoundException
             || ex is NullReferenceException
             || ex is ArgumentNullException
-            || ex is Autodesk.Revit.Exceptions.ApplicationException) {
+            || ex is Autodesk.Revit.Exceptions.ArgumentException) {
 
                 throw new OpeningNotPlacedException("Не удалось найти точку вставки");
             }


### PR DESCRIPTION
## Описание ошибки

При выполнении команды "Расставить все" выскакивала следующая ошибка:

![image](https://github.com/user-attachments/assets/2e02979d-ea66-4744-93b5-071e7d1f4254)

При отладке выяснилось, что данная ошибка возникает при определении точки вставки задания на отверстие и должна далее попадать в соответствующее окно с ошибками расстановки заданий.

![image](https://github.com/user-attachments/assets/c2aa9957-936d-436a-a89b-338a386467c5)

## Решение

Скорректированы перехватываемые исключения при определении точки вставки
