### PR TITLE
RevitMechanicalSpecification: Лишний пробел в наименовании

### DIFF
--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamNameFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamNameFiller.cs
@@ -71,7 +71,7 @@ namespace RevitMechanicalSpecification.Models.Fillers {
                     return GetFlexElementName(specificationElement);
             }
 
-            return $"{_name} {_nameAddon}";
+            return string.IsNullOrEmpty(_nameAddon) ? _name : $"{_name} {_nameAddon}";
         }
 
         /// <summary>


### PR DESCRIPTION
Лишний пробел по умолчанию в именах ломал сортировку узлов в сложных спецификациях