### PR TITLE
RevitDeclarations: Исправлена ошибка "временных" семейств

### DIFF
--- a/src/RevitDeclarations/Models/RevitRepository.cs
+++ b/src/RevitDeclarations/Models/RevitRepository.cs
@@ -15,8 +15,7 @@ namespace RevitDeclarations.Models {
         private readonly List<ElementOnPhaseStatus> _statuses = new List<ElementOnPhaseStatus>() {
                 ElementOnPhaseStatus.Existing,
                 ElementOnPhaseStatus.Demolished,
-                ElementOnPhaseStatus.New,
-                ElementOnPhaseStatus.Temporary
+                ElementOnPhaseStatus.New
             };
 
         public RevitRepository(UIApplication uiApplication) {


### PR DESCRIPTION
Если в Revit у экземпляра семейства совпадает стадии сноса и возведения, то элемент имеет временный статус.
Для таких экземпляров в Revit API нельзя получить связанные помещения.

При наличии таких экземпляров при расчете УТП возникала ошибка (для дверей и сантехники).
Теперь этот статус удален из списка статусов для фильтрации элементов.

