### PR TITLE
RevitApartmentPlans: Добавлена обработка связей и копирование детализации

### DIFF
--- a/src/RevitApartmentPlans/Models/Apartment.cs
+++ b/src/RevitApartmentPlans/Models/Apartment.cs
@@ -4,22 +4,21 @@ using System.Collections.ObjectModel;
 using System.Linq;
 
 using Autodesk.Revit.DB;
-using Autodesk.Revit.DB.Architecture;
 
 namespace RevitApartmentPlans.Models {
     internal class Apartment {
-        private readonly ICollection<Room> _rooms;
+        private readonly ICollection<RoomElement> _rooms;
 
         /// <summary>
-        /// Конструктор квартиры на основе коллекции помещений.
+        /// Конструктор квартиры из активного документа на основе коллекции помещений. 
+        /// Помещения могут быть как в активном документе, так и в связанном файле.
         /// </summary>
-        /// <param name="rooms">Коллекция помещений квартиры, в которой находися как минимум 1 элемент.
-        /// Также все помещения квартиры должны быть на одном и том же уровне.</param>
+        /// <param name="rooms">Коллекция помещений квартиры, в которой находися как минимум 1 элемент.</param>
         /// <param name="name">Название квартиры.</param>
+        /// <param name="level">Уровень квартиры из активного документа.</param>
         /// <exception cref="ArgumentNullException">Исключение, если один из обязательных параметров null</exception>
         /// <exception cref="ArgumentOutOfRangeException">Исключение, если коллекция помещений пустая</exception>
-        /// <exception cref="ArgumentException">Исключение, если помещения расположены на разных уровнях</exception>
-        public Apartment(ICollection<Room> rooms, string name) {
+        public Apartment(ICollection<RoomElement> rooms, string name, Level level) {
             if(rooms is null) {
                 throw new ArgumentNullException(nameof(rooms));
             }
@@ -29,15 +28,14 @@ namespace RevitApartmentPlans.Models {
             if(rooms.Count == 0) {
                 throw new ArgumentOutOfRangeException(nameof(rooms));
             }
-            if(rooms.Select(r => r.LevelId).Distinct().Count() != 1) {
-                throw new ArgumentException($"Помещения квартиры {name} расположены на разных уровнях.");
-            }
 
             _rooms = rooms;
             Name = name;
-            Level level = rooms.First().Level;
             LevelName = level.Name;
             LevelId = level.Id;
+        }
+
+        public Apartment(ICollection<RoomElement> rooms, string name) : this(rooms, name, rooms.First().Room.Level) {
         }
 
 
@@ -51,8 +49,8 @@ namespace RevitApartmentPlans.Models {
         public string LevelName { get; }
 
 
-        public IReadOnlyCollection<Room> GetRooms() {
-            return new ReadOnlyCollection<Room>(_rooms.ToArray());
+        public IReadOnlyCollection<RoomElement> GetRooms() {
+            return new ReadOnlyCollection<RoomElement>(_rooms.ToArray());
         }
     }
 }

--- a/src/RevitApartmentPlans/Models/Apartment.cs
+++ b/src/RevitApartmentPlans/Models/Apartment.cs
@@ -35,9 +35,6 @@ namespace RevitApartmentPlans.Models {
             LevelId = level.Id;
         }
 
-        public Apartment(ICollection<RoomElement> rooms, string name) : this(rooms, name, rooms.First().Room.Level) {
-        }
-
 
         /// <summary>
         /// Номер квартиры

--- a/src/RevitApartmentPlans/Models/PluginConfig.cs
+++ b/src/RevitApartmentPlans/Models/PluginConfig.cs
@@ -44,5 +44,10 @@ namespace RevitApartmentPlans.Models {
         /// Копировать с детализацией
         /// </summary>
         public bool CopyDetail { get; set; }
+
+        /// <summary>
+        /// Обрабатывать связанные файлы
+        /// </summary>
+        public bool ProcessLinks { get; set; }
     }
 }

--- a/src/RevitApartmentPlans/Models/PluginConfig.cs
+++ b/src/RevitApartmentPlans/Models/PluginConfig.cs
@@ -39,5 +39,10 @@ namespace RevitApartmentPlans.Models {
         /// Id всех выбранных пользователем шаблонов видов для создания планов
         /// </summary>
         public ElementId[] ViewTemplates { get; set; }
+
+        /// <summary>
+        /// Копировать с детализацией
+        /// </summary>
+        public bool CopyDetail { get; set; }
     }
 }

--- a/src/RevitApartmentPlans/Models/RevitRepository.cs
+++ b/src/RevitApartmentPlans/Models/RevitRepository.cs
@@ -159,6 +159,31 @@ namespace RevitApartmentPlans.Models {
         }
 
         /// <summary>
+        /// Копирует вид с детализацией.
+        /// </summary>
+        /// <param name="view">Вид для копирования</param>
+        /// <returns>Скопированный вид с детализацией.</returns>
+        /// <exception cref="InvalidOperationException">Исключение, если не удалось скопировать вид.</exception>
+        /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null.</exception>
+        public ViewPlan DuplicateView(ViewPlan view) {
+            if(view is null) {
+                throw new ArgumentNullException(nameof(view));
+            }
+            // при копировании видов, с которыми работает плагин, проблем быть не должно,
+            // но пусть будут исключения на всякий случай
+            const ViewDuplicateOption opts = ViewDuplicateOption.WithDetailing;
+            if(view.CanViewBeDuplicated(opts)) {
+                var id = view.Duplicate(opts);
+                if(id.IsNotNull()) {
+                    return Document.GetElement(id) as ViewPlan
+                        ?? throw new InvalidOperationException(
+                            $"Пустой id скопированного вида {view.Name} с детализацией");
+                }
+            }
+            throw new InvalidOperationException($"Не удалось скопировать вид {view.Name} с детализацией");
+        }
+
+        /// <summary>
         /// Возвращает тип шаблона вида: план этажа/план потолка
         /// </summary>
         /// <param name="template">Шаблон вида</param>
@@ -180,6 +205,15 @@ namespace RevitApartmentPlans.Models {
         /// </summary>
         public bool ActiveViewIsPlan() {
             return Document.ActiveView as ViewPlan != null;
+        }
+
+        /// <summary>
+        /// Возвращает активный вид (план)
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Исключение, если активынй вид не является планом</exception>
+        public ViewPlan GetActiveViewPlan() {
+            return Document.ActiveView as ViewPlan
+                ?? throw new InvalidOperationException("Активный вид не является планом");
         }
 
 

--- a/src/RevitApartmentPlans/Models/RevitRepository.cs
+++ b/src/RevitApartmentPlans/Models/RevitRepository.cs
@@ -280,8 +280,9 @@ namespace RevitApartmentPlans.Models {
         }
 
         private ICollection<Apartment> GetApartments(ICollection<RoomElement> rooms, string paramName) {
+            var level = GetLevelOfActivePlan();
             return rooms.GroupBy(r => r.Room.GetParamValue<string>(paramName))
-                .Select(g => new Apartment(g.ToArray(), g.Key))
+                .Select(g => new Apartment(g.ToArray(), g.Key, level))
                 .ToArray();
         }
 

--- a/src/RevitApartmentPlans/Models/RoomElement.cs
+++ b/src/RevitApartmentPlans/Models/RoomElement.cs
@@ -1,0 +1,21 @@
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+
+namespace RevitApartmentPlans.Models {
+    internal class RoomElement {
+        public RoomElement(Room room, Transform transform) {
+            Room = room ?? throw new System.ArgumentNullException(nameof(room));
+            Transform = transform ?? throw new System.ArgumentNullException(nameof(transform));
+        }
+
+        public RoomElement(Room room) : this(room, Transform.Identity) { }
+
+
+        public Room Room { get; }
+        public Transform Transform { get; }
+
+        public Reference GetReference() {
+            return new Reference(Room);
+        }
+    }
+}

--- a/src/RevitApartmentPlans/Models/RoomElement.cs
+++ b/src/RevitApartmentPlans/Models/RoomElement.cs
@@ -3,19 +3,43 @@ using Autodesk.Revit.DB.Architecture;
 
 namespace RevitApartmentPlans.Models {
     internal class RoomElement {
-        public RoomElement(Room room, Transform transform) {
+        private readonly RevitLinkInstance _link;
+
+        /// <summary>
+        /// Создает обертку помещения из связи
+        /// </summary>
+        /// <param name="room">Помещение из связи</param>
+        /// <param name="link">Связь, в которой находится помещение</param>
+        /// <exception cref="System.ArgumentNullException">Исключение, если обязательный параметр null</exception>
+        public RoomElement(Room room, RevitLinkInstance link) {
             Room = room ?? throw new System.ArgumentNullException(nameof(room));
-            Transform = transform ?? throw new System.ArgumentNullException(nameof(transform));
+            _link = link ?? throw new System.ArgumentNullException(nameof(link));
+            Transform = link.GetTransform();
         }
 
-        public RoomElement(Room room) : this(room, Transform.Identity) { }
+        /// <summary>
+        /// Создает обертку помещения из активного файла
+        /// </summary>
+        /// <param name="room">Помещение из активного файла</param>
+        public RoomElement(Room room) {
+            Room = room ?? throw new System.ArgumentNullException(nameof(room));
+            Transform = Transform.Identity;
+        }
 
 
         public Room Room { get; }
+
+        /// <summary>
+        /// Трансформация помещения относительно активного файла
+        /// </summary>
         public Transform Transform { get; }
 
         public Reference GetReference() {
-            return new Reference(Room);
+            if(_link != null) {
+                return new Reference(Room).CreateLinkReference(_link);
+            } else {
+                return new Reference(Room);
+            }
         }
     }
 }

--- a/src/RevitApartmentPlans/RevitApartmentPlansCommand.cs
+++ b/src/RevitApartmentPlans/RevitApartmentPlansCommand.cs
@@ -57,7 +57,7 @@ namespace RevitApartmentPlans {
                     .InSingletonScope();
 
                 kernel.UseXtraProgressDialog<MainViewModel>();
-                kernel.UseXtraMessageBox<MainViewModel>();
+                kernel.UseXtraMessageBox<ApartmentsViewModel>();
                 kernel.Bind<ApartmentsViewModel>()
                     .ToSelf()
                     .InSingletonScope();

--- a/src/RevitApartmentPlans/RevitApartmentPlansCommand.cs
+++ b/src/RevitApartmentPlans/RevitApartmentPlansCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Windows;
 
 using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 
 using dosymep.Bim4Everyone;
@@ -51,6 +52,9 @@ namespace RevitApartmentPlans {
                     .InSingletonScope();
                 kernel.Bind<PluginConfig>()
                     .ToMethod(c => PluginConfig.GetPluginConfig());
+                kernel.Bind<LinkFilterProvider>()
+                    .ToSelf()
+                    .InSingletonScope();
 
                 kernel.UseXtraProgressDialog<MainViewModel>();
                 kernel.UseXtraMessageBox<MainViewModel>();

--- a/src/RevitApartmentPlans/Services/BoundsCalculationService.cs
+++ b/src/RevitApartmentPlans/Services/BoundsCalculationService.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 
 using Autodesk.Revit.DB;
-using Autodesk.Revit.DB.Architecture;
 
 using RevitApartmentPlans.Models;
 
@@ -48,7 +47,7 @@ namespace RevitApartmentPlans.Services {
         /// </summary>
         /// <param name="room">Помещение</param>
         /// <returns>Внешний контур помещения</returns>
-        private CurveLoop GetOuterRoomBound(Room room) {
+        private CurveLoop GetOuterRoomBound(RoomElement room) {
             return _revitRepository.GetBoundaryCurveLoops(room)
                 .OrderByDescending(loop => loop.GetExactLength())
                 .First();

--- a/src/RevitApartmentPlans/Services/IViewPlanCreationService.cs
+++ b/src/RevitApartmentPlans/Services/IViewPlanCreationService.cs
@@ -28,5 +28,25 @@ namespace RevitApartmentPlans.Services {
             double feetOffset,
             IProgress<int> progress = null,
             CancellationToken ct = default);
+
+        /// <summary>
+        /// Создает планы по квартирам с детализацией.<br/>
+        /// Для каждой квартиры формируется несколько планов по одному на каждый заданный шаблон.<br/>
+        /// Тип вида соответствует заданному виду с элементами детализаци.
+        /// </summary>
+        /// <param name="apartments">Квартиры</param>
+        /// <param name="templates">Шаблоны видов - планы этажей/планы потолков</param>
+        /// <param name="feetOffset">Наружный отступ от контура квартиры для подрезки вида</param>
+        /// <param name="detailView">Вид с элементами детализации для этой квартиры</param>
+        /// <param name="progress">Уведомитель процесса</param>
+        /// <param name="ct">Токен отмены</param>
+        /// <returns>Коллекция созданных планов по квартирам с сохраненными элементами детализации</returns>
+        ICollection<ViewPlan> CreateViews(
+            ICollection<Apartment> apartments,
+            ICollection<ViewPlan> templates,
+            double feetOffset,
+            ViewPlan detailView,
+            IProgress<int> progress = null,
+            CancellationToken ct = default);
     }
 }

--- a/src/RevitApartmentPlans/Services/LinkFilterProvider.cs
+++ b/src/RevitApartmentPlans/Services/LinkFilterProvider.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Autodesk.Revit.DB;
+
+using dosymep.Revit;
+
+namespace RevitApartmentPlans.Services {
+    internal class LinkFilterProvider {
+        public FilteredElementCollector GetFilter(RevitLinkInstance link, ViewPlan activePlan) {
+            if(link is null) {
+                throw new ArgumentNullException(nameof(link));
+            }
+            if(activePlan is null) {
+                throw new ArgumentNullException(nameof(activePlan));
+            }
+
+#if REVIT_2023_OR_LESS
+            var solid = GetCropSolid(activePlan);
+            var transform = link.GetTransform();
+            var transformedSolid = SolidUtils.CreateTransformed(solid, transform.Inverse);
+            return new FilteredElementCollector(link.GetLinkDocument())
+                .WherePasses(new ElementIntersectsSolidFilter(transformedSolid));
+#else
+            return new FilteredElementCollector(activePlan.Document, activePlan.Id, link.Id);
+#endif
+        }
+
+        /// <summary>
+        /// Строит солид путем выдавливания формы области подрезки от секущей плоскости вверх на 1 фут
+        /// </summary>
+        /// <param name="viewPlan">План для создания солида</param>
+        /// <returns>Солид области подрезки</returns>
+        private Solid GetCropSolid(ViewPlan viewPlan) {
+            var cutZ = GetCutPlaneZ(viewPlan);
+            var loops = GetShape(viewPlan, cutZ);
+            return GeometryCreationUtilities.CreateExtrusionGeometry(loops, XYZ.BasisZ, 1);
+        }
+
+        /// <summary>
+        /// Возвращает форму области подрезки плана, если она включена, или прямоугольник по боксу
+        /// </summary>
+        private IList<CurveLoop> GetShape(ViewPlan viewPlan, double z) {
+            var shape = viewPlan.GetCropRegionShapeManager().GetCropShape().Select(loop => CopyToZ(loop, z)).ToArray();
+            if(shape is null) {
+                var box = viewPlan.GetBoundingBox();
+
+                var bottomLeft = new XYZ(box.Min.X, box.Min.Y, z);
+                var topLeft = new XYZ(box.Min.X, box.Max.Y, z);
+                var topRight = new XYZ(box.Max.X, box.Max.Y, z);
+                var bottomRight = new XYZ(box.Max.X, box.Min.Y, z);
+
+                shape = new CurveLoop[]{ CurveLoop.Create(new Curve[] {
+                    Line.CreateBound(bottomLeft, topLeft),
+                    Line.CreateBound(topLeft, topRight),
+                    Line.CreateBound(topRight, bottomRight),
+                    Line.CreateBound(bottomRight, bottomLeft)
+                })};
+            }
+            return shape;
+        }
+
+        private CurveLoop CopyToZ(CurveLoop loop, double z) {
+            double loopZ = loop.First().GetEndPoint(0).Z;
+            var transform = Transform.CreateTranslation(new XYZ(0, 0, z - loopZ));
+            return CurveLoop.CreateViaTransform(loop, transform);
+        }
+
+        private double GetCutPlaneZ(ViewPlan viewPlan) {
+            var viewRange = viewPlan.GetViewRange();
+            var doc = viewPlan.Document;
+            // ссылки на другие уровни (сверху/внизу) нельзя получить, если там установлено уровень выше/неограниченный.
+            // поэтому берем уровень секущей плоскости
+            var cutLevel = doc.GetElement(viewRange.GetLevelId(PlanViewPlane.CutPlane)) as Level;
+
+            return viewRange.GetOffset(PlanViewPlane.BottomClipPlane) + cutLevel.Elevation;
+        }
+    }
+}

--- a/src/RevitApartmentPlans/Services/LinkFilterProvider.cs
+++ b/src/RevitApartmentPlans/Services/LinkFilterProvider.cs
@@ -18,7 +18,9 @@ namespace RevitApartmentPlans.Services {
                 throw new ArgumentNullException(nameof(activePlan));
             }
 
-#if REVIT_2023_OR_LESS
+#if REVIT_2024_OR_GREATER
+            return new FilteredElementCollector(activePlan.Document, activePlan.Id, link.Id);
+#else
             var solid = GetCropSolid(activePlan);
             var transform = link.GetTransform();
             var box = solid.GetTransformedBoundingBox().TransformBoundingBox(transform.Inverse);
@@ -37,11 +39,10 @@ namespace RevitApartmentPlans.Services {
                 .ToElements();
             return new FilteredElementCollector(link.GetLinkDocument())
                 .WherePasses(new BoundingBoxIntersectsFilter(new Outline(box.Min, box.Max)));
-#else
-            return new FilteredElementCollector(activePlan.Document, activePlan.Id, link.Id);
 #endif
         }
 
+#if REVIT_2023_OR_LESS
         /// <summary>
         /// Строит солид путем выдавливания формы области подрезки от секущей плоскости вверх на 1 фут
         /// </summary>
@@ -91,5 +92,6 @@ namespace RevitApartmentPlans.Services {
 
             return viewRange.GetOffset(PlanViewPlane.CutPlane) + cutLevel.Elevation;
         }
+#endif
     }
 }

--- a/src/RevitApartmentPlans/Services/LinkFilterProvider.cs
+++ b/src/RevitApartmentPlans/Services/LinkFilterProvider.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Autodesk.Revit.DB;
-using Autodesk.Revit.DB.Architecture;
 
 using dosymep.Revit;
 using dosymep.Revit.Geometry;
@@ -24,19 +23,7 @@ namespace RevitApartmentPlans.Services {
             var solid = GetCropSolid(activePlan);
             var transform = link.GetTransform();
             var box = solid.GetTransformedBoundingBox().TransformBoundingBox(transform.Inverse);
-            var t0 = new FilteredElementCollector(link.GetLinkDocument())
-                .WherePasses(new BoundingBoxIntersectsFilter(new Outline(box.Min, box.Max)));
-
-            var t01 = t0.WherePasses(new RoomFilter())
-                         .Cast<Room>()
-                         .Where(r => r.Area > 0 && r.IsExistsParamValue("Кем занято"))
-                         .ToArray();
-            var transformedSolid = SolidUtils.CreateTransformed(solid, transform.Inverse);
-            var t = new FilteredElementCollector(link.GetLinkDocument())
-                .WhereElementIsNotElementType()
-                .WherePasses(new ElementIntersectsSolidFilter(transformedSolid))
-                .WherePasses(new RoomFilter())
-                .ToElements();
+            // ElementIntersectsSolidFilter не фильтрует помещения
             return new FilteredElementCollector(link.GetLinkDocument())
                 .WherePasses(new BoundingBoxIntersectsFilter(new Outline(box.Min, box.Max)));
 #endif

--- a/src/RevitApartmentPlans/ViewModels/MainViewModel.cs
+++ b/src/RevitApartmentPlans/ViewModels/MainViewModel.cs
@@ -12,7 +12,6 @@ namespace RevitApartmentPlans.ViewModels {
     internal class MainViewModel : BaseViewModel {
         private readonly PluginConfig _pluginConfig;
         private readonly RevitRepository _revitRepository;
-        private readonly IMessageBoxService _messageBoxService;
         private readonly IViewPlanCreationService _viewPlanCreationService;
         private readonly ILengthConverter _lengthConverter;
         private readonly IProgressDialogFactory _progressDialogFactory;
@@ -37,7 +36,6 @@ namespace RevitApartmentPlans.ViewModels {
             RevitRepository revitRepository,
             ViewTemplatesViewModel viewTemplatesViewModel,
             ApartmentsViewModel apartmentsViewModel,
-            IMessageBoxService messageBoxService,
             IViewPlanCreationService viewPlanCreationService,
             ILengthConverter lengthConverter,
             IProgressDialogFactory progressDialogFactory
@@ -51,8 +49,6 @@ namespace RevitApartmentPlans.ViewModels {
                 ?? throw new System.ArgumentNullException(nameof(viewTemplatesViewModel));
             ApartmentsViewModel = apartmentsViewModel
                 ?? throw new System.ArgumentNullException(nameof(apartmentsViewModel));
-            _messageBoxService = messageBoxService
-                ?? throw new System.ArgumentNullException(nameof(messageBoxService));
             _viewPlanCreationService = viewPlanCreationService
                 ?? throw new System.ArgumentNullException(nameof(viewPlanCreationService));
             _lengthConverter = lengthConverter
@@ -64,7 +60,7 @@ namespace RevitApartmentPlans.ViewModels {
         }
 
         public IProgressDialogFactory ProgressDialogFactory => _progressDialogFactory;
-        public IMessageBoxService MessageBoxService => _messageBoxService;
+
         public ICommand LoadViewCommand { get; }
         public ICommand AcceptViewCommand { get; }
 

--- a/src/RevitApartmentPlans/ViewModels/MainViewModel.cs
+++ b/src/RevitApartmentPlans/ViewModels/MainViewModel.cs
@@ -91,12 +91,6 @@ namespace RevitApartmentPlans.ViewModels {
             set => RaiseAndSetIfChanged(ref _copyDetail, value);
         }
 
-        private bool _processLinks;
-        public bool ProcessLinks {
-            get => _processLinks;
-            set => RaiseAndSetIfChanged(ref _processLinks, value);
-
-        }
 
         private void LoadView() {
             LoadConfig();
@@ -170,7 +164,6 @@ namespace RevitApartmentPlans.ViewModels {
 
             OffsetMm = setting?.OffsetMm ?? _defaultOffsetMm;
             CopyDetail = setting?.CopyDetail ?? false;
-            ProcessLinks = setting?.ProcessLinks ?? false;
         }
 
         private void SaveConfig() {
@@ -180,7 +173,7 @@ namespace RevitApartmentPlans.ViewModels {
             setting.ParamName = ApartmentsViewModel?.SelectedParam?.Name ?? string.Empty;
             setting.ViewTemplates = ViewTemplatesViewModel?.ViewTemplates?.Select(t => t.GetTemplate().Id).ToArray();
             setting.CopyDetail = CopyDetail;
-            setting.ProcessLinks = ProcessLinks;
+            setting.ProcessLinks = ApartmentsViewModel?.ProcessLinks ?? false;
             _pluginConfig.SaveProjectConfig();
         }
     }

--- a/src/RevitApartmentPlans/ViewModels/MainViewModel.cs
+++ b/src/RevitApartmentPlans/ViewModels/MainViewModel.cs
@@ -91,6 +91,12 @@ namespace RevitApartmentPlans.ViewModels {
             set => RaiseAndSetIfChanged(ref _copyDetail, value);
         }
 
+        private bool _processLinks;
+        public bool ProcessLinks {
+            get => _processLinks;
+            set => RaiseAndSetIfChanged(ref _processLinks, value);
+
+        }
 
         private void LoadView() {
             LoadConfig();
@@ -164,6 +170,7 @@ namespace RevitApartmentPlans.ViewModels {
 
             OffsetMm = setting?.OffsetMm ?? _defaultOffsetMm;
             CopyDetail = setting?.CopyDetail ?? false;
+            ProcessLinks = setting?.ProcessLinks ?? false;
         }
 
         private void SaveConfig() {
@@ -173,6 +180,7 @@ namespace RevitApartmentPlans.ViewModels {
             setting.ParamName = ApartmentsViewModel?.SelectedParam?.Name ?? string.Empty;
             setting.ViewTemplates = ViewTemplatesViewModel?.ViewTemplates?.Select(t => t.GetTemplate().Id).ToArray();
             setting.CopyDetail = CopyDetail;
+            setting.ProcessLinks = ProcessLinks;
             _pluginConfig.SaveProjectConfig();
         }
     }

--- a/src/RevitApartmentPlans/Views/MainWindow.xaml
+++ b/src/RevitApartmentPlans/Views/MainWindow.xaml
@@ -115,8 +115,7 @@
             <dxe:CheckEdit EditValue="{Binding CopyDetail}"
                            Content="Копировать с детализацией"
                            Margin="5 0 0 0"/>
-            <dxe:CheckEdit
-                EditValue="{Binding ApartmentsViewModel.ProcessLinks}"
+            <dxe:CheckEdit EditValue="{Binding ApartmentsViewModel.ProcessLinks}"
                            Content="Обрабатывать связи"
                            Margin="5 0 0 0"/>
             <DockPanel HorizontalAlignment="Right">

--- a/src/RevitApartmentPlans/Views/MainWindow.xaml
+++ b/src/RevitApartmentPlans/Views/MainWindow.xaml
@@ -26,7 +26,7 @@
         <dxmvvm:EventToCommand EventName="Loaded"
                                Command="{Binding LoadViewCommand}" />
         <common:AttachServiceBehavior AttachableService="{Binding ProgressDialogFactory}" />
-        <common:AttachServiceBehavior AttachableService="{Binding MessageBoxService}" />
+        <common:AttachServiceBehavior AttachableService="{Binding ApartmentsViewModel.MessageBoxService}" />
     </dxmvvm:Interaction.Behaviors>
 
     <Window.Resources>
@@ -90,7 +90,7 @@
 
         <DockPanel Grid.Row="0"
                    Margin="5"
-                   HorizontalAlignment="Left">
+                   HorizontalAlignment="Stretch">
             <TextBlock Text="Отступ: "
                        TextAlignment="Center"
                        VerticalAlignment="Center" />
@@ -119,6 +119,25 @@
                 EditValue="{Binding ApartmentsViewModel.ProcessLinks}"
                            Content="Обрабатывать связи"
                            Margin="5 0 0 0"/>
+            <DockPanel HorizontalAlignment="Right">
+                <DockPanel.Resources>
+                    <Style TargetType="dx:SimpleButton">
+                            <Setter Property="Visibility"
+                                    Value="Hidden" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding ApartmentsViewModel.ShowWarningButton}"
+                                         Value="True">
+                                <Setter Property="Visibility"
+                                        Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </DockPanel.Resources>
+                <dx:SimpleButton Width="25"
+                                 Height="25"
+                                 Glyph="{dx:DXImage 'Images/Status/Warning_16x16.png'}"
+                                 Command="{Binding ApartmentsViewModel.ShowWarningCommand}" />
+            </DockPanel>
         </DockPanel>
 
         <Grid Grid.Row="1"

--- a/src/RevitApartmentPlans/Views/MainWindow.xaml
+++ b/src/RevitApartmentPlans/Views/MainWindow.xaml
@@ -115,6 +115,9 @@
             <dxe:CheckEdit EditValue="{Binding CopyDetail}"
                            Content="Копировать с детализацией"
                            Margin="5 0 0 0"/>
+            <dxe:CheckEdit EditValue="{Binding ProcessLinks}"
+                           Content="Обрабатывать связи"
+                           Margin="5 0 0 0"/>
         </DockPanel>
 
         <Grid Grid.Row="1"

--- a/src/RevitApartmentPlans/Views/MainWindow.xaml
+++ b/src/RevitApartmentPlans/Views/MainWindow.xaml
@@ -115,7 +115,8 @@
             <dxe:CheckEdit EditValue="{Binding CopyDetail}"
                            Content="Копировать с детализацией"
                            Margin="5 0 0 0"/>
-            <dxe:CheckEdit EditValue="{Binding ProcessLinks}"
+            <dxe:CheckEdit
+                EditValue="{Binding ApartmentsViewModel.ProcessLinks}"
                            Content="Обрабатывать связи"
                            Margin="5 0 0 0"/>
         </DockPanel>

--- a/src/RevitApartmentPlans/Views/MainWindow.xaml
+++ b/src/RevitApartmentPlans/Views/MainWindow.xaml
@@ -112,6 +112,9 @@
                               IsCaseSensitiveFilter="False"
                               PopupMaxHeight="250"
                               NullText="Выберите параметр для группировки" />
+            <dxe:CheckEdit EditValue="{Binding CopyDetail}"
+                           Content="Копировать с детализацией"
+                           Margin="5 0 0 0"/>
         </DockPanel>
 
         <Grid Grid.Row="1"


### PR DESCRIPTION
# Обновления

- Добавлена обработка помещений из связанных файлов. В 2022 и 2023 может работать некорректно из-за отсутствующего функционала в api revit:
    - [перегрузка](https://www.revitapidocs.com/2024/968b52a0-de55-2f96-de40-968812bc41c7.htm) конструктора `FilteredElementCollector` для фильтрации элементов из связи, видимых на виде активного документа, которая появилась только в 2024 версии
    - [выделение](https://www.revitapidocs.com/2023/813a9d31-bc4f-1ebc-9a7b-69a2a99d22ac.htm) элементов из связей через `Reference`, которое появилось только в 2023 версии
- Добавлена возможность копировать элементы детализации с активного вида

## Обновленный интерфейс главного окна

![image](https://github.com/user-attachments/assets/039e9b1a-b597-4a6e-a220-9472591350df)

При включении обработки связей в 2022 и 2023 версии появляется кнопка для отображения предупреждения:

![image](https://github.com/user-attachments/assets/766ff9d9-d844-4c8b-80f3-95c58971712b)

