### PR TITLE
RevitReinforcementCoefficient: Изменен расчет арматуры

### DIFF
--- a/src/RevitReinforcementCoefficient/Models/Analyzers/DesignTypeListAnalyzer.cs
+++ b/src/RevitReinforcementCoefficient/Models/Analyzers/DesignTypeListAnalyzer.cs
@@ -84,7 +84,8 @@ namespace RevitReinforcementCoefficient.Models.Analyzers {
                 // Сделали преобразование null в "" из-за того, что фильтрация в GUI иначе нормально не отрабатывает
                 string docPackage = element.GetParamValue<string>(_documentationSet) ?? "";
                 string elemSection = element.GetParamValue<string>(_section) ?? "";
-                bool aboveZero = element.GetParamValue<int>(_organizationalLevel) > 0;
+                var organizationalLevelAsStr = element.GetParam(_organizationalLevel).AsValueString();
+                bool aboveZero = !organizationalLevelAsStr.Contains('-');
 
                 // Ищем подходящий тип конструкции среди уже существующих в списке
                 DesignTypeVM designType = designTypes.FirstOrDefault(

--- a/src/RevitReinforcementCoefficient/Models/Analyzers/DesignTypeListAnalyzer.cs
+++ b/src/RevitReinforcementCoefficient/Models/Analyzers/DesignTypeListAnalyzer.cs
@@ -84,6 +84,9 @@ namespace RevitReinforcementCoefficient.Models.Analyzers {
                 // Сделали преобразование null в "" из-за того, что фильтрация в GUI иначе нормально не отрабатывает
                 string docPackage = element.GetParamValue<string>(_documentationSet) ?? "";
                 string elemSection = element.GetParamValue<string>(_section) ?? "";
+
+                // Следующий код реализован представленным образом в связи с проблемой, когда параметр с именем 
+                // _organizationalLevel может иметь разный тип данных
                 var organizationalLevelAsStr = element.GetParam(_organizationalLevel).AsValueString();
                 bool aboveZero = !organizationalLevelAsStr.Contains('-');
 

--- a/src/RevitReinforcementCoefficient/Models/ElementModels/RebarElement.cs
+++ b/src/RevitReinforcementCoefficient/Models/ElementModels/RebarElement.cs
@@ -11,7 +11,12 @@ namespace RevitReinforcementCoefficient.Models.ElementModels {
 
         // Соотношение между диаметром арматурного стержня и массой его одного метра
         private readonly Dictionary<double, double> _massPerLengthDict = new Dictionary<double, double>() {
+            { 4, 0.098},
+            { 5, 0.144},
+            { 6, 0.222},
+            { 7, 0.302},
             { 8, 0.395},
+            { 9, 0.499},
             { 10, 0.617},
             { 12, 0.888},
             { 14, 1.208},
@@ -74,7 +79,8 @@ namespace RevitReinforcementCoefficient.Models.ElementModels {
         public double Calculate() {
             int numberOfForm = _utils.GetParamValueAnywhere<int>(RevitElement, _numberOfFormParamName);
             double dimeter = _utils.GetParamValueAnywhere<double>(RevitElement, _dimeterParamName);
-            double dimeterInMm = UnitUtilsHelper.ConvertFromInternalValue(dimeter);
+            double dimeterInMm = Math.Round(UnitUtilsHelper.ConvertFromInternalValue(dimeter));
+
             int calcInLinearMeters = _utils.GetParamValueAnywhere<int>(RevitElement, _calcInLinearMetersParamName);
             int countInLevel = _utils.GetParamValueAnywhere<int>(RevitElement, _countInLevelParamName);
             int countOfLevel = _utils.GetParamValueAnywhere<int>(RevitElement, _countOfLevelParamName);
@@ -103,7 +109,7 @@ namespace RevitReinforcementCoefficient.Models.ElementModels {
             // @Базовый_Масса на единицу длины
             // Погонная масса арматуры
             double massPerUnitLength;
-            // Сравниваем номер формы арматурногно стержня и граничный номер формы для арматуры (обычно 2000)
+            // Сравниваем номер формы арматурного стержня и граничный номер формы для арматуры (обычно 2000)
             if(numberOfForm < _limitNumberOfForm) {
 
                 // TODO реализовать вывод в отчет с уведомлением, что один из стержней не посчитался


### PR DESCRIPTION
Решены проблемы:
- не учтены некоторые диаметры арматурных стержней для расчета;
- данные, которые в Revit в параметре записаны целым числом иногда могут приходить с дробной частью после конвертации из внутренних единиц; 
- решена проблема двойственности параметра "обр_ФОП_Орг. уровень" в семействах (и различия их типов данных; в результате несогласованных действий разработчиков семейств, некоторые семейства могут содержать два параметра с именем "обр_ФОП_Орг. уровень" разных типов данных).