### PR TITLE
RevitMechanicalSpecification: Единицы измерения

### DIFF
--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamUnitFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamUnitFiller.cs
@@ -70,8 +70,9 @@ namespace RevitMechanicalSpecification.Models.Fillers {
                 return Config.SingleUnit;
             }
             if(_kitNames.Contains(unit)) {
-                return Config.SingleUnit;
+                return Config.KitUnit;
             }
+            
             return defaultUnit;
         }
 
@@ -96,9 +97,9 @@ namespace RevitMechanicalSpecification.Models.Fillers {
             }
             if(element.Category.IsId(BuiltInCategory.OST_PipeInsulations)) {
                 return DefaultCheck(Config.MeterUnit);
+            } else {
+                return DefaultCheck(Config.SingleUnit);
             }
-
-            return Config.SingleUnit;
         }
     }
 }


### PR DESCRIPTION
Правка филлера единиц измерения - ранее игнорировались размерности комплектов, заменяясь штуками.