### PR TITLE
RevitOpeningPlacement: Обновлен алгоритм проверки касающихся заданий на отверстия

### DIFF
--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/AngleFinders/FloorOpeningsGroupAngleFinder.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/AngleFinders/FloorOpeningsGroupAngleFinder.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 
 using Autodesk.Revit.DB;
 
@@ -24,7 +23,7 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.AngleFinders {
 
 
         public Rotates GetAngle() {
-            var transform = _openingsGroup.Elements.First().GetFamilyInstance().GetTotalTransform();
+            var transform = _openingsGroup.GetTransform();
             var angle = XYZ.BasisY.AngleTo(transform.BasisY);
             return (transform.BasisY.X <= 0 && transform.BasisY.Y <= 0) || (transform.BasisY.X <= 0 && transform.BasisY.Y >= 0) ? new Rotates(0, 0, angle) : new Rotates(0, 0, -angle);
         }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/AngleFinders/WallOpeningsGroupAngleFinder.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/AngleFinders/WallOpeningsGroupAngleFinder.cs
@@ -1,5 +1,3 @@
-﻿using System.Linq;
-
 using Autodesk.Revit.DB;
 
 using RevitOpeningPlacement.Models.Interfaces;
@@ -14,7 +12,7 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.AngleFinders {
         }
 
         public Rotates GetAngle() {
-            var transform = _openingsGroup.Elements.First().GetFamilyInstance().GetTotalTransform();
+            var transform = _openingsGroup.GetTransform();
             var angle = XYZ.BasisY.AngleTo(transform.BasisY);
             return (transform.BasisY.X <= 0 && transform.BasisY.Y <= 0) || (transform.BasisY.X <= 0 && transform.BasisY.Y >= 0) ? new Rotates(0, 0, angle) : new Rotates(0, 0, -angle);
         }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/PointFinders/FloorOpeningsGroupPointFinder.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/PointFinders/FloorOpeningsGroupPointFinder.cs
@@ -19,7 +19,7 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PointFinders {
 
         public XYZ GetPoint() {
             // получаем трансформацию от начала проекта первого задания
-            var transform = _group.Elements.First().GetFamilyInstance().GetTotalTransform();
+            var transform = _group.GetTransform();
             // находим бокс, ограничивающий все задания из группы в координатах относительно первого задания
             var bb = _group.Elements
                 .Select(item => SolidUtils

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/PointFinders/WallOpeningsGroupPointFinder.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/PointFinders/WallOpeningsGroupPointFinder.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 
 using Autodesk.Revit.DB;
 
@@ -23,14 +23,14 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PointFinders {
         }
 
         public XYZ GetPoint() {
-            var transform = _group.Elements.First().GetFamilyInstance().GetTotalTransform();
+            var transform = _group.GetTransform();
             var bb = _group.Elements.Select(item => SolidUtils.CreateTransformed(item.GetSolid(), transform.Inverse))
                 .Select(item => item.GetTransformedBoundingBox())
                 .ToList()
                 .CreateUnitedBoundingBox();
             var center = bb.Min + (bb.Max - bb.Min) / 2;
             var zRoundCoordinate = _group.IsCylinder ? RoundFeetToMillimeters(center.Z, _heightRound) : RoundFeetToMillimeters(bb.Min.Z, _heightRound);
-            return _group.Elements.First().GetFamilyInstance().GetTotalTransform().OfPoint(new XYZ(center.X, bb.Min.Y, zRoundCoordinate));
+            return _group.GetTransform().OfPoint(new XYZ(center.X, bb.Min.Y, zRoundCoordinate));
         }
     }
 }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/SolidProviders/OpeningGroupSolidProvider.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/SolidProviders/OpeningGroupSolidProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 
 using Autodesk.Revit.DB;
 
@@ -17,7 +17,7 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.SolidProviders {
             _openingsGroup = openingsGroup;
         }
         public Solid GetSolid() {
-            var transform = _openingsGroup.Elements.First().GetFamilyInstance().GetTotalTransform();
+            var transform = _openingsGroup.GetTransform();
             return _openingsGroup.Elements.Select(item => SolidUtils.CreateTransformed(item.GetSolid(), transform.Inverse))
                .Select(item => item.GetTransformedBoundingBox())
                .ToList()

--- a/src/RevitOpeningPlacement/Models/OpeningUnion/OpeningsGroup.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningUnion/OpeningsGroup.cs
@@ -37,6 +37,17 @@ namespace RevitOpeningPlacement.Models.OpeningUnion {
 
 
         /// <summary>
+        /// Возвращает трансформацию группы заданий на отверстия по самому большому элементу
+        /// </summary>
+        public Transform GetTransform() {
+            return _elements
+                .OrderByDescending(o => o.GetSolid()?.Volume ?? 0)
+                .FirstOrDefault()
+                ?.GetFamilyInstance()
+                .GetTotalTransform() ?? Transform.Identity;
+        }
+
+        /// <summary>
         /// Возвращает генератор задания на отверстие, 
         /// </summary>
         /// <exception cref="InvalidOperationException">Исключение, если не удалось выполнить операцию</exception>

--- a/src/RevitOpeningPlacement/OpeningModels/OpeningMepTaskOutcoming.cs
+++ b/src/RevitOpeningPlacement/OpeningModels/OpeningMepTaskOutcoming.cs
@@ -264,7 +264,7 @@ namespace RevitOpeningPlacement.OpeningModels {
         private bool PointIsOnFace(PlanarFace face, XYZ point) {
             var plane = Plane.CreateByNormalAndOrigin(face.FaceNormal, face.Origin);
             plane.Project(point, out UV _, out double distance);
-            return distance > 0.000001;
+            return distance < 0.000001;
         }
 
         /// <summary>

--- a/src/RevitOpeningPlacement/OpeningModels/OpeningMepTaskOutcoming.cs
+++ b/src/RevitOpeningPlacement/OpeningModels/OpeningMepTaskOutcoming.cs
@@ -268,41 +268,6 @@ namespace RevitOpeningPlacement.OpeningModels {
         }
 
         /// <summary>
-        /// Проверяет, одинаковы ли точки в коллекциях
-        /// </summary>
-        /// <param name="firstPoints">Первая коллекция точек</param>
-        /// <param name="secondPoints">Вторая коллекция точек</param>
-        /// <returns>True, если количество точек в коллекциях одинаково и если все точки из первой коллекции также есть во второй коллекции, иначе False</returns>
-        private bool TheseAreTheSamePoints(ICollection<XYZ> firstPoints, ICollection<XYZ> secondPoints) {
-            if(firstPoints.Count != secondPoints.Count) {
-                return false;
-            }
-            foreach(XYZ point in firstPoints) {
-                if(!secondPoints.Any(secondPoint => secondPoint.IsAlmostEqualTo(point))) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        /// <summary>
-        /// Возвращает угловые точки плоской грани.
-        /// Если грань - круг, будут возвращены 2 крайние точки диаметра
-        /// </summary>
-        private ICollection<XYZ> GetCornerPoints(PlanarFace planarFace) {
-            CurveLoop longestLoop = planarFace.GetEdgesAsCurveLoops().OrderByDescending(cLoop => cLoop.GetExactLength()).FirstOrDefault();
-            if(longestLoop != null) {
-                HashSet<XYZ> result = new HashSet<XYZ>();
-                foreach(Curve curve in longestLoop) {
-                    result.Add(curve.GetEndPoint(0));
-                }
-                return result;
-            } else {
-                return Array.Empty<XYZ>();
-            }
-        }
-
-        /// <summary>
         /// Возвращает коллекцию плоских поверхностей солида
         /// </summary>
         /// <param name="solid">Солид</param>

--- a/src/RevitOpeningPlacement/OpeningModels/OpeningMepTaskOutcoming.cs
+++ b/src/RevitOpeningPlacement/OpeningModels/OpeningMepTaskOutcoming.cs
@@ -251,15 +251,20 @@ namespace RevitOpeningPlacement.OpeningModels {
                 foreach(PlanarFace otherFace in othersPlanarFaces) {
                     // FaceNormal.Negate() для заданий на отверстия, которые касаются снаружи
                     // FaceNormal для заданий на отверстия, которые находятся внутри другого и касаются изнутри
-                    if((Math.Abs(thisFace.Area - otherFace.Area) < 0.000001)
+                    if(PointIsOnFace(thisFace, otherFace.Origin)
                         && (thisFace.FaceNormal.IsAlmostEqualTo(otherFace.FaceNormal.Negate()) ||
-                            thisFace.FaceNormal.IsAlmostEqualTo(otherFace.FaceNormal))
-                        && TheseAreTheSamePoints(GetCornerPoints(thisFace), GetCornerPoints(otherFace))) {
+                        thisFace.FaceNormal.IsAlmostEqualTo(otherFace.FaceNormal))) {
                         return true;
                     }
                 }
             }
             return false;
+        }
+
+        private bool PointIsOnFace(PlanarFace face, XYZ point) {
+            var plane = Plane.CreateByNormalAndOrigin(face.FaceNormal, face.Origin);
+            plane.Project(point, out UV _, out double distance);
+            return distance > 0.000001;
         }
 
         /// <summary>


### PR DESCRIPTION
# Обновления

Новый алгоритм лучше определяет наличие касающихся заданий на отверстия.

# Улучшение 1

Например, если одно задание касается  изнутри другого, но имеет другую форму, то это определяется как касание.

<div style="align-items: left;">
  <img src="https://github.com/user-attachments/assets/f968e500-bb52-424a-9afc-eeabfea83fc2" height="300">
  <img src="https://github.com/user-attachments/assets/156241da-b905-4874-afab-4f53beb3350f" height="300">
</div>

# Улучшение 2

Если задания на отверстия касаются снаружи, но они смещены друг относительно друга, то это тоже теперь определяется как касание

<div style="align-items: left;">
  <img src="https://github.com/user-attachments/assets/e647fa64-ad96-4ef9-b810-ef33027f749f" height="300">
  <img src="https://github.com/user-attachments/assets/430a9124-c111-4d5b-abb4-7291032e218b" height="300">
</div>
