### PR TITLE
RevitCreatingFiltersByValues: Изменен способ получения элементов

### DIFF
--- a/src/RevitCreatingFiltersByValues/Models/ExportContext.cs
+++ b/src/RevitCreatingFiltersByValues/Models/ExportContext.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+
+using Autodesk.Revit.DB;
+
+namespace RevitCreatingFiltersByValues.Models {
+    public class ExportContext : IExportContext {
+        private readonly Document _document;
+        public List<Element> ExportedElements { get; } = new List<Element>();
+
+        public ExportContext(Document document) {
+            _document = document;
+        }
+
+        public bool Start() {
+            return true;
+        }
+
+        public void Finish() {
+        }
+
+        public RenderNodeAction OnElementBegin(ElementId elementId) {
+            // Получаем элемент по его ID
+            Element element = _document.GetElement(elementId);
+            if(element != null) {
+                ExportedElements.Add(element);
+            }
+            return RenderNodeAction.Proceed;
+        }
+
+        // Остальные методы интерфейса IExportContext
+        public RenderNodeAction OnViewBegin(ViewNode node) => RenderNodeAction.Proceed;
+        public RenderNodeAction OnInstanceBegin(InstanceNode node) => RenderNodeAction.Proceed;
+        public void OnElementEnd(ElementId elementId) { }
+        public void OnInstanceEnd(InstanceNode node) { }
+        public void OnViewEnd(ElementId elementId) { }
+        public void OnPolymesh(PolymeshTopology node) { }
+        public void OnMaterial(MaterialNode node) { }
+
+        public bool IsCanceled() {
+            return false;
+        }
+
+        public RenderNodeAction OnLinkBegin(LinkNode node) {
+            return RenderNodeAction.Proceed;
+        }
+
+        public void OnLinkEnd(LinkNode node) { }
+
+        public RenderNodeAction OnFaceBegin(FaceNode node) {
+            return RenderNodeAction.Proceed;
+        }
+
+        public void OnFaceEnd(FaceNode node) { }
+
+        public void OnRPC(RPCNode node) { }
+
+        public void OnLight(LightNode node) { }
+    }
+}

--- a/src/RevitCreatingFiltersByValues/Models/ExportContext.cs
+++ b/src/RevitCreatingFiltersByValues/Models/ExportContext.cs
@@ -6,6 +6,7 @@ namespace RevitCreatingFiltersByValues.Models {
     public class ExportContext : IExportContext {
         private readonly Document _document;
         public List<Element> ExportedElements { get; } = new List<Element>();
+        private Document _currentLinkDocument;
 
         public ExportContext(Document document) {
             _document = document;
@@ -19,8 +20,7 @@ namespace RevitCreatingFiltersByValues.Models {
         }
 
         public RenderNodeAction OnElementBegin(ElementId elementId) {
-            // Получаем элемент по его ID
-            Element element = _document.GetElement(elementId);
+            Element element = _currentLinkDocument?.GetElement(elementId) ?? _document.GetElement(elementId);
             if(element != null) {
                 ExportedElements.Add(element);
             }
@@ -41,19 +41,20 @@ namespace RevitCreatingFiltersByValues.Models {
         }
 
         public RenderNodeAction OnLinkBegin(LinkNode node) {
+            _currentLinkDocument = node.GetDocument();
             return RenderNodeAction.Proceed;
         }
 
-        public void OnLinkEnd(LinkNode node) { }
+        public void OnLinkEnd(LinkNode node) {
+            _currentLinkDocument = null;
+        }
 
         public RenderNodeAction OnFaceBegin(FaceNode node) {
             return RenderNodeAction.Proceed;
         }
 
         public void OnFaceEnd(FaceNode node) { }
-
         public void OnRPC(RPCNode node) { }
-
         public void OnLight(LightNode node) { }
     }
 }

--- a/src/RevitCreatingFiltersByValues/Models/FilterElemsByExportService.cs
+++ b/src/RevitCreatingFiltersByValues/Models/FilterElemsByExportService.cs
@@ -1,9 +1,6 @@
 using System.Collections.Generic;
-using System.Linq;
 
 using Autodesk.Revit.DB;
-
-using dosymep.Revit;
 
 namespace RevitCreatingFiltersByValues.Models {
     internal class FilterElemsByExportService {
@@ -16,51 +13,18 @@ namespace RevitCreatingFiltersByValues.Models {
         /// <summary>
         /// Получает элементы, видимые на виде при помощи функции экспорта
         /// </summary>
-        /// <returns></returns>
-        public List<Element> GetElemetns() {
+        public List<Element> GetElements() {
             View activeView = _doc.ActiveView;
-            // Список для хранения всех экспортированных элементов
             List<Element> allExportedElements = new List<Element>();
 
-            var linkInstances = new FilteredElementCollector(_doc, activeView.Id)
-                .OfClass(typeof(RevitLinkInstance))
-                .Cast<RevitLinkInstance>()
-                .ToList();
+            var exportContext = new ExportContext(_doc);
+            CustomExporter exporter = new CustomExporter(_doc, exportContext) {
+                IncludeGeometricObjects = true,
+                ShouldStopOnError = false
+            };
+            exporter.Export(activeView);
 
-            using(Transaction transaction = _doc.StartTransaction("Временное скрытие/изоляция")) {
-                // Для корректного получения элементов на виде (в т.ч. из связанных файлов),
-                // чтобы избежать дублирования необходимо сначала временно скрыть все экземпляры
-                // связанных файлов и произвести экспорт того, что есть в текущем файле.
-                // Затем вернуть отображение связей, изолировать их по одной и производить экспорт
-                activeView.HideElements(linkInstances.Select(x => x.Id).ToList());
-
-                var exportContext = new ExportContext(_doc);
-                CustomExporter exporter = new CustomExporter(_doc, exportContext) {
-                    IncludeGeometricObjects = true,
-                    ShouldStopOnError = false
-                };
-                exporter.Export(activeView);
-
-                allExportedElements.AddRange(exportContext.ExportedElements);
-                activeView.UnhideElements(linkInstances.Select(x => x.Id).ToList());
-
-                foreach(var linkInstance in linkInstances) {
-                    activeView.IsolateElementsTemporary(new List<ElementId> { linkInstance.Id });
-
-                    exportContext = new ExportContext(linkInstance.GetLinkDocument());
-                    exporter = new CustomExporter(_doc, exportContext) {
-                        IncludeGeometricObjects = true,
-                        ShouldStopOnError = false
-                    };
-                    exporter.Export(activeView);
-
-                    allExportedElements.AddRange(exportContext.ExportedElements);
-                    activeView.DisableTemporaryViewMode(TemporaryViewMode.TemporaryHideIsolate);
-                }
-                // Манипуляции со скрытием/отображением необходимо производить под транзакцией
-                // но в дальнейшем она не нужна, поэтому сбрасываем ее
-                transaction.RollBack();
-            }
+            allExportedElements.AddRange(exportContext.ExportedElements);
             return allExportedElements;
         }
     }

--- a/src/RevitCreatingFiltersByValues/Models/FilterElemsByExportService.cs
+++ b/src/RevitCreatingFiltersByValues/Models/FilterElemsByExportService.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Autodesk.Revit.DB;
+
+using dosymep.Revit;
+
+namespace RevitCreatingFiltersByValues.Models {
+    internal class FilterElemsByExportService {
+        private readonly Document _doc;
+
+        public FilterElemsByExportService(Document doc) {
+            _doc = doc;
+        }
+
+        /// <summary>
+        /// Получает элементы, видимые на виде при помощи функции экспорта
+        /// </summary>
+        /// <returns></returns>
+        public List<Element> GetElemetns() {
+            View activeView = _doc.ActiveView;
+            // Список для хранения всех экспортированных элементов
+            List<Element> allExportedElements = new List<Element>();
+
+            var linkInstances = new FilteredElementCollector(_doc, activeView.Id)
+                .OfClass(typeof(RevitLinkInstance))
+                .Cast<RevitLinkInstance>()
+                .ToList();
+
+            using(Transaction transaction = _doc.StartTransaction("Временное скрытие/изоляция")) {
+                // Для корректного получения элементов на виде (в т.ч. из связанных файлов),
+                // чтобы избежать дублирования необходимо сначала временно скрыть все экземпляры
+                // связанных файлов и произвести экспорт того, что есть в текущем файле.
+                // Затем вернуть отображение связей, изолировать их по одной и производить экспорт
+                activeView.HideElements(linkInstances.Select(x => x.Id).ToList());
+
+                var exportContext = new ExportContext(_doc);
+                CustomExporter exporter = new CustomExporter(_doc, exportContext) {
+                    IncludeGeometricObjects = true,
+                    ShouldStopOnError = false
+                };
+                exporter.Export(activeView);
+
+                allExportedElements.AddRange(exportContext.ExportedElements);
+                activeView.UnhideElements(linkInstances.Select(x => x.Id).ToList());
+
+                foreach(var linkInstance in linkInstances) {
+                    activeView.IsolateElementsTemporary(new List<ElementId> { linkInstance.Id });
+
+                    exportContext = new ExportContext(linkInstance.GetLinkDocument());
+                    exporter = new CustomExporter(_doc, exportContext) {
+                        IncludeGeometricObjects = true,
+                        ShouldStopOnError = false
+                    };
+                    exporter.Export(activeView);
+
+                    allExportedElements.AddRange(exportContext.ExportedElements);
+                    activeView.DisableTemporaryViewMode(TemporaryViewMode.TemporaryHideIsolate);
+                }
+                // Манипуляции со скрытием/отображением необходимо производить под транзакцией
+                // но в дальнейшем она не нужна, поэтому сбрасываем ее
+                transaction.RollBack();
+            }
+            return allExportedElements;
+        }
+    }
+}

--- a/src/RevitCreatingFiltersByValues/Models/RevitRepository.cs
+++ b/src/RevitCreatingFiltersByValues/Models/RevitRepository.cs
@@ -1,12 +1,8 @@
 using System;
-using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Windows;
-using System.Windows.Controls;
 
-using Autodesk.Revit.ApplicationServices;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 
@@ -78,7 +74,7 @@ namespace RevitCreatingFiltersByValues.Models {
             List<Element> elementsInView;
             try {
                 FilterElemsByExportService filterElemsByExportService = new FilterElemsByExportService(Document);
-                elementsInView = filterElemsByExportService.GetElemetns();
+                elementsInView = filterElemsByExportService.GetElements();
             } catch(Exception) {
                 elementsInView = new FilteredElementCollector(Document, Document.ActiveView.Id)
                                         .WhereElementIsNotElementType()
@@ -105,11 +101,8 @@ namespace RevitCreatingFiltersByValues.Models {
                     }
                 }
             }
-
-
             return patterns;
         }
-
 
 
         /// <summary>
@@ -129,14 +122,12 @@ namespace RevitCreatingFiltersByValues.Models {
         }
 
 
-
         /// <summary>
         /// Получает категории, представленные на виде + элементы в словаре по ним
         /// </summary>
         public ObservableCollection<CategoryElements> GetCategoriesInView(bool checkFlag) {
 
             ObservableCollection<CategoryElements> categoryElements = new ObservableCollection<CategoryElements>();
-
             foreach(Element elem in GetElementsInView()) {
                 if(elem.Category is null) { continue; }
 
@@ -157,14 +148,11 @@ namespace RevitCreatingFiltersByValues.Models {
                         break;
                     }
                 }
-
                 if(flag is false) {
                     categoryElements.Add(new CategoryElements(catOfElem, elemCategoryId, checkFlag, new List<Element>() { elem }));
                 }
             }
-
             return categoryElements;
         }
-
     }
 }


### PR DESCRIPTION
Плагин применяется для создания фильтров (переопределения графики на виде иным способом) по значениям элементов, видимых на виде.
В связи с тем, что появилась потребность создавать фильтры по значениям элементов из связанных файлов, была изменена методика получения элементов (предыдущая не работала корректна с элементами из связей). Получение элементов теперь производится при помощи экспорта.
Изменения интерфейса плагина отсутствуют.