### PR TITLE
RevitRooms: Добавлен параметр фиксации этажа помещения

### DIFF
--- a/src/RevitRooms/Models/CheckProjectParams.cs
+++ b/src/RevitRooms/Models/CheckProjectParams.cs
@@ -32,6 +32,7 @@ namespace RevitRooms.Models {
 #if REVIT_2021_OR_LESS
             _projectParameters.SetupRevitParams(_uiApplication.ActiveUIDocument.Document,
                 ProjectParamsConfig.Instance.IsRoomNumberFix,
+                ProjectParamsConfig.Instance.IsRoomLevelFix,
                 ProjectParamsConfig.Instance.NumberingOrder,
                 SharedParamsConfig.Instance.RoomArea,
                 SharedParamsConfig.Instance.RoomsCount,
@@ -64,6 +65,7 @@ namespace RevitRooms.Models {
 #else
             _projectParameters.SetupRevitParams(_uiApplication.ActiveUIDocument.Document,
                 ProjectParamsConfig.Instance.IsRoomNumberFix,
+                ProjectParamsConfig.Instance.IsRoomLevelFix,
                 ProjectParamsConfig.Instance.NumberingOrder,
                 SharedParamsConfig.Instance.RoomArea,
                 SharedParamsConfig.Instance.RoomsCount,

--- a/src/RevitRooms/ViewModels/RevitViewModel.cs
+++ b/src/RevitRooms/ViewModels/RevitViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -401,7 +401,7 @@ namespace RevitRooms.ViewModels {
                 // Подсчет площадей помещений
                 foreach(var level in levels) {
                     foreach(var spatialElement in level.GetRooms(phases)) {
-                        if(IsFillLevel) {
+                        if(IsFillLevel && !spatialElement.IsLevelFix) {
                             // Заполняем параметр Этаж
                             _revitRepository.UpdateLevelSharedParam(spatialElement.Element, levelNames);
                         }

--- a/src/RevitRooms/ViewModels/SpatialElementViewModel.cs
+++ b/src/RevitRooms/ViewModels/SpatialElementViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -112,6 +112,7 @@ namespace RevitRooms.ViewModels {
         }
 
         public bool IsNumberFix => Element.GetParamValueOrDefault<int>(ProjectParamsConfig.Instance.IsRoomNumberFix) == 1;
+        public bool IsLevelFix => Element.GetParamValueOrDefault<int>(ProjectParamsConfig.Instance.IsRoomLevelFix) == 1;
 
         public double ComputeRoomAreaWithRatio() {
             // Area = 0 - по умолчанию

--- a/src/dosymep/ThemedPlatformWindow.cs
+++ b/src/dosymep/ThemedPlatformWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -113,12 +113,13 @@ namespace dosymep.WPF.Views {
                 .Build<PlatformWindowConfig>();
         }
 
+
         private void OnUIThemeChanged(UIThemes obj) {
             UpdateTheme();
         }
 
         private void UpdateTheme() {
-            UIThemeUpdaterService.SetTheme(this, UIThemeService.HostTheme);
+            UIThemeUpdaterService.SetTheme(UIThemeService.HostTheme, this);
         }
     }
 }


### PR DESCRIPTION
В скрипт добавлен bool-параметр (IsRoomLevelFix) для фиксации значения этажа у помещения.
Если значение этого параметра true, то при расчете квартирографии значение параметра этажа у помещения не обновляется.