### PR TITLE
RevitClashDetective: Обновлен навигатор по коллизиям

### DIFF
--- a/src/RevitClashDetective/ViewModels/Navigator/ClashViewModel.cs
+++ b/src/RevitClashDetective/ViewModels/Navigator/ClashViewModel.cs
@@ -12,6 +12,7 @@ using RevitClashDetective.Models.Clashes;
 namespace RevitClashDetective.ViewModels.Navigator {
     internal class ClashViewModel : BaseViewModel, IEquatable<ClashViewModel> {
         private ClashStatus _clashStatus;
+        private string _clashName;
         private readonly RevitRepository _revitRepository;
 
         public ClashViewModel(RevitRepository revitRepository, ClashModel clash) {
@@ -21,13 +22,13 @@ namespace RevitClashDetective.ViewModels.Navigator {
 
             FirstCategory = clash.MainElement.Category;
             FirstTypeName = clash.MainElement.Name;
-            FirstFamilyName = GetFamilyName(clash.MainElement);
+            FirstFamilyName = clash.MainElement.FamilyName;
             FirstDocumentName = clash.MainElement.DocumentName;
             FirstLevel = clash.MainElement.Level;
 
             SecondCategory = clash.OtherElement.Category;
             SecondTypeName = clash.OtherElement.Name;
-            SecondFamilyName = GetFamilyName(clash.OtherElement);
+            SecondFamilyName = clash.OtherElement.FamilyName;
             SecondLevel = clash.OtherElement.Level;
             SecondDocumentName = clash.OtherElement.DocumentName;
 
@@ -44,7 +45,10 @@ namespace RevitClashDetective.ViewModels.Navigator {
             set => RaiseAndSetIfChanged(ref _clashStatus, value);
         }
 
-        public string ClashName { get; }
+        public string ClashName {
+            get => _clashName;
+            set => RaiseAndSetIfChanged(ref _clashName, value);
+        }
 
         public string FirstTypeName { get; }
 
@@ -90,6 +94,7 @@ namespace RevitClashDetective.ViewModels.Navigator {
 
         public ClashModel GetClashModel() {
             Clash.ClashStatus = ClashStatus;
+            Clash.Name = ClashName;
             return Clash;
         }
 

--- a/src/RevitClashDetective/ViewModels/Navigator/ClashViewModel.cs
+++ b/src/RevitClashDetective/ViewModels/Navigator/ClashViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 using Autodesk.Revit.DB;
 
+using dosymep.Revit;
 using dosymep.WPF.ViewModels;
 
 using RevitClashDetective.Models;
@@ -16,13 +17,17 @@ namespace RevitClashDetective.ViewModels.Navigator {
         public ClashViewModel(RevitRepository revitRepository, ClashModel clash) {
             _revitRepository = revitRepository;
 
+            ClashName = clash.Name;
+
             FirstCategory = clash.MainElement.Category;
-            FirstName = clash.MainElement.Name;
+            FirstTypeName = clash.MainElement.Name;
+            FirstFamilyName = GetFamilyName(clash.MainElement);
             FirstDocumentName = clash.MainElement.DocumentName;
             FirstLevel = clash.MainElement.Level;
 
             SecondCategory = clash.OtherElement.Category;
-            SecondName = clash.OtherElement.Name;
+            SecondTypeName = clash.OtherElement.Name;
+            SecondFamilyName = GetFamilyName(clash.OtherElement);
             SecondLevel = clash.OtherElement.Level;
             SecondDocumentName = clash.OtherElement.DocumentName;
 
@@ -39,7 +44,11 @@ namespace RevitClashDetective.ViewModels.Navigator {
             set => RaiseAndSetIfChanged(ref _clashStatus, value);
         }
 
-        public string FirstName { get; }
+        public string ClashName { get; }
+
+        public string FirstTypeName { get; }
+
+        public string FirstFamilyName { get; }
 
         public string FirstDocumentName { get; }
 
@@ -47,7 +56,9 @@ namespace RevitClashDetective.ViewModels.Navigator {
 
         public string FirstCategory { get; }
 
-        public string SecondName { get; }
+        public string SecondTypeName { get; }
+
+        public string SecondFamilyName { get; }
 
         public string SecondLevel { get; }
 
@@ -91,11 +102,11 @@ namespace RevitClashDetective.ViewModels.Navigator {
             hashCode = hashCode * -1521134295 + ClashStatus.GetHashCode();
             hashCode = hashCode * -1521134295 + EqualityComparer<ElementId>.Default.GetHashCode(Clash.MainElement.Id);
             hashCode = hashCode * -1521134295 + EqualityComparer<ElementId>.Default.GetHashCode(Clash.OtherElement.Id);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(FirstName);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(FirstTypeName);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(FirstDocumentName);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(FirstLevel);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(FirstCategory);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(SecondName);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(SecondTypeName);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(SecondLevel);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(SecondDocumentName);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(SecondCategory);
@@ -106,11 +117,11 @@ namespace RevitClashDetective.ViewModels.Navigator {
             return other != null
                 && Clash.MainElement.Id == other.Clash.MainElement.Id
                 && Clash.OtherElement.Id == other.Clash.OtherElement.Id
-                && FirstName == other.FirstName
+                && FirstTypeName == other.FirstTypeName
                 && FirstDocumentName == other.FirstDocumentName
                 && FirstLevel == other.FirstLevel
                 && FirstCategory == other.FirstCategory
-                && SecondName == other.SecondName
+                && SecondTypeName == other.SecondTypeName
                 && SecondLevel == other.SecondLevel
                 && SecondDocumentName == other.SecondDocumentName
                 && SecondCategory == other.SecondCategory;
@@ -130,6 +141,12 @@ namespace RevitClashDetective.ViewModels.Navigator {
             return (
                 Math.Round(clashData.ClashVolume / minVolume * 100, 2),
                 Math.Round(_revitRepository.ConvertToM3(clashData.ClashVolume), 6));
+        }
+
+        private string GetFamilyName(ElementModel elementModel) {
+            var doc = elementModel.GetDocInfo(_revitRepository.DocInfos)?.Doc;
+            var element = doc?.GetElement(elementModel.Id);
+            return element?.HasElementType() ?? false ? element.GetElementType().FamilyName : string.Empty;
         }
     }
 }

--- a/src/RevitClashDetective/Views/NavigatorView.xaml
+++ b/src/RevitClashDetective/Views/NavigatorView.xaml
@@ -113,8 +113,7 @@
                     </dxg:GridColumn.CellTemplate>
                 </dxg:GridColumn>
                 
-                <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
-                                Header="Название"
+                <dxg:GridColumn Header="Название"
                                 FieldName="ClashName"/>
                 <dxg:GridColumn Header="Статус">
                     <dxg:GridColumn.CellTemplate>

--- a/src/RevitClashDetective/Views/NavigatorView.xaml
+++ b/src/RevitClashDetective/Views/NavigatorView.xaml
@@ -122,7 +122,7 @@
                             <dxe:ComboBoxEdit ApplyItemTemplateToSelectedItem="True"
                                               IsTextEditable="False"
                                               EditMode="InplaceActive"
-                                              EditValue="{Binding Row.ClashStatus}"
+                                              EditValue="{Binding Row.ClashStatus, UpdateSourceTrigger=PropertyChanged}"
                                               ItemsSource="{dxe:EnumItemsSource EnumType={x:Type m:ClashStatus}}" />
                         </DataTemplate>
                     </dxg:GridColumn.CellTemplate>

--- a/src/RevitClashDetective/Views/NavigatorView.xaml
+++ b/src/RevitClashDetective/Views/NavigatorView.xaml
@@ -112,7 +112,10 @@
                         </DataTemplate>
                     </dxg:GridColumn.CellTemplate>
                 </dxg:GridColumn>
-
+                
+                <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
+                                Header="Название"
+                                FieldName="ClashName"/>
                 <dxg:GridColumn Header="Статус">
                     <dxg:GridColumn.CellTemplate>
                         <DataTemplate>
@@ -124,7 +127,6 @@
                         </DataTemplate>
                     </dxg:GridColumn.CellTemplate>
                 </dxg:GridColumn>
-
                 <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
                                 Header="Уровень 1"
                                 FieldName="FirstLevel" />
@@ -133,7 +135,10 @@
                                 FieldName="FirstCategory" />
                 <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
                                 Header="Имя типа 1"
-                                FieldName="FirstName" />
+                                FieldName="FirstTypeName" />
+                <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
+                                Header="Имя семейства 1"
+                                FieldName="FirstFamilyName" />
                 <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
                                 Header="Имя файла 1"
                                 FieldName="FirstDocumentName" />
@@ -145,7 +150,10 @@
                                 FieldName="SecondCategory" />
                 <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
                                 Header="Имя типа 2"
-                                FieldName="SecondName" />
+                                FieldName="SecondTypeName" />
+                <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
+                                Header="Имя семейства 2"
+                                FieldName="SecondFamilyName" />
                 <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
                                 Header="Имя файла 2"
                                 FieldName="SecondDocumentName" />

--- a/src/RevitClashDetective/Views/RevitReportClashNavigator.xaml
+++ b/src/RevitClashDetective/Views/RevitReportClashNavigator.xaml
@@ -61,11 +61,11 @@
                
                 <dxg:GridColumn ReadOnly="True" Header="Уровень 1" FieldName="FirstLevel"/>
                 <dxg:GridColumn ReadOnly="True" Header="Категория 1" FieldName="FirstCategory" />
-                <dxg:GridColumn ReadOnly="True" Header="Имя типа 1" FieldName="FirstName" />
+                <dxg:GridColumn ReadOnly="True" Header="Имя типа 1" FieldName="FirstTypeName" />
                 <dxg:GridColumn ReadOnly="True" Header="Имя файла 1" FieldName="FirstDocumentName" />
                 <dxg:GridColumn ReadOnly="True" Header="Уровень 2" FieldName="SecondLevel" />
                 <dxg:GridColumn ReadOnly="True" Header="Категория 2" FieldName="SecondCategory" />
-                <dxg:GridColumn ReadOnly="True" Header="Имя типа 2" FieldName="SecondName" />
+                <dxg:GridColumn ReadOnly="True" Header="Имя типа 2" FieldName="SecondTypeName" />
                 <dxg:GridColumn ReadOnly="True" Header="Имя файла 2" FieldName="SecondDocumentName" />
             </dxg:GridControl.Columns>
         </dxg:GridControl>

--- a/src/RevitClashes/Models/ClashDetection/ClashDetector.cs
+++ b/src/RevitClashes/Models/ClashDetection/ClashDetector.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 
 using RevitClashDetective.Models.Clashes;
@@ -24,6 +24,9 @@ namespace RevitClashDetective.Models.ClashDetection {
                     clashes.AddRange(providerClashDetector.GetClashes());
                 }
             }
+            for(int i = 0; i < clashes.Count; i++) {
+                clashes[i].Name = $"Конфликт{i + 1}";
+            }
 
             return clashes;
         }
@@ -35,6 +38,7 @@ namespace RevitClashDetective.Models.ClashDetection {
                 var oldClashe = oldClashes.FirstOrDefault(item => item.Equals(newClash));
                 if(oldClashe != null) {
                     newClash.ClashStatus = oldClashe.ClashStatus;
+                    newClash.Name = oldClashe.Name;
                 }
                 yield return newClash;
             }

--- a/src/RevitClashes/Models/ClashDetection/ClashDetector.cs
+++ b/src/RevitClashes/Models/ClashDetection/ClashDetector.cs
@@ -38,7 +38,7 @@ namespace RevitClashDetective.Models.ClashDetection {
                 var oldClashe = oldClashes.FirstOrDefault(item => item.Equals(newClash));
                 if(oldClashe != null) {
                     newClash.ClashStatus = oldClashe.ClashStatus;
-                    newClash.Name = oldClashe.Name;
+                    newClash.Name = string.IsNullOrWhiteSpace(oldClashe.Name) ? newClash.Name : oldClashe.Name;
                 }
                 yield return newClash;
             }

--- a/src/RevitClashes/Models/Clashes/ClashModel.cs
+++ b/src/RevitClashes/Models/Clashes/ClashModel.cs
@@ -54,13 +54,19 @@ namespace RevitClashDetective.Models.Clashes {
             return this;
         }
 
+        /// <summary>
+        /// Проверяет, что хотя бы 1 элемент коллизии находится в одном из заданных файлов
+        /// </summary>
+        /// <param name="documentNames">Коллекция названий файлов для проверки</param>
+        /// <returns>True, если хотя бы 1 элемент коллизии находится в одном из заданных файлов, иначе False</returns>
         public bool IsValid(ICollection<string> documentNames) {
-            var clashDocuments = new[] { MainElement.DocumentName, OtherElement.DocumentName };
-            var clashElements = new[] {_revitRepository.GetElement(MainElement.DocumentName, MainElement.Id),
-                                       _revitRepository.GetElement(OtherElement.DocumentName, OtherElement.Id)};
-
-            return clashDocuments.All(item => documentNames.Any(d => d.Contains(item))) && clashElements.Any(item => item != null)
-                   && clashElements.All(item => item?.GetTypeId().IsNotNull() == true);
+            var clashElements = new[] { MainElement, OtherElement };
+            return clashElements.Where(el => el != null)
+                .Where(e => documentNames.Any(d => d.Contains(e?.DocumentName)))
+                .Select(e => _revitRepository.GetElement(e.DocumentName, e.Id))
+                .Where(e => e != null)
+                .Where(e => e.GetTypeId().IsNotNull())
+                .Count() > 0;
         }
 
         public override bool Equals(object obj) {

--- a/src/RevitClashes/Models/Clashes/ClashModel.cs
+++ b/src/RevitClashes/Models/Clashes/ClashModel.cs
@@ -43,6 +43,7 @@ namespace RevitClashDetective.Models.Clashes {
         }
 
 
+        public string Name { get; set; }
         public ClashStatus ClashStatus { get; set; }
         public ElementModel MainElement { get; set; }
         public ElementModel OtherElement { get; set; }

--- a/src/RevitClashes/Models/Clashes/ElementModel.cs
+++ b/src/RevitClashes/Models/Clashes/ElementModel.cs
@@ -4,6 +4,8 @@ using System.Linq;
 
 using Autodesk.Revit.DB;
 
+using dosymep.Revit;
+
 using pyRevitLabs.Json;
 
 using RevitClashDetective.Models.Extensions;
@@ -33,6 +35,7 @@ namespace RevitClashDetective.Models.Clashes {
 
             Id = element.Id;
             Name = element.Name;
+            FamilyName = element.GetElementType().FamilyName;
             Category = element.Category?.Name;
             Level = RevitRepository.GetLevelName(element);
             DocumentName = RevitRepository.GetDocumentName(element.Document);
@@ -41,7 +44,14 @@ namespace RevitClashDetective.Models.Clashes {
 
 
         public ElementId Id { get; set; }
+        /// <summary>
+        /// Имя типоразмера
+        /// </summary>
         public string Name { get; set; }
+        /// <summary>
+        /// Имя семейства
+        /// </summary>
+        public string FamilyName { get; set; }
         public string Category { get; set; }
         public string Level { get; set; }
         public string DocumentName { get; set; }

--- a/src/RevitClashes/Models/RevitClashReport/NavisXmlClashesLoader.cs
+++ b/src/RevitClashes/Models/RevitClashReport/NavisXmlClashesLoader.cs
@@ -142,11 +142,16 @@ namespace RevitClashDetective.Models.RevitClashReport {
         }
 
         private ClashModel GetClashModel(XElement clashResult) {
+            var name = clashResult.Attribute("name")?.Value ?? string.Empty;
+            var status = GetClashStatus(clashResult.Attribute("status")?.Value);
             var elements = clashResult.Descendants("clashobject")
                 .Take(2)
                 .Select(c => GetElementModel(c))
                 .ToArray();
-            var clash = new ClashModel();
+            var clash = new ClashModel() {
+                Name = name,
+                ClashStatus = status
+            };
             if(elements.Length == 2) {
                 clash.MainElement = elements[0];
                 clash.OtherElement = elements[1];
@@ -185,6 +190,21 @@ namespace RevitClashDetective.Models.RevitClashReport {
             return _revitRepository.DocInfos.Any(d => d.Name.Equals(
                 RevitRepository.GetDocumentName(file),
                 StringComparison.CurrentCultureIgnoreCase));
+        }
+
+        private ClashStatus GetClashStatus(string status) {
+            switch(status?.ToLower()) {
+                case "new":
+                case "active":
+                    return ClashStatus.Active;
+                case "reviewed":
+                case "approved":
+                    return ClashStatus.Analized;
+                case "resolved":
+                    return ClashStatus.Solved;
+                default:
+                    return ClashStatus.Active;
+            }
         }
     }
 }

--- a/src/RevitClashes/Models/RevitClashReport/NavisXmlClashesLoader.cs
+++ b/src/RevitClashes/Models/RevitClashReport/NavisXmlClashesLoader.cs
@@ -165,7 +165,15 @@ namespace RevitClashDetective.Models.RevitClashReport {
                 t => t.Element("value").Value);
             string file = tags.TryGetValue("элемент файл источника", out string fileName) ? fileName : null;
             ElementId id = tags.TryGetValue("объект id", out string idStr) ? GetId(idStr) : ElementId.InvalidElementId;
-            return GetElementModel(file, id);
+            var elementModel = GetElementModel(file, id);
+            return elementModel.Id.IsNotNull() ? elementModel :
+                new ElementModel() {
+                    Id = id,
+                    DocumentName = file,
+                    Name = tags.TryGetValue("объект имя", out string name) ? name : string.Empty,
+                    FamilyName = tags.TryGetValue("объект семейство", out string famName) ? famName : string.Empty,
+                    Level = clashObject.Element("layer")?.Value ?? string.Empty
+                };
         }
 
         private ElementModel GetElementModel(string fileName, ElementId id) {


### PR DESCRIPTION
# Обновления

- в интерфейс навигатора добавлены столбцы с названием коллизии и именем семейства. Столбец с названием коллизии сделан редактируемым
- добавлен импорт статусов из xml отчета Navisworks
- в окне навигатора теперь отображаются коллизии, где хотя бы один из элементов коллизии находится в одном из подгруженных связанных файлов или в активном документе

![image](https://github.com/user-attachments/assets/da249883-a1d4-4f71-962f-3cb6bac3343d)
