### PR TITLE
RevitOpeningPlacement: Обновлён плагин

### DIFF
--- a/src/RevitOpeningPlacement/Models/Configs/MepCategory.cs
+++ b/src/RevitOpeningPlacement/Models/Configs/MepCategory.cs
@@ -13,6 +13,7 @@ namespace RevitOpeningPlacement.Models.Configs {
     /// </summary>
     internal class MepCategory : IEquatable<MepCategory> {
         public const int DefaultRoundingMm = 50;
+        public const int DefaultElevationRoundingMm = 10;
         public const int DefaultMinSizeMm = 0;
         public const int DefaultMaxSizeMm = 10000;
         public const int DefaultOffsetMm = 50;
@@ -101,9 +102,14 @@ namespace RevitOpeningPlacement.Models.Configs {
             };
 
         /// <summary>
-        /// Значение округления габаритов итогового размещенного задания на отверстие в месте пересечения элемента данной категории и конструктивного элемента
+        /// Значение округления габаритов в мм итогового размещенного задания на отверстие в месте пересечения элемента данной категории и конструктивного элемента
         /// </summary>
         public int Rounding { get; set; } = DefaultRoundingMm;
+
+        /// <summary>
+        /// Значение округления отметки низа в мм размещенного задания на отверстие в месте пересечения элемента данной категории и конструктивного элемента
+        /// </summary>
+        public int ElevationRounding { get; set; } = DefaultElevationRoundingMm;
 
         /// <summary>
         /// Правила фильтрации элементов данной категории

--- a/src/RevitOpeningPlacement/Models/Configs/OpeningConfig.cs
+++ b/src/RevitOpeningPlacement/Models/Configs/OpeningConfig.cs
@@ -23,6 +23,16 @@ namespace RevitOpeningPlacement.Models.Configs {
         public MepCategoryCollection Categories { get; set; } = new MepCategoryCollection();
 
         /// <summary>
+        /// Округление размеров объединенных заданий на отверстия в мм
+        /// </summary>
+        public int UnitedTasksSizeRounding { get; set; } = 10;
+
+        /// <summary>
+        /// Округление отметки объединенных заданий на отверстия в мм
+        /// </summary>
+        public int UnitedTasksElevationRounding { get; set; } = 10;
+
+        /// <summary>
         /// Флаг для вывода ошибок расстановки заданий на отверстия пользователю
         /// </summary>
         public bool ShowPlacingErrors { get; set; } = false;

--- a/src/RevitOpeningPlacement/Models/Configs/OpeningRealsArConfig.cs
+++ b/src/RevitOpeningPlacement/Models/Configs/OpeningRealsArConfig.cs
@@ -1,4 +1,3 @@
-
 using System;
 
 using Autodesk.Revit.DB;
@@ -12,15 +11,14 @@ using RevitClashDetective.Models.FilterModel;
 
 namespace RevitOpeningPlacement.Models.Configs {
     /// <summary>
-    /// Настройки расстановки чистовых отверстий в файле КР
+    /// Настройки расстановки чистовых отверстий в файле АР
     /// </summary>
-    internal class OpeningRealsKrConfig : ProjectConfig {
+    internal class OpeningRealsArConfig : ProjectConfig {
         public string RevitVersion { get; set; }
         [JsonIgnore]
         public override string ProjectConfigPath { get; set; }
         [JsonIgnore]
         public override IConfigSerializer Serializer { get; set; }
-        public OpeningRealKrPlacementType PlacementType { get; set; } = OpeningRealKrPlacementType.PlaceByAr;
 
         /// <summary>
         /// Округление габаритов отверстия в мм
@@ -32,15 +30,15 @@ namespace RevitOpeningPlacement.Models.Configs {
         /// </summary>
         public int ElevationRounding { get; set; } = 1;
 
-        public static OpeningRealsKrConfig GetOpeningConfig(Document document) {
+        public static OpeningRealsArConfig GetOpeningConfig(Document document) {
             if(document is null) { throw new ArgumentNullException(nameof(document)); }
 
             return new ProjectConfigBuilder()
                 .SetSerializer(new RevitClashConfigSerializer(new OpeningSerializationBinder(), document))
                 .SetPluginName(nameof(RevitOpeningPlacement))
                 .SetRevitVersion(ModuleEnvironment.RevitVersion)
-                .SetProjectConfigName(nameof(OpeningRealsKrConfig) + ".json")
-                .Build<OpeningRealsKrConfig>();
+                .SetProjectConfigName(nameof(OpeningRealsArConfig) + ".json")
+                .Build<OpeningRealsArConfig>();
         }
     }
 }

--- a/src/RevitOpeningPlacement/Models/Interfaces/IOpeningGroupPlacerInitializer.cs
+++ b/src/RevitOpeningPlacement/Models/Interfaces/IOpeningGroupPlacerInitializer.cs
@@ -1,8 +1,9 @@
-﻿using RevitOpeningPlacement.Models.OpeningPlacement;
+using RevitOpeningPlacement.Models.Configs;
+using RevitOpeningPlacement.Models.OpeningPlacement;
 using RevitOpeningPlacement.Models.OpeningUnion;
 
 namespace RevitOpeningPlacement.Models.Interfaces {
     internal interface IOpeningGroupPlacerInitializer {
-        OpeningPlacer GetPlacer(RevitRepository revitRepository, OpeningsGroup openingsGroup);
+        OpeningPlacer GetPlacer(RevitRepository revitRepository, OpeningConfig config, OpeningsGroup openingsGroup);
     }
 }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/FloorSolidParameterGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/FloorSolidParameterGetter.cs
@@ -16,6 +16,7 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters {
         private readonly IPointFinder _pointFinder;
         private readonly ILevelFinder _levelFinder;
         private readonly OpeningsGroup _openingsGroup;
+        private readonly OpeningConfig _config;
         private readonly MepCategory[] _mepCategories;
         private readonly Element _mepElement;
         private readonly Element _structureElement;
@@ -25,17 +26,20 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters {
         /// Конструктор для получения параметров задания на отверстие из группы заданий на отверстия
         /// </summary>
         /// <param name="openingsGroup">Группа заданий на отверстия</param>
+        /// <param name="config">Настройки расстановки заданий на отверстия</param>
         /// <exception cref="System.ArgumentNullException">Исключение, если обязательный параметр null</exception>
         public FloorSolidParameterGetter(
             ISolidProvider solidProvider,
             IPointFinder pointFinder,
             ILevelFinder levelFinder,
-            OpeningsGroup openingsGroup
+            OpeningsGroup openingsGroup,
+            OpeningConfig config
             ) {
             _solidProvider = solidProvider ?? throw new System.ArgumentNullException(nameof(solidProvider));
             _pointFinder = pointFinder ?? throw new System.ArgumentNullException(nameof(pointFinder));
             _levelFinder = levelFinder ?? throw new System.ArgumentNullException(nameof(levelFinder));
             _openingsGroup = openingsGroup ?? throw new System.ArgumentNullException(nameof(openingsGroup));
+            _config = config ?? throw new System.ArgumentNullException(nameof(config));
             _createdByGroup = true;
         }
 
@@ -64,7 +68,9 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters {
 
 
         public IEnumerable<ParameterValuePair> GetParamValues() {
-            var sizeInit = new FloorOpeningSizeInitializer(_solidProvider.GetSolid(), _mepCategories);
+            var sizeInit = _createdByGroup
+                ? new FloorOpeningSizeInitializer(_solidProvider.GetSolid(), _config.UnitedTasksSizeRounding)
+                : new FloorOpeningSizeInitializer(_solidProvider.GetSolid(), 0, _mepCategories);
 
             //габариты отверстия
             if(_createdByGroup && _openingsGroup.IsCylinder) {

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/WallSolidParameterGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ParameterGetters/ParametersGetters/WallSolidParameterGetter.cs
@@ -24,6 +24,7 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters {
         private readonly Element _mepElement;
         private readonly Element _structureElement;
         private readonly OpeningsGroup _openingsGroup;
+        private readonly OpeningConfig _openingConfig;
         private readonly bool _createdByOpeningGroup = false;
 
 
@@ -31,12 +32,14 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters {
             ISolidProvider solidProvider,
             IPointFinder pointFinder,
             ILevelFinder levelFinder,
-            OpeningsGroup openingsGroup
+            OpeningsGroup openingsGroup,
+            OpeningConfig openingConfig
             ) {
             _solidProvider = solidProvider ?? throw new System.ArgumentNullException(nameof(solidProvider));
             _pointFinder = pointFinder ?? throw new System.ArgumentNullException(nameof(pointFinder));
             _levelFinder = levelFinder ?? throw new System.ArgumentNullException(nameof(levelFinder));
             _openingsGroup = openingsGroup ?? throw new System.ArgumentNullException(nameof(openingsGroup));
+            _openingConfig = openingConfig ?? throw new System.ArgumentNullException(nameof(openingConfig));
             _createdByOpeningGroup = true;
         }
 
@@ -59,7 +62,9 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ParameterGetters {
 
 
         public IEnumerable<ParameterValuePair> GetParamValues() {
-            var sizeInit = new WallOpeningSizeInitializer(_solidProvider.GetSolid(), _mepCategories);
+            var sizeInit = _createdByOpeningGroup
+                ? new WallOpeningSizeInitializer(_solidProvider.GetSolid(), _openingConfig.UnitedTasksSizeRounding)
+                : new WallOpeningSizeInitializer(_solidProvider.GetSolid(), 0, _mepCategories);
             //габариты отверстия
             bool isRound = _createdByOpeningGroup && _openingsGroup.IsCylinder;
             if(isRound) {

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/PlacerInitializers/FittingWallPlacerInitializer.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/PlacerInitializers/FittingWallPlacerInitializer.cs
@@ -20,7 +20,7 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PlacerInitializers {
             var clash = new FittingClash<Wall>(revitRepository, clashModel);
             var angleFinder = new WallAngleFinder(clash.Element2, clash.Element2Transform);
             var solidProvider = new FittingClashSolidProvider<Wall>(clash, angleFinder);
-            var heightGetter = new WallOpeningSizeInitializer(solidProvider.GetSolid(), categoryOptions).GetHeight();
+            var heightGetter = new WallOpeningSizeInitializer(solidProvider.GetSolid(), 0, categoryOptions).GetHeight();
             var roundings = categoryOptions.Select(c => c.ElevationRounding).ToArray();
             int rounding = roundings.Length > 0 ? roundings.Min() : 0;
             var pointFinder = new FittingWallPointFinder(clash, angleFinder, rounding, heightGetter);

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/PlacerInitializers/FittingWallPlacerInitializer.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/PlacerInitializers/FittingWallPlacerInitializer.cs
@@ -1,4 +1,6 @@
 
+using System.Linq;
+
 using Autodesk.Revit.DB;
 
 using RevitClashDetective.Models.Clashes;
@@ -19,7 +21,9 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PlacerInitializers {
             var angleFinder = new WallAngleFinder(clash.Element2, clash.Element2Transform);
             var solidProvider = new FittingClashSolidProvider<Wall>(clash, angleFinder);
             var heightGetter = new WallOpeningSizeInitializer(solidProvider.GetSolid(), categoryOptions).GetHeight();
-            var pointFinder = new FittingWallPointFinder(clash, angleFinder, heightGetter);
+            var roundings = categoryOptions.Select(c => c.ElevationRounding).ToArray();
+            int rounding = roundings.Length > 0 ? roundings.Min() : 0;
+            var pointFinder = new FittingWallPointFinder(clash, angleFinder, rounding, heightGetter);
             var levelFinder = new ClashLevelFinder(revitRepository, clashModel);
 
             return new OpeningPlacer(revitRepository, clashModel) {

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/PlacerInitializers/FloorOpeningGroupPlacerInitializer.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/PlacerInitializers/FloorOpeningGroupPlacerInitializer.cs
@@ -18,7 +18,7 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PlacerInitializers {
 
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
         /// <exception cref="ArgumentOutOfRangeException">Исключение, если количество элементов в группе отверстий меньше 2</exception>
-        public OpeningPlacer GetPlacer(RevitRepository revitRepository, OpeningsGroup openingsGroup) {
+        public OpeningPlacer GetPlacer(RevitRepository revitRepository, Configs.OpeningConfig config, OpeningsGroup openingsGroup) {
             if(openingsGroup is null) {
                 throw new ArgumentNullException(nameof(openingsGroup));
             }
@@ -40,7 +40,7 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PlacerInitializers {
                 LevelFinder = levelFinder,
                 AngleFinder = new FloorOpeningsGroupAngleFinder(openingsGroup),
 
-                ParameterGetter = new FloorSolidParameterGetter(new OpeningGroupSolidProvider(openingsGroup), pointFinder, levelFinder, openingsGroup)
+                ParameterGetter = new FloorSolidParameterGetter(new OpeningGroupSolidProvider(openingsGroup), pointFinder, levelFinder, openingsGroup, config)
             };
         }
     }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/PlacerInitializers/RectangleMepWallPlacerInitializer.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/PlacerInitializers/RectangleMepWallPlacerInitializer.cs
@@ -22,14 +22,15 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PlacerInitializers {
                 Type = revitRepository.GetOpeningTaskType(OpeningType.WallRectangle),
             };
             if(clash.Element1.IsPerpendicular(clash.Element2)) {
-                var pointFinder = new WallPointFinder(clash, new HeightValueGetter(clash.Element1, categoryOption));
+                var pointFinder = new WallPointFinder(clash, categoryOption.ElevationRounding, new HeightValueGetter(clash.Element1, categoryOption));
                 placer.PointFinder = pointFinder;
                 placer.ParameterGetter = new PerpendicularRectangleCurveWallParamGetter(clash, categoryOption, pointFinder, levelFinder);
             } else {
-                var pointFinder = new WallPointFinder(clash, new InclinedSizeInitializer(clash, categoryOption).GetRectangleMepHeightGetter());
+                var pointFinder = new WallPointFinder(clash, categoryOption.ElevationRounding, new InclinedSizeInitializer(clash, categoryOption).GetRectangleMepHeightGetter());
                 placer.ParameterGetter = new InclinedRectangleCurveWallParameterGetter(clash, categoryOption, pointFinder, levelFinder);
                 placer.PointFinder = pointFinder;
-            };
+            }
+            ;
 
             return placer;
         }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/PlacerInitializers/RoundMepWallPlacerInitializer.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/PlacerInitializers/RoundMepWallPlacerInitializer.cs
@@ -25,19 +25,20 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PlacerInitializers {
                 OpeningType openingType = new RoundMepWallOpeningTaskTypeProvider(clash.Element1, categoryOption).GetOpeningTaskType();
                 var pointFinder =
                     openingType == OpeningType.WallRound
-                    ? new WallPointFinder(clash)
-                    : new WallPointFinder(clash, new DiameterValueGetter(clash.Element1, categoryOption));
+                    ? new WallPointFinder(clash, categoryOption.ElevationRounding)
+                    : new WallPointFinder(clash, categoryOption.ElevationRounding, new DiameterValueGetter(clash.Element1, categoryOption));
 
                 placer.PointFinder = pointFinder;
                 placer.ParameterGetter = new PerpendicularRoundCurveWallParamGetter(clash, categoryOption, pointFinder, openingType, levelFinder);
                 placer.Type = revitRepository.GetOpeningTaskType(openingType);
             } else {
-                var pointFinder = new WallPointFinder(clash, new InclinedSizeInitializer(clash, categoryOption).GetRoundMepHeightGetter());
+                var pointFinder = new WallPointFinder(clash, categoryOption.ElevationRounding, new InclinedSizeInitializer(clash, categoryOption).GetRoundMepHeightGetter());
 
                 placer.PointFinder = pointFinder;
                 placer.ParameterGetter = new InclinedRoundCurveWallParamGetter(clash, categoryOption, pointFinder, levelFinder);
                 placer.Type = revitRepository.GetOpeningTaskType(OpeningType.WallRectangle);
-            };
+            }
+            ;
 
             return placer;
         }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/PlacerInitializers/WallOpeningGroupPlacerInitializer.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/PlacerInitializers/WallOpeningGroupPlacerInitializer.cs
@@ -18,7 +18,7 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PlacerInitializers {
 
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
         /// <exception cref="ArgumentOutOfRangeException">Исключение, если количество элементов в группе отверстий меньше 2</exception>
-        public OpeningPlacer GetPlacer(RevitRepository revitRepository, OpeningsGroup openingsGroup) {
+        public OpeningPlacer GetPlacer(RevitRepository revitRepository, Configs.OpeningConfig config, OpeningsGroup openingsGroup) {
             if(openingsGroup is null) {
                 throw new ArgumentNullException(nameof(openingsGroup));
             }
@@ -28,7 +28,7 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PlacerInitializers {
             if(openingsGroup.Elements.Count < 2) {
                 throw new ArgumentOutOfRangeException(nameof(openingsGroup.Elements.Count));
             }
-            var pointFinder = new WallOpeningsGroupPointFinder(openingsGroup);
+            var pointFinder = new WallOpeningsGroupPointFinder(openingsGroup, config.UnitedTasksElevationRounding);
             var levelFinder = new OpeningsGroupLevelFinder(openingsGroup);
             return new OpeningPlacer(revitRepository) {
                 Type = openingsGroup.IsCylinder
@@ -38,7 +38,7 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PlacerInitializers {
                 PointFinder = pointFinder,
                 LevelFinder = levelFinder,
                 AngleFinder = new WallOpeningsGroupAngleFinder(openingsGroup),
-                ParameterGetter = new WallSolidParameterGetter(new OpeningGroupSolidProvider(openingsGroup), pointFinder, levelFinder, openingsGroup)
+                ParameterGetter = new WallSolidParameterGetter(new OpeningGroupSolidProvider(openingsGroup), pointFinder, levelFinder, openingsGroup, config)
             };
         }
     }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/PointFinders/FittingWallPointFinder.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/PointFinders/FittingWallPointFinder.cs
@@ -21,11 +21,12 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PointFinders {
         /// <summary>
         /// Округление высотной отметки отверстия в мм
         /// </summary>
-        private const int _heightRound = 10;
+        private readonly int _heightRound;
 
-        public FittingWallPointFinder(FittingClash<Wall> clash, IAngleFinder angleFinder, IValueGetter<DoubleParamValue> sizeGetter = null) {
+        public FittingWallPointFinder(FittingClash<Wall> clash, IAngleFinder angleFinder, int heightRound, IValueGetter<DoubleParamValue> sizeGetter = null) {
             _clash = clash;
             _angleFinder = angleFinder;
+            _heightRound = heightRound;
             _sizeGetter = sizeGetter;
         }
 

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/PointFinders/WallOpeningsGroupPointFinder.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/PointFinders/WallOpeningsGroupPointFinder.cs
@@ -16,10 +16,16 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PointFinders {
         /// <summary>
         /// Округление высотной отметки отверстия в мм
         /// </summary>
-        private const int _heightRound = 10;
+        private readonly int _heightRound;
 
-        public WallOpeningsGroupPointFinder(OpeningsGroup group) {
+        /// <summary>
+        /// Конструирует провайдер точки вставки для объединенного задания на отверстие
+        /// </summary>
+        /// <param name="group">Объединенное задание на отверстие</param>
+        /// <param name="heightRounding">Округление отметки в мм</param>
+        public WallOpeningsGroupPointFinder(OpeningsGroup group, int heightRounding) {
             _group = group ?? throw new System.ArgumentNullException(nameof(group));
+            _heightRound = heightRounding;
         }
 
         public XYZ GetPoint() {
@@ -29,8 +35,9 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PointFinders {
                 .ToList()
                 .CreateUnitedBoundingBox();
             var center = bb.Min + (bb.Max - bb.Min) / 2;
-            var zRoundCoordinate = _group.IsCylinder ? RoundFeetToMillimeters(center.Z, _heightRound) : RoundFeetToMillimeters(bb.Min.Z, _heightRound);
-            return _group.GetTransform().OfPoint(new XYZ(center.X, bb.Min.Y, zRoundCoordinate));
+            var zCoordinate = _group.IsCylinder ? center.Z : bb.Min.Z;
+            var transformedPoint = _group.GetTransform().OfPoint(new XYZ(center.X, bb.Min.Y, zCoordinate));
+            return new XYZ(transformedPoint.X, transformedPoint.Y, RoundFeetToMillimeters(transformedPoint.Z, _heightRound));
         }
     }
 }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/PointFinders/WallPointFinder.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/PointFinders/WallPointFinder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using Autodesk.Revit.DB;
 
@@ -16,18 +16,20 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.PointFinders {
         /// <summary>
         /// Округление высотной отметки отверстия в мм
         /// </summary>
-        private const int _heightRound = 10;
+        private readonly int _heightRound;
 
         /// <summary>
         /// Конструктор класса, предоставляющего точку вставки задания на отверстие в стене
         /// </summary>
         /// <param name="clash">Пересечение линейного инженерного элемента со стеной</param>
+        /// <param name="heightRound">Округление высотной отметки задания на отверстие в мм</param>
         /// <param name="rectangleHeightGetter">
         /// Высота прямоугольного отверстия - опциональный параметр для прямоугольных отверстий.
         /// Нужен для корректировки точки вставки, т.к. точка вставки прямоугольного отверстия в стене находится у нижней грани.
         /// </param>
-        public WallPointFinder(MepCurveClash<Wall> clash, IValueGetter<DoubleParamValue> rectangleHeightGetter = null) {
+        public WallPointFinder(MepCurveClash<Wall> clash, int heightRound, IValueGetter<DoubleParamValue> rectangleHeightGetter = null) {
             _clash = clash;
+            _heightRound = heightRound;
             _rectangleHeightGetter = rectangleHeightGetter;
         }
 

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/FloorOpeningSizeInitializer.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/FloorOpeningSizeInitializer.cs
@@ -1,4 +1,4 @@
-﻿
+
 using Autodesk.Revit.DB;
 
 using RevitClashDetective.Models.Value;
@@ -10,23 +10,31 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ValueGetters {
 
     internal class FloorOpeningSizeInitializer {
         private readonly BoundingBoxXYZ _bb;
+        private readonly int _defaultSizeRounding;
         private readonly MepCategory[] _mepCategories;
 
-        public FloorOpeningSizeInitializer(Solid solid, params MepCategory[] mepCategories) {
+        /// <summary>
+        /// Конструирует инициализатор параметров для габаритов задания на отверстие по солиду с учетом округлений и отступов
+        /// </summary>
+        /// <param name="solid">Солид для определения габаритов</param>
+        /// <param name="defaultSizeRounding">Округление размеров задания на отверстие по умолчанию в мм</param>
+        /// <param name="mepCategories">Категории ВИС с настройками округлений размеров и отступов</param>
+        public FloorOpeningSizeInitializer(Solid solid, int defaultSizeRounding, params MepCategory[] mepCategories) {
             _bb = solid.GetBoundingBox();
+            _defaultSizeRounding = defaultSizeRounding;
             _mepCategories = mepCategories;
         }
 
         public IValueGetter<DoubleParamValue> GetWidth() {
-            return new OpeningSizeGetter(_bb.Max.X, _bb.Min.X, _mepCategories);
+            return new OpeningSizeGetter(_bb.Max.X - _bb.Min.X, _defaultSizeRounding, _mepCategories);
         }
 
         public IValueGetter<DoubleParamValue> GetHeight() {
-            return new OpeningSizeGetter(_bb.Max.Y, _bb.Min.Y, _mepCategories);
+            return new OpeningSizeGetter(_bb.Max.Y - _bb.Min.Y, _defaultSizeRounding, _mepCategories);
         }
 
         public IValueGetter<DoubleParamValue> GetThickness() {
-            return new OpeningSizeGetter(_bb.Max.Z, _bb.Min.Z);
+            return new OpeningSizeGetter(_bb.Max.Z - _bb.Min.Z, 0);
         }
     }
 }

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/OpeningSizeGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/OpeningSizeGetter.cs
@@ -9,28 +9,35 @@ using RevitOpeningPlacement.Models.Interfaces;
 
 namespace RevitOpeningPlacement.Models.OpeningPlacement.ValueGetters {
     internal class OpeningSizeGetter : RoundValueGetter, IValueGetter<DoubleParamValue> {
-        private readonly double _max;
-        private readonly double _min;
+        private readonly double _size;
+        private readonly int _defaultSizeRounding;
         private readonly MepCategory[] _mepCategories;
         /// <summary>
         /// Минимальное значение габарита задания на отверстие в футах (5 мм)
         /// </summary>
         private const double _minGeometryFeetSize = 0.015;
 
-        public OpeningSizeGetter(double max, double min, params MepCategory[] mepCategories) {
-            _max = max;
-            _min = min;
+        /// <summary>
+        /// Создает объект для получения размеров задания на отверстия с учетом отступов и округлений
+        /// </summary>
+        /// <param name="size">Начальный размер заания на отверстие без отступов и округлений в единицах Revit</param>
+        /// <param name="defaultSizeRounding">Округление размеров по умолчанию в мм, которое применится, 
+        /// если <paramref name="mepCategories"/> пустая коллекция</param>
+        /// <param name="mepCategories">Категории ВИС для настройки отступов и округлений</param>
+        public OpeningSizeGetter(double size, int defaultSizeRounding, params MepCategory[] mepCategories) {
+            _size = size;
+            _defaultSizeRounding = defaultSizeRounding;
             _mepCategories = mepCategories;
         }
 
         public DoubleParamValue GetValue() {
-            var size = _max - _min;
+            var size = _size;
             int mmRound = 0;
             if(_mepCategories != null && _mepCategories.Length > 0) {
-                size += _mepCategories.Max(item => item.GetOffsetValue(_max - _min));
+                size += _mepCategories.Max(item => item.GetOffsetValue(_size));
                 mmRound = _mepCategories.Max(x => x.Rounding);
             } else {
-                mmRound = 10;
+                mmRound = _defaultSizeRounding;
             }
             size = RoundToCeilingFeetToMillimeters(size, mmRound);
             //проверка на недопустимо малые габариты

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/OpeningSizeGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/OpeningSizeGetter.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System.Linq;
 
 using RevitClashDetective.Models.Value;

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/RoundValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/RoundValueGetter.cs
@@ -29,26 +29,34 @@ namespace RevitOpeningPlacement.Models.OpeningPlacement.ValueGetters {
 
         /// <summary>
         /// Округляет полученное значение длины (в футах) до ближайшего сверху целого заданного количества миллиметров и возвращает округленную длину в футах.
-        /// Если значение округления 0 или меньше, будет произведено округление по умолчанию до 1 мм.
+        /// Если значение округления 0 или меньше, округление произведено не будет.
         /// </summary>
         /// <param name="ftValue">Размер в футах, который нужно округлить до заданного количества миллиметров</param>
         /// <param name="mmRound">Значение округления в миллиметрах</param>
         /// <returns>Размер в футах, округленный до заданного количества миллиметров</returns>
         protected double RoundToCeilingFeetToMillimeters(double ftValue, int mmRound) {
-            var ftRound = mmRound > 0 ? GetFeetRound(mmRound) : GetFeetRound(1);
-            return Math.Ceiling(Math.Round(ftValue / ftRound, _digitsRound, MidpointRounding.AwayFromZero)) * ftRound;
+            if(mmRound > 0) {
+                var ftRound = GetFeetRound(mmRound);
+                return Math.Ceiling(Math.Round(ftValue / ftRound, _digitsRound, MidpointRounding.AwayFromZero)) * ftRound;
+            } else {
+                return ftValue;
+            }
         }
 
         /// <summary>
         /// Округляет полученное значение длины (в футах) до ближайшего снизу целого заданного количества миллиметров и возвращает округленную длину в футах.
-        /// Если значение округления 0 или меньше, будет произведено округление по умолчанию до 1 мм.
+        /// Если значение округления 0 или меньше, округление произведено не будет.
         /// </summary>
         /// <param name="ftValue">Размер в футах, который нужно округлить до заданного количества миллиметров</param>
         /// <param name="mmRound">Значение округления в миллиметрах</param>
         /// <returns>Размер в футах, округленный до заданного количества миллиметров</returns>
         protected double RoundToFloorFeetToMillimeters(double ftValue, int mmRound = 1) {
-            var ftRound = mmRound > 0 ? GetFeetRound(mmRound) : GetFeetRound(1);
-            return Math.Floor(Math.Round(ftValue / ftRound, _digitsRound, MidpointRounding.AwayFromZero)) * ftRound;
+            if(mmRound > 0) {
+                var ftRound = GetFeetRound(mmRound);
+                return Math.Floor(Math.Round(ftValue / ftRound, _digitsRound, MidpointRounding.AwayFromZero)) * ftRound;
+            } else {
+                return ftValue;
+            }
         }
 
 

--- a/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/WallOpeningSizeInitializer.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningPlacement/ValueGetters/WallOpeningSizeInitializer.cs
@@ -1,4 +1,4 @@
-﻿
+
 using Autodesk.Revit.DB;
 
 using RevitClashDetective.Models.Value;
@@ -9,22 +9,30 @@ using RevitOpeningPlacement.Models.Interfaces;
 namespace RevitOpeningPlacement.Models.OpeningPlacement.ValueGetters {
     internal class WallOpeningSizeInitializer {
         private readonly BoundingBoxXYZ _bb;
+        private readonly int _defaultSizeRounding;
         private readonly MepCategory[] _mepCategories;
 
-        public WallOpeningSizeInitializer(Solid solid, params MepCategory[] mepCategories) {
+        /// <summary>
+        /// Инициализатор значений параметров для габаритов задания на отверстия с учетом округлений и отступов
+        /// </summary>
+        /// <param name="solid">Солид для определения габаритов задания на отверстие без учета габаритов и отступов</param>
+        /// <param name="defaultSizeRounding">Округление размеров задания на отверстие в мм по умолчанию</param>
+        /// <param name="mepCategories">Категории ВИС с настройками отступов и округлений</param>
+        public WallOpeningSizeInitializer(Solid solid, int defaultSizeRounding, params MepCategory[] mepCategories) {
             _bb = solid.GetBoundingBox();
+            _defaultSizeRounding = defaultSizeRounding;
             _mepCategories = mepCategories;
         }
         public IValueGetter<DoubleParamValue> GetWidth() {
-            return new OpeningSizeGetter(_bb.Max.X, _bb.Min.X, _mepCategories);
+            return new OpeningSizeGetter(_bb.Max.X - _bb.Min.X, _defaultSizeRounding, _mepCategories);
         }
 
         public IValueGetter<DoubleParamValue> GetHeight() {
-            return new OpeningSizeGetter(_bb.Max.Z, _bb.Min.Z, _mepCategories);
+            return new OpeningSizeGetter(_bb.Max.Z - _bb.Min.Z, _defaultSizeRounding, _mepCategories);
         }
 
         public IValueGetter<DoubleParamValue> GetThickness() {
-            return new OpeningSizeGetter(_bb.Max.Y, _bb.Min.Y);
+            return new OpeningSizeGetter(_bb.Max.Y - _bb.Min.Y, 0);
         }
     }
 }

--- a/src/RevitOpeningPlacement/Models/OpeningUnion/MultilayerOpeningsGroupsProvider.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningUnion/MultilayerOpeningsGroupsProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -115,7 +115,7 @@ namespace RevitOpeningPlacement.Models.OpeningUnion {
         private ICollection<OpeningMepTaskOutcoming> GetTouchingOpenings(OpeningMepTaskOutcoming baseOpening, ICollection<OpeningMepTaskOutcoming> otherOpenings) {
             HashSet<OpeningMepTaskOutcoming> touchingOpenings = new HashSet<OpeningMepTaskOutcoming>();
             foreach(OpeningMepTaskOutcoming otherOpening in otherOpenings) {
-                if(baseOpening.HasCommonFace(otherOpening)) {
+                if(baseOpening.Intersect(otherOpening)) {
                     touchingOpenings.Add(otherOpening);
                 }
             }

--- a/src/RevitOpeningPlacement/Models/OpeningUnion/OpeningsGroup.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningUnion/OpeningsGroup.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 using Autodesk.Revit.DB;
 
+using RevitOpeningPlacement.Models.Configs;
 using RevitOpeningPlacement.Models.OpeningPlacement;
 using RevitOpeningPlacement.Models.OpeningPlacement.PlacerInitializers;
 using RevitOpeningPlacement.OpeningModels;
@@ -50,15 +51,16 @@ namespace RevitOpeningPlacement.Models.OpeningUnion {
         /// <summary>
         /// Возвращает генератор задания на отверстие, 
         /// </summary>
+        /// <param name="config">Настройки расстановки заданий на отверстия</param>
         /// <exception cref="InvalidOperationException">Исключение, если не удалось выполнить операцию</exception>
         /// <exception cref="ArgumentOutOfRangeException">В группе находится менее 2-х заданий на отверстия</exception>
-        public OpeningPlacer GetOpeningPlacer(RevitRepository revitRepository) {
+        public OpeningPlacer GetOpeningPlacer(RevitRepository revitRepository, OpeningConfig config) {
             try {
                 OpeningPlacer placer;
                 if(_elements.Any(task => (task.OpeningType == OpeningType.FloorRound) || (task.OpeningType == OpeningType.FloorRectangle))) {
-                    placer = new FloorOpeningGroupPlacerInitializer().GetPlacer(revitRepository, this);
+                    placer = new FloorOpeningGroupPlacerInitializer().GetPlacer(revitRepository, config, this);
                 } else {
-                    placer = new WallOpeningGroupPlacerInitializer().GetPlacer(revitRepository, this);
+                    placer = new WallOpeningGroupPlacerInitializer().GetPlacer(revitRepository, config, this);
                 }
                 return placer;
 

--- a/src/RevitOpeningPlacement/Models/OpeningUnion/OpeningsGroup.cs
+++ b/src/RevitOpeningPlacement/Models/OpeningUnion/OpeningsGroup.cs
@@ -137,7 +137,7 @@ namespace RevitOpeningPlacement.Models.OpeningUnion {
         /// <param name="otherOpeningTask">Проверяемое задание на отверстие</param>
         /// <returns>True, если группа пустая или если среди отверстий в группе есть хотя бы одно, которое имеет общую грань с проверяемым, иначе False</returns>
         private bool IsTouchingOpening(OpeningMepTaskOutcoming otherOpeningTask) {
-            return (_elements.Count == 0) || _elements.Any(existingOpening => existingOpening.HasCommonFace(otherOpeningTask));
+            return (_elements.Count == 0) || _elements.Any(existingOpening => existingOpening.Intersect(otherOpeningTask));
         }
 
         /// <summary>
@@ -146,13 +146,21 @@ namespace RevitOpeningPlacement.Models.OpeningUnion {
         /// <param name="otherOpeningTask">Проверяемое задание на отверстие</param>
         /// <returns>True, если задания на отверстия в группе расположены на той же прямой, что и проверяемое, иначе False</returns>
         private bool OpeningsLocatedOnTheSameLine(OpeningMepTaskOutcoming otherOpeningTask) {
-            if(_elements.Count < 2) { return true; }
-            XYZ firstToOtherDirection = GetDirectionBetween(_elements.First(), otherOpeningTask);
-            XYZ lastToOtherDirection = GetDirectionBetween(_elements.Last(), otherOpeningTask);
-            double angle = firstToOtherDirection.AngleTo(lastToOtherDirection);
-            bool angleIsZero = Math.Round(angle, 9) == 0;
-            bool angleIsPi = Math.Round(angle - Math.PI, 9) == 0;
-            return angleIsZero || angleIsPi;
+            if(_elements.Count == 0) { return true; }
+            if(_elements.Count == 1) {
+                var firstNormal = _elements.First().GetFamilyInstance().FacingOrientation;
+                var firstLocation = _elements.First().Location;
+                var secondLocation = otherOpeningTask.Location;
+                var direction = (secondLocation - firstLocation).Normalize();
+                return firstNormal.IsAlmostEqualTo(direction) || firstNormal.IsAlmostEqualTo(direction.Negate());
+            } else {
+                XYZ firstToOtherDirection = GetDirectionBetween(_elements.First(), otherOpeningTask);
+                XYZ lastToOtherDirection = GetDirectionBetween(_elements.Last(), otherOpeningTask);
+                double angle = firstToOtherDirection.AngleTo(lastToOtherDirection);
+                bool angleIsZero = Math.Round(angle, 9) == 0;
+                bool angleIsPi = Math.Round(angle - Math.PI, 9) == 0;
+                return angleIsZero || angleIsPi;
+            }
         }
 
         /// <summary>

--- a/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/ParameterGetters/ManyOpeningTasksInFloorParameterGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/ParameterGetters/ManyOpeningTasksInFloorParameterGetter.cs
@@ -15,16 +15,19 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.ParameterGetters {
     /// </summary>
     internal class ManyOpeningTasksInFloorParameterGetter : IParametersGetter {
         private readonly ICollection<OpeningMepTaskIncoming> _incomingTasks;
+        private readonly int _rounding;
 
 
         /// <summary>
         /// Конструктор класса, предоставляющего параметров габариты чистового отверстия, размещаемого в перекрытии по нескольким заданиям на отверстия
         /// </summary>
         /// <param name="incomingTasks">Входящие задания на отверстия</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
         /// <exception cref="ArgumentException">Исключение, если в коллекции меньше одного элемента</exception>
-        public ManyOpeningTasksInFloorParameterGetter(ICollection<OpeningMepTaskIncoming> incomingTasks) {
+        public ManyOpeningTasksInFloorParameterGetter(ICollection<OpeningMepTaskIncoming> incomingTasks, int rounding) {
             _incomingTasks = incomingTasks ?? throw new ArgumentNullException(nameof(incomingTasks));
+            _rounding = rounding;
             if(_incomingTasks.Count < 1) { throw new ArgumentException(nameof(incomingTasks)); }
         }
 
@@ -33,10 +36,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.ParameterGetters {
             // габариты отверстия
             yield return new DoubleParameterGetter(
                 RealOpeningArPlacer.RealOpeningArHeight,
-                new RectangleOpeningInFloorHeightValueGetter(_incomingTasks.Cast<IOpeningTaskIncoming>().ToArray())).GetParamValue();
+                new RectangleOpeningInFloorHeightValueGetter(_incomingTasks.Cast<IOpeningTaskIncoming>().ToArray(), _rounding)).GetParamValue();
             yield return new DoubleParameterGetter(
                 RealOpeningArPlacer.RealOpeningArWidth,
-                new RectangleOpeningInFloorWidthValueGetter(_incomingTasks.Cast<IOpeningTaskIncoming>().ToArray())).GetParamValue();
+                new RectangleOpeningInFloorWidthValueGetter(_incomingTasks.Cast<IOpeningTaskIncoming>().ToArray(), _rounding)).GetParamValue();
 
             // логические флаги для обозначений разделов отверстия
             var isEomValueGetter = new IsEomValueGetter(_incomingTasks);

--- a/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/ParameterGetters/ManyOpeningTasksInWallParameterGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/ParameterGetters/ManyOpeningTasksInWallParameterGetter.cs
@@ -19,19 +19,22 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.ParameterGetters {
         private readonly Wall _wall;
         private readonly ICollection<OpeningMepTaskIncoming> _incomingTasks;
         private readonly IPointFinder _pointFinder;
+        private readonly int _rounding;
 
 
         /// <summary>
         /// Конструктор класса, предоставляющего параметры для чистового прямоугольного отверстия в стене для нескольких заданий на отверстия
         /// </summary>
         /// <param name="incomingTasks">Входящие задания на отверстия</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="System.ArgumentNullException">Исключение, если обязательный параметр null</exception>
         /// <exception cref="ArgumentException">Исключение, если в коллекции меньше одного элемента</exception>
-        public ManyOpeningTasksInWallParameterGetter(Wall wall, ICollection<OpeningMepTaskIncoming> incomingTasks, IPointFinder pointFinder) {
+        public ManyOpeningTasksInWallParameterGetter(Wall wall, ICollection<OpeningMepTaskIncoming> incomingTasks, IPointFinder pointFinder, int rounding) {
             _wall = wall ?? throw new ArgumentNullException(nameof(wall));
             _incomingTasks = incomingTasks ?? throw new System.ArgumentNullException(nameof(incomingTasks));
             if(_incomingTasks.Count < 1) { throw new ArgumentException(nameof(incomingTasks)); }
             _pointFinder = pointFinder ?? throw new ArgumentNullException(nameof(pointFinder));
+            _rounding = rounding;
         }
 
 
@@ -39,10 +42,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.ParameterGetters {
             // габариты отверстия
             yield return new DoubleParameterGetter(
                 RealOpeningArPlacer.RealOpeningArHeight,
-                new RectangleOpeningInWallHeightValueGetter(_incomingTasks.Cast<IOpeningTaskIncoming>().ToArray(), _pointFinder)).GetParamValue();
+                new RectangleOpeningInWallHeightValueGetter(_incomingTasks.Cast<IOpeningTaskIncoming>().ToArray(), _pointFinder, _rounding)).GetParamValue();
             yield return new DoubleParameterGetter(
                 RealOpeningArPlacer.RealOpeningArWidth,
-                new RectangleOpeningInWallWidthValueGetter(_incomingTasks.Cast<IOpeningTaskIncoming>().ToArray(), _wall)).GetParamValue();
+                new RectangleOpeningInWallWidthValueGetter(_incomingTasks.Cast<IOpeningTaskIncoming>().ToArray(), _wall, _rounding)).GetParamValue();
 
             // логические флаги для обозначений разделов отверстия
             var isEomValueGetter = new IsEomValueGetter(_incomingTasks);

--- a/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/ParameterGetters/SingleRectangleOpeningTaskInFloorParameterGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/ParameterGetters/SingleRectangleOpeningTaskInFloorParameterGetter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using RevitOpeningPlacement.Models.Interfaces;
@@ -14,16 +14,19 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.ParameterGetters {
     /// </summary>
     internal class SingleRectangleOpeningTaskInFloorParameterGetter : IParametersGetter {
         private readonly OpeningMepTaskIncoming _openingMepTaskIncoming;
+        private readonly int _rounding;
 
 
         /// <summary>
         /// Конструктор класса, предоставляющего параметры для чистового прямоугольного отверстия из параметров входящего задания на прямоугольное отверстие в перекрытии
         /// </summary>
         /// <param name="incomingTask">Входящее задание на отверстие</param>
-        public SingleRectangleOpeningTaskInFloorParameterGetter(OpeningMepTaskIncoming incomingTask) {
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
+        public SingleRectangleOpeningTaskInFloorParameterGetter(OpeningMepTaskIncoming incomingTask, int rounding) {
             if(incomingTask is null) { throw new ArgumentNullException(nameof(incomingTask)); }
 
             _openingMepTaskIncoming = incomingTask;
+            _rounding = rounding;
         }
 
 
@@ -31,10 +34,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.ParameterGetters {
             // габариты отверстия
             yield return new DoubleParameterGetter(
                 RealOpeningArPlacer.RealOpeningArHeight,
-                new RectangleOpeningInFloorHeightValueGetter(_openingMepTaskIncoming)).GetParamValue();
+                new RectangleOpeningInFloorHeightValueGetter(_openingMepTaskIncoming, _rounding)).GetParamValue();
             yield return new DoubleParameterGetter(
                 RealOpeningArPlacer.RealOpeningArWidth,
-                new RectangleOpeningInFloorWidthValueGetter(_openingMepTaskIncoming)).GetParamValue();
+                new RectangleOpeningInFloorWidthValueGetter(_openingMepTaskIncoming, _rounding)).GetParamValue();
 
             // логические флаги для обозначений разделов отверстия
             var isEomValueGetter = new IsEomValueGetter(_openingMepTaskIncoming);

--- a/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/ParameterGetters/SingleRectangleOpeningTaskInWallParameterGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/ParameterGetters/SingleRectangleOpeningTaskInWallParameterGetter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using RevitOpeningPlacement.Models.Interfaces;
@@ -15,18 +15,21 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.ParameterGetters {
     internal class SingleRectangleOpeningTaskInWallParameterGetter : IParametersGetter {
         private readonly OpeningMepTaskIncoming _openingMepTaskIncoming;
         private readonly IPointFinder _pointFinder;
+        private readonly int _rounding;
 
         /// <summary>
         /// Конструктор класса, предоставляющего параметры для чистового прямоугольного отверстия из параметров входящего задания на прямоугольное отверстие в стене
         /// </summary>
         /// <param name="incomingTask">Входящее задание на отверстие</param>
         /// <param name="pointFinder">Провайдер точки вставки чистового отверстия</param>
-        public SingleRectangleOpeningTaskInWallParameterGetter(OpeningMepTaskIncoming incomingTask, IPointFinder pointFinder) {
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
+        public SingleRectangleOpeningTaskInWallParameterGetter(OpeningMepTaskIncoming incomingTask, IPointFinder pointFinder, int rounding) {
             if(incomingTask is null) { throw new ArgumentNullException(nameof(incomingTask)); }
             if(pointFinder is null) { throw new ArgumentNullException(nameof(pointFinder)); }
 
             _openingMepTaskIncoming = incomingTask;
             _pointFinder = pointFinder;
+            _rounding = rounding;
         }
 
 
@@ -34,10 +37,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.ParameterGetters {
             // габариты отверстия
             yield return new DoubleParameterGetter(
                 RealOpeningArPlacer.RealOpeningArHeight,
-                new RectangleOpeningInWallHeightValueGetter(_openingMepTaskIncoming, _pointFinder)).GetParamValue();
+                new RectangleOpeningInWallHeightValueGetter(_openingMepTaskIncoming, _pointFinder, _rounding)).GetParamValue();
             yield return new DoubleParameterGetter(
                 RealOpeningArPlacer.RealOpeningArWidth,
-                new RectangleOpeningInWallWidthValueGetter(_openingMepTaskIncoming)).GetParamValue();
+                new RectangleOpeningInWallWidthValueGetter(_openingMepTaskIncoming, _rounding)).GetParamValue();
 
             // логические флаги для обозначений разделов отверстия
             var isEomValueGetter = new IsEomValueGetter(_openingMepTaskIncoming);

--- a/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/ParameterGetters/SingleRoundOpeningTaskInFloorParameterGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/ParameterGetters/SingleRoundOpeningTaskInFloorParameterGetter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using RevitOpeningPlacement.Models.Interfaces;
@@ -14,16 +14,19 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.ParameterGetters {
     /// </summary>
     internal class SingleRoundOpeningTaskInFloorParameterGetter : IParametersGetter {
         private readonly OpeningMepTaskIncoming _openingMepTaskIncoming;
+        private readonly int _rounding;
 
 
         /// <summary>
         /// Класс, предоставляющий параметры для чистового круглого отверстия из параметров входящего задания на круглое отверстие в перекрытии
         /// </summary>
         /// <param name="incomingTask">Входящее задание на отверстие</param>
-        public SingleRoundOpeningTaskInFloorParameterGetter(OpeningMepTaskIncoming incomingTask) {
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
+        public SingleRoundOpeningTaskInFloorParameterGetter(OpeningMepTaskIncoming incomingTask, int rounding) {
             if(incomingTask is null) { throw new ArgumentNullException(nameof(incomingTask)); }
 
             _openingMepTaskIncoming = incomingTask;
+            _rounding = rounding;
         }
 
 
@@ -31,7 +34,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.ParameterGetters {
             // габариты отверстия
             yield return new DoubleParameterGetter(
                 RealOpeningArPlacer.RealOpeningArDiameter,
-                new RoundOpeningInFloorDiameterValueGetter(_openingMepTaskIncoming)).GetParamValue();
+                new RoundOpeningInFloorDiameterValueGetter(_openingMepTaskIncoming, _rounding)).GetParamValue();
 
             // логические флаги для обозначений разделов отверстия
             var isEomValueGetter = new IsEomValueGetter(_openingMepTaskIncoming);

--- a/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/ParameterGetters/SingleRoundOpeningTaskInWallParameterGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/ParameterGetters/SingleRoundOpeningTaskInWallParameterGetter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using RevitOpeningPlacement.Models.Interfaces;
@@ -15,6 +15,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.ParameterGetters {
     internal class SingleRoundOpeningTaskInWallParameterGetter : IParametersGetter {
         private readonly OpeningMepTaskIncoming _openingMepTaskIncoming;
         private readonly IPointFinder _pointFinder;
+        private readonly int _rounding;
 
 
         /// <summary>
@@ -22,12 +23,14 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.ParameterGetters {
         /// </summary>
         /// <param name="incomingTask">Входящее задание на отверстие</param>
         /// <param name="pointFinder">Провайдер точки вставки чистового отверстия</param>
-        public SingleRoundOpeningTaskInWallParameterGetter(OpeningMepTaskIncoming incomingTask, IPointFinder pointFinder) {
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
+        public SingleRoundOpeningTaskInWallParameterGetter(OpeningMepTaskIncoming incomingTask, IPointFinder pointFinder, int rounding) {
             if(incomingTask is null) { throw new ArgumentNullException(nameof(incomingTask)); }
             if(pointFinder is null) { throw new ArgumentNullException(nameof(pointFinder)); }
 
             _openingMepTaskIncoming = incomingTask;
             _pointFinder = pointFinder;
+            _rounding = rounding;
         }
 
 
@@ -35,7 +38,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.ParameterGetters {
             // габариты отверстия
             yield return new DoubleParameterGetter(
                 RealOpeningArPlacer.RealOpeningArDiameter,
-                new RoundOpeningInWallDiameterValueGetter(_openingMepTaskIncoming, _pointFinder)).GetParamValue();
+                new RoundOpeningInWallDiameterValueGetter(_openingMepTaskIncoming, _pointFinder, _rounding)).GetParamValue();
 
             // логические флаги для обозначений разделов отверстия
             var isEomValueGetter = new IsEomValueGetter(_openingMepTaskIncoming);

--- a/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/PointFinders/BoundingBoxBottomPointFinder.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/PointFinders/BoundingBoxBottomPointFinder.cs
@@ -11,21 +11,25 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.PointFinders {
     /// </summary>
     internal class BoundingBoxBottomPointFinder : RoundValueGetter, IPointFinder {
         private readonly BoundingBoxXYZ _bbox;
+        private readonly int _roundingMm;
 
 
         /// <summary>
         /// Конструктор класса, предоставляющего точку вставки чистового отверстия по заданному боксу. Использовать для получения точки вставки чистового отверстия по нескольким заданиям на отверстия в стене
         /// </summary>
+        /// <param name="bbox">Бокс</param>
+        /// <param name="roundingMm">Округление высотной отметки в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public BoundingBoxBottomPointFinder(BoundingBoxXYZ bbox) {
+        public BoundingBoxBottomPointFinder(BoundingBoxXYZ bbox, int roundingMm) {
             _bbox = bbox ?? throw new ArgumentNullException(nameof(bbox));
+            _roundingMm = roundingMm;
         }
 
 
         public XYZ GetPoint() {
             var x = (_bbox.Max.X + _bbox.Min.X) / 2;
             var y = (_bbox.Max.Y + _bbox.Min.Y) / 2;
-            var z = RoundToFloorFeetToMillimeters(_bbox.Min.Z);
+            var z = RoundToFloorFeetToMillimeters(_bbox.Min.Z, _roundingMm);
             return new XYZ(x, y, z);
         }
     }

--- a/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/PointFinders/SingleOpeningTaskPointFinder.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/PointFinders/SingleOpeningTaskPointFinder.cs
@@ -12,16 +12,17 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.PointFinders {
     /// </summary>
     internal class SingleOpeningTaskPointFinder : RoundValueGetter, IPointFinder {
         private readonly OpeningMepTaskIncoming _openingMepTaskIncoming;
+        private readonly int _rounding;
 
         /// <summary>
         /// Конструктор класса, предоставляющего точку вставки для чистового отверстия по заданию на отверстие
         /// </summary>
         /// <param name="incomingTask">Входящее задание на отверстие</param>
+        /// <param name="rounding">Округление высотной отметки в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public SingleOpeningTaskPointFinder(OpeningMepTaskIncoming incomingTask) {
-            if(incomingTask is null) { throw new ArgumentNullException(nameof(incomingTask)); }
-
-            _openingMepTaskIncoming = incomingTask;
+        public SingleOpeningTaskPointFinder(OpeningMepTaskIncoming incomingTask, int rounding) {
+            _openingMepTaskIncoming = incomingTask ?? throw new ArgumentNullException(nameof(incomingTask));
+            _rounding = rounding;
         }
 
 
@@ -30,7 +31,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.PointFinders {
                 case OpeningType.WallRound:
                 case OpeningType.WallRectangle:
                     var point = _openingMepTaskIncoming.Location;
-                    return new XYZ(point.X, point.Y, RoundToFloorFeetToMillimeters(point.Z));
+                    return new XYZ(point.X, point.Y, RoundToFloorFeetToMillimeters(point.Z, _rounding));
                 default:
                     return _openingMepTaskIncoming.Location;
             }

--- a/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/Providers/ManyOpeningTasksParameterGettersProvider.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/Providers/ManyOpeningTasksParameterGettersProvider.cs
@@ -15,6 +15,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.Providers {
         private readonly Element _host;
         private readonly ICollection<OpeningMepTaskIncoming> _incomingTasks;
         private readonly IPointFinder _pointFinder;
+        private readonly int _rounding;
 
 
         /// <summary>
@@ -23,9 +24,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.Providers {
         /// <param name="host">Хост чистового отверстия</param>
         /// <param name="incomingTasks">Входящие задания на отверстия</param>
         /// <param name="pointFinder">Интерфейс, предоставляющий точку вставки чистового отверстия</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
         /// <exception cref="ArgumentException">Исключение, если в коллекции меньше 1 элемента</exception>
-        public ManyOpeningTasksParameterGettersProvider(Element host, ICollection<OpeningMepTaskIncoming> incomingTasks, IPointFinder pointFinder) {
+        public ManyOpeningTasksParameterGettersProvider(Element host, ICollection<OpeningMepTaskIncoming> incomingTasks, IPointFinder pointFinder, int rounding) {
             if(host is null) { throw new ArgumentNullException(nameof(host)); }
             if(!((host is Wall) || (host is Floor))) { throw new ArgumentException(nameof(host)); }
             if(incomingTasks is null) { throw new ArgumentNullException(nameof(incomingTasks)); }
@@ -35,14 +37,15 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.Providers {
             _host = host;
             _incomingTasks = incomingTasks;
             _pointFinder = pointFinder;
+            _rounding = rounding;
         }
 
 
         public IParametersGetter GetParametersGetter() {
             if(_host is Floor) {
-                return new ManyOpeningTasksInFloorParameterGetter(_incomingTasks);
+                return new ManyOpeningTasksInFloorParameterGetter(_incomingTasks, _rounding);
             } else if(_host is Wall wall) {
-                return new ManyOpeningTasksInWallParameterGetter(wall, _incomingTasks, _pointFinder);
+                return new ManyOpeningTasksInWallParameterGetter(wall, _incomingTasks, _pointFinder, _rounding);
             } else {
                 throw new ArgumentException("Тип хоста отверстия не поддерживается");
             }

--- a/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/Providers/ManyOpeningTasksPointFinderProvider.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/Providers/ManyOpeningTasksPointFinderProvider.cs
@@ -17,6 +17,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.Providers {
     internal class ManyOpeningTasksPointFinderProvider {
         private readonly Element _host;
         private readonly ICollection<OpeningMepTaskIncoming> _incomingTasks;
+        private readonly int _rounding;
 
 
         /// <summary>
@@ -24,9 +25,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.Providers {
         /// </summary>
         /// <param name="host">Хост для чистового отверстия</param>
         /// <param name="incomingTasks">Входящие задания на отверстия</param>
+        /// <param name="rounding">Округление высотной отметки</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
         /// <exception cref="ArgumentException">Исключение, если в коллекции меньше 1 элемента</exception>
-        public ManyOpeningTasksPointFinderProvider(Element host, ICollection<OpeningMepTaskIncoming> incomingTasks) {
+        public ManyOpeningTasksPointFinderProvider(Element host, ICollection<OpeningMepTaskIncoming> incomingTasks, int rounding) {
             if(host is null) { throw new ArgumentNullException(nameof(host)); }
             if(!((host is Wall) || (host is Floor))) { throw new ArgumentException(nameof(host)); }
             if(incomingTasks is null) { throw new ArgumentNullException(nameof(incomingTasks)); }
@@ -34,6 +36,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.Providers {
 
             _host = host;
             _incomingTasks = incomingTasks;
+            _rounding = rounding;
         }
 
         public IPointFinder GetPointFinder() {
@@ -53,7 +56,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.Providers {
         }
 
         private IPointFinder GetWallPointFinder(BoundingBoxXYZ unitedBBox) {
-            return new BoundingBoxBottomPointFinder(unitedBBox);
+            return new BoundingBoxBottomPointFinder(unitedBBox, _rounding);
         }
 
         private BoundingBoxXYZ GetUnitedBBox(ICollection<OpeningMepTaskIncoming> incomingTasks) {

--- a/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/Providers/SingleOpeningTaskParameterGettersProvider.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/Providers/SingleOpeningTaskParameterGettersProvider.cs
@@ -11,6 +11,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.Providers {
     internal class SingleOpeningTaskParameterGettersProvider {
         private readonly OpeningMepTaskIncoming _openingMepTaskIncoming;
         private readonly IPointFinder _pointFinder;
+        private readonly int _rounding;
 
 
         /// <summary>
@@ -18,13 +19,15 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.Providers {
         /// </summary>
         /// <param name="incomingTask">Входящее задание на отверстие</param>
         /// <param name="pointFinder">Провайдер точки вставки чистового отверстия</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public SingleOpeningTaskParameterGettersProvider(OpeningMepTaskIncoming incomingTask, IPointFinder pointFinder) {
+        public SingleOpeningTaskParameterGettersProvider(OpeningMepTaskIncoming incomingTask, IPointFinder pointFinder, int rounding) {
             if(incomingTask is null) { throw new ArgumentNullException(nameof(incomingTask)); }
             if(pointFinder is null) { throw new ArgumentNullException(nameof(pointFinder)); }
 
             _openingMepTaskIncoming = incomingTask;
             _pointFinder = pointFinder;
+            _rounding = rounding;
         }
 
 
@@ -32,13 +35,13 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.Providers {
         public IParametersGetter GetParametersGetter() {
             switch(_openingMepTaskIncoming.OpeningType) {
                 case OpeningType.WallRectangle:
-                    return new SingleRectangleOpeningTaskInWallParameterGetter(_openingMepTaskIncoming, _pointFinder);
+                    return new SingleRectangleOpeningTaskInWallParameterGetter(_openingMepTaskIncoming, _pointFinder, _rounding);
                 case OpeningType.FloorRectangle:
-                    return new SingleRectangleOpeningTaskInFloorParameterGetter(_openingMepTaskIncoming);
+                    return new SingleRectangleOpeningTaskInFloorParameterGetter(_openingMepTaskIncoming, _rounding);
                 case OpeningType.WallRound:
-                    return new SingleRoundOpeningTaskInWallParameterGetter(_openingMepTaskIncoming, _pointFinder);
+                    return new SingleRoundOpeningTaskInWallParameterGetter(_openingMepTaskIncoming, _pointFinder, _rounding);
                 case OpeningType.FloorRound:
-                    return new SingleRoundOpeningTaskInFloorParameterGetter(_openingMepTaskIncoming);
+                    return new SingleRoundOpeningTaskInFloorParameterGetter(_openingMepTaskIncoming, _rounding);
                 default:
                     throw new ArgumentException(nameof(_openingMepTaskIncoming.OpeningType));
             }

--- a/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/Providers/SingleOpeningTaskPointFinderProvider.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/Providers/SingleOpeningTaskPointFinderProvider.cs
@@ -10,22 +10,23 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement.Providers {
     /// </summary>
     internal class SingleOpeningTaskPointFinderProvider {
         private readonly OpeningMepTaskIncoming _openingMepTaskIncoming;
+        private readonly int _rounding;
 
 
         /// <summary>
         /// Конструктор класса, предоставляющего <see cref="IPointFinder"/> для чистового отверстия для размещения по одному заданию на отверстие
         /// </summary>
         /// <param name="incomingTask">Входящее задание на отверстие</param>
+        /// <param name="rounding">Округление высотной отметки в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public SingleOpeningTaskPointFinderProvider(OpeningMepTaskIncoming incomingTask) {
-            if(incomingTask is null) { throw new ArgumentNullException(nameof(incomingTask)); }
-
-            _openingMepTaskIncoming = incomingTask;
+        public SingleOpeningTaskPointFinderProvider(OpeningMepTaskIncoming incomingTask, int rounding) {
+            _openingMepTaskIncoming = incomingTask ?? throw new ArgumentNullException(nameof(incomingTask));
+            _rounding = rounding;
         }
 
 
         public IPointFinder GetPointFinder() {
-            return new SingleOpeningTaskPointFinder(_openingMepTaskIncoming);
+            return new SingleOpeningTaskPointFinder(_openingMepTaskIncoming, _rounding);
         }
     }
 }

--- a/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/RealOpeningArPlacer.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningArPlacement/RealOpeningArPlacer.cs
@@ -9,6 +9,7 @@ using dosymep.Revit;
 
 using RevitClashDetective.Models.Extensions;
 
+using RevitOpeningPlacement.Models.Configs;
 using RevitOpeningPlacement.Models.Exceptions;
 using RevitOpeningPlacement.Models.Extensions;
 using RevitOpeningPlacement.Models.Interfaces;
@@ -21,6 +22,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement {
     /// </summary>
     internal class RealOpeningArPlacer {
         private readonly RevitRepository _revitRepository;
+        private readonly OpeningRealsArConfig _config;
 
         public const string RealOpeningArDiameter = "ФОП_РАЗМ_Диаметр";
         public const string RealOpeningArWidth = "ФОП_РАЗМ_Ширина проёма";
@@ -44,6 +46,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement {
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
         public RealOpeningArPlacer(RevitRepository revitRepository) {
             _revitRepository = revitRepository ?? throw new ArgumentNullException(nameof(revitRepository));
+            _config = OpeningRealsArConfig.GetOpeningConfig(_revitRepository.Doc);
         }
 
 
@@ -187,12 +190,12 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement {
         private void PlaceByOneTask(Element host, OpeningMepTaskIncoming openingTask) {
             try {
                 var symbol = GetFamilySymbol(host, openingTask);
-                var pointFinder = GetPointFinder(openingTask);
+                var pointFinder = GetPointFinder(openingTask, _config.ElevationRounding);
                 var point = pointFinder.GetPoint();
 
                 var instance = _revitRepository.CreateInstance(point, symbol, host) ?? throw new OpeningNotPlacedException("Не удалось создать экземпляр семейства");
 
-                var parameterGetter = GetParameterGetter(openingTask, pointFinder);
+                var parameterGetter = GetParameterGetter(openingTask, pointFinder, _config.Rounding);
                 SetParamValues(instance, parameterGetter);
 
                 var angleFinder = GetAngleFinder(openingTask);
@@ -221,12 +224,12 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement {
         private void PlaceUnitedByManyTasks(Element host, ICollection<OpeningMepTaskIncoming> openingTasks) {
             try {
                 var symbol = GetFamilySymbol(host);
-                var pointFinder = GetPointFinder(host, openingTasks);
+                var pointFinder = GetPointFinder(host, openingTasks, _config.ElevationRounding);
                 var point = pointFinder.GetPoint();
 
                 var instance = _revitRepository.CreateInstance(point, symbol, host) ?? throw new OpeningNotPlacedException("Не удалось создать экземпляр семейства");
 
-                var parameterGetter = GetParameterGetter(host, openingTasks, pointFinder);
+                var parameterGetter = GetParameterGetter(host, openingTasks, pointFinder, _config.Rounding);
                 SetParamValues(instance, parameterGetter);
 
                 _revitRepository.SetSelection(instance.Id);
@@ -281,8 +284,9 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement {
         /// </summary>
         /// <param name="incomingTask">Входящее задание на отверстие</param>
         /// <param name="pointFinder">Провайдер точки вставки чистового отверстия</param>
-        private IParametersGetter GetParameterGetter(OpeningMepTaskIncoming incomingTask, IPointFinder pointFinder) {
-            var provider = new SingleOpeningTaskParameterGettersProvider(incomingTask, pointFinder);
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
+        private IParametersGetter GetParameterGetter(OpeningMepTaskIncoming incomingTask, IPointFinder pointFinder, int rounding) {
+            var provider = new SingleOpeningTaskParameterGettersProvider(incomingTask, pointFinder, rounding);
             return provider.GetParametersGetter();
         }
 
@@ -292,8 +296,9 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement {
         /// <param name="host">Хост чистового отверстия - стена или перекрытие</param>
         /// <param name="incomingTasks">Входящие задания на отверстия</param>
         /// <param name="pointFinder">Провайдер точки вставки чистового отверстия</param>
-        private IParametersGetter GetParameterGetter(Element host, ICollection<OpeningMepTaskIncoming> incomingTasks, IPointFinder pointFinder) {
-            return new ManyOpeningTasksParameterGettersProvider(host, incomingTasks, pointFinder).GetParametersGetter();
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
+        private IParametersGetter GetParameterGetter(Element host, ICollection<OpeningMepTaskIncoming> incomingTasks, IPointFinder pointFinder, int rounding) {
+            return new ManyOpeningTasksParameterGettersProvider(host, incomingTasks, pointFinder, rounding).GetParametersGetter();
         }
 
         /// <summary>
@@ -309,8 +314,9 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement {
         /// Возвращает интерфейс, предоставляющий точку вставки
         /// </summary>
         /// <param name="incomingTask">Входящее задание на отверстие</param>
-        private IPointFinder GetPointFinder(OpeningMepTaskIncoming incomingTask) {
-            var provider = new SingleOpeningTaskPointFinderProvider(incomingTask);
+        /// <param name="rounding">Округление высотной отметки в мм</param>
+        private IPointFinder GetPointFinder(OpeningMepTaskIncoming incomingTask, int rounding) {
+            var provider = new SingleOpeningTaskPointFinderProvider(incomingTask, rounding);
             return provider.GetPointFinder();
         }
 
@@ -320,8 +326,9 @@ namespace RevitOpeningPlacement.Models.RealOpeningArPlacement {
         /// </summary>
         /// <param name="host">Хост чистового отверстия - стена или перекрытие</param>
         /// <param name="incomingTasks">Входящие задания на отверстия</param>
-        private IPointFinder GetPointFinder(Element host, ICollection<OpeningMepTaskIncoming> incomingTasks) {
-            var provider = new ManyOpeningTasksPointFinderProvider(host, incomingTasks);
+        /// <param name="rounding">Округление высотной отметки в мм</param>
+        private IPointFinder GetPointFinder(Element host, ICollection<OpeningMepTaskIncoming> incomingTasks, int rounding) {
+            var provider = new ManyOpeningTasksPointFinderProvider(host, incomingTasks, rounding);
             return provider.GetPointFinder();
         }
     }

--- a/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/ManyOpeningArTasksInFloorParameterGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/ManyOpeningArTasksInFloorParameterGetter.cs
@@ -13,15 +13,18 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
     /// </summary>
     internal class ManyOpeningArTasksInFloorParameterGetter : IParametersGetter {
         private readonly ICollection<IOpeningTaskIncoming> _incomingTasks;
+        private readonly int _rounding;
 
 
         /// <summary>
         /// Конструктор класса, предоставляющего параметры отверстия КР, размещаемого в перекрытии по нескольким заданиям
         /// </summary>
         /// <param name="incomingTasks">Входящие задания</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public ManyOpeningArTasksInFloorParameterGetter(ICollection<IOpeningTaskIncoming> incomingTasks) {
+        public ManyOpeningArTasksInFloorParameterGetter(ICollection<IOpeningTaskIncoming> incomingTasks, int rounding) {
             _incomingTasks = incomingTasks ?? throw new ArgumentNullException(nameof(incomingTasks));
+            _rounding = rounding;
         }
 
 
@@ -29,10 +32,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
             // габариты отверстия
             yield return new DoubleParameterGetter(
                 RealOpeningKrPlacer.RealOpeningKrInFloorHeight,
-                new RectangleOpeningInFloorHeightValueGetter(_incomingTasks)).GetParamValue();
+                new RectangleOpeningInFloorHeightValueGetter(_incomingTasks, _rounding)).GetParamValue();
             yield return new DoubleParameterGetter(
                 RealOpeningKrPlacer.RealOpeningKrInFloorWidth,
-                new RectangleOpeningInFloorWidthValueGetter(_incomingTasks)).GetParamValue();
+                new RectangleOpeningInFloorWidthValueGetter(_incomingTasks, _rounding)).GetParamValue();
 
             // текстовые данные отверстия
             yield return new StringParameterGetter(

--- a/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/ManyOpeningArTasksInWallParameterGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/ManyOpeningArTasksInWallParameterGetter.cs
@@ -17,6 +17,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
         private readonly ICollection<IOpeningTaskIncoming> _incomingTasks;
         private readonly IPointFinder _pointFinder;
         private readonly Wall _wall;
+        private readonly int _rounding;
 
 
         /// <summary>
@@ -24,14 +25,16 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
         /// </summary>
         /// <param name="incomingTasks">Входящие задания</param>
         /// <param name="pointFinder">Провайдер точки вставки отверстия КР</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
         /// <exception cref="ArgumentException">Исключение, если количество элементов в коллекции меньше 1</exception>
-        public ManyOpeningArTasksInWallParameterGetter(ICollection<IOpeningTaskIncoming> incomingTasks, IPointFinder pointFinder, Wall wall) {
+        public ManyOpeningArTasksInWallParameterGetter(ICollection<IOpeningTaskIncoming> incomingTasks, IPointFinder pointFinder, Wall wall, int rounding) {
             _incomingTasks = incomingTasks ?? throw new ArgumentNullException(nameof(incomingTasks));
             if(_incomingTasks.Count < 1) { throw new ArgumentException(nameof(incomingTasks)); }
 
             _pointFinder = pointFinder ?? throw new ArgumentNullException(nameof(pointFinder));
             _wall = wall ?? throw new ArgumentNullException(nameof(wall));
+            _rounding = rounding;
         }
 
 
@@ -39,10 +42,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
             // габариты отверстия
             yield return new DoubleParameterGetter(
                 RealOpeningKrPlacer.RealOpeningKrInWallHeight,
-                new RectangleOpeningInWallHeightValueGetter(_incomingTasks, _pointFinder)).GetParamValue();
+                new RectangleOpeningInWallHeightValueGetter(_incomingTasks, _pointFinder, _rounding)).GetParamValue();
             yield return new DoubleParameterGetter(
                 RealOpeningKrPlacer.RealOpeningKrInWallWidth,
-                new RectangleOpeningInWallWidthValueGetter(_incomingTasks, _wall)).GetParamValue();
+                new RectangleOpeningInWallWidthValueGetter(_incomingTasks, _wall, _rounding)).GetParamValue();
 
             // текстовые данные отверстия
             yield return new StringParameterGetter(

--- a/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/SingleOpeningArTaskInFloorParameterGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/SingleOpeningArTaskInFloorParameterGetter.cs
@@ -13,15 +13,18 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
     /// </summary>
     internal class SingleOpeningArTaskInFloorParameterGetter : IParametersGetter {
         private readonly IOpeningTaskIncoming _incomingTask;
+        private readonly int _rounding;
 
 
         /// <summary>
         /// Конструктор класса, предоставляющего значения параметров для КР отверстия, размещаемого по одному заданию на отверстие
         /// </summary>
         /// <param name="incomingTask">Входящее задание на отверстие</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public SingleOpeningArTaskInFloorParameterGetter(IOpeningTaskIncoming incomingTask) {
+        public SingleOpeningArTaskInFloorParameterGetter(IOpeningTaskIncoming incomingTask, int rounding) {
             _incomingTask = incomingTask ?? throw new ArgumentNullException(nameof(incomingTask));
+            _rounding = rounding;
         }
 
 
@@ -29,10 +32,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
             // габариты отверстия
             yield return new DoubleParameterGetter(
                 RealOpeningKrPlacer.RealOpeningKrInFloorHeight,
-                new RectangleOpeningInFloorHeightValueGetter(_incomingTask)).GetParamValue();
+                new RectangleOpeningInFloorHeightValueGetter(_incomingTask, _rounding)).GetParamValue();
             yield return new DoubleParameterGetter(
                 RealOpeningKrPlacer.RealOpeningKrInFloorWidth,
-                new RectangleOpeningInFloorWidthValueGetter(_incomingTask)).GetParamValue();
+                new RectangleOpeningInFloorWidthValueGetter(_incomingTask, _rounding)).GetParamValue();
 
             // текстовые данные отверстия
             yield return new StringParameterGetter(

--- a/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/SingleRectangleOpeningArTaskInWallParameterGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/SingleRectangleOpeningArTaskInWallParameterGetter.cs
@@ -14,6 +14,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
     internal class SingleRectangleOpeningArTaskInWallParameterGetter : IParametersGetter {
         private readonly IOpeningTaskIncoming _incomingTask;
         private readonly IPointFinder _pointFinder;
+        private readonly int _rounding;
 
 
         /// <summary>
@@ -21,10 +22,12 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
         /// </summary>
         /// <param name="incomingTask">Входящее задание на отверстие</param>
         /// <param name="pointFinder">Провайдер точки вставки отверстия КР</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public SingleRectangleOpeningArTaskInWallParameterGetter(IOpeningTaskIncoming incomingTask, IPointFinder pointFinder) {
+        public SingleRectangleOpeningArTaskInWallParameterGetter(IOpeningTaskIncoming incomingTask, IPointFinder pointFinder, int rounding) {
             _incomingTask = incomingTask ?? throw new ArgumentNullException(nameof(incomingTask));
             _pointFinder = pointFinder ?? throw new ArgumentNullException(nameof(pointFinder));
+            _rounding = rounding;
         }
 
 
@@ -32,10 +35,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
             // габариты отверстия
             yield return new DoubleParameterGetter(
                 RealOpeningKrPlacer.RealOpeningKrInWallHeight,
-                new RectangleOpeningInWallHeightValueGetter(_incomingTask, _pointFinder)).GetParamValue();
+                new RectangleOpeningInWallHeightValueGetter(_incomingTask, _pointFinder, _rounding)).GetParamValue();
             yield return new DoubleParameterGetter(
                 RealOpeningKrPlacer.RealOpeningKrInWallWidth,
-                new RectangleOpeningInWallWidthValueGetter(_incomingTask)).GetParamValue();
+                new RectangleOpeningInWallWidthValueGetter(_incomingTask, _rounding)).GetParamValue();
 
             // текстовые данные отверстия
             yield return new StringParameterGetter(

--- a/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/SingleRoundOpeningArTaskInWallParameterGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/ParameterGetters/SingleRoundOpeningArTaskInWallParameterGetter.cs
@@ -14,6 +14,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
     internal class SingleRoundOpeningArTaskInWallParameterGetter : IParametersGetter {
         private readonly IOpeningTaskIncoming _incomingTask;
         private readonly IPointFinder _pointFinder;
+        private readonly int _rounding;
 
 
         /// <summary>
@@ -21,10 +22,12 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
         /// </summary>
         /// <param name="incomingTask">Входящее задание на отверстие</param>
         /// <param name="pointFinder">Провайдер точки вставки отверстия КР</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public SingleRoundOpeningArTaskInWallParameterGetter(IOpeningTaskIncoming incomingTask, IPointFinder pointFinder) {
+        public SingleRoundOpeningArTaskInWallParameterGetter(IOpeningTaskIncoming incomingTask, IPointFinder pointFinder, int rounding) {
             _incomingTask = incomingTask ?? throw new ArgumentNullException(nameof(incomingTask));
             _pointFinder = pointFinder ?? throw new ArgumentNullException(nameof(pointFinder));
+            _rounding = rounding;
         }
 
 
@@ -32,7 +35,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.ParameterGetters {
             // габариты отверстия
             yield return new DoubleParameterGetter(
                 RealOpeningKrPlacer.RealOpeningKrDiameter,
-                new RoundOpeningInWallDiameterValueGetter(_incomingTask, _pointFinder)).GetParamValue();
+                new RoundOpeningInWallDiameterValueGetter(_incomingTask, _pointFinder, _rounding)).GetParamValue();
 
             // текстовые данные отверстия
             yield return new StringParameterGetter(

--- a/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/PointFinders/SingleOpeningArTaskPointFinder.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/PointFinders/SingleOpeningArTaskPointFinder.cs
@@ -9,15 +9,18 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.PointFinders {
     /// </summary>
     internal class SingleOpeningArTaskPointFinder : RoundValueGetter, IPointFinder {
         private readonly IOpeningTaskIncoming _openingArTaskIncoming;
+        private readonly int _rounding;
 
 
         /// <summary>
         /// Конструктор класса, предоставляющего точку вставки для чистового отверстия КР
         /// </summary>
         /// <param name="incomingTask">Входящее задание на отверстие</param>
+        /// <param name="rounding">Округление отметки отверстия в мм</param>
         /// <exception cref="System.ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public SingleOpeningArTaskPointFinder(IOpeningTaskIncoming incomingTask) {
+        public SingleOpeningArTaskPointFinder(IOpeningTaskIncoming incomingTask, int rounding) {
             _openingArTaskIncoming = incomingTask ?? throw new System.ArgumentNullException(nameof(incomingTask));
+            _rounding = rounding;
         }
 
 
@@ -26,7 +29,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.PointFinders {
                 case OpeningType.WallRound:
                 case OpeningType.WallRectangle:
                     var point = _openingArTaskIncoming.Location;
-                    return new XYZ(point.X, point.Y, RoundToFloorFeetToMillimeters(point.Z));
+                    return new XYZ(point.X, point.Y, RoundToFloorFeetToMillimeters(point.Z, _rounding));
                 default:
                     return _openingArTaskIncoming.Location;
             }

--- a/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/Providers/ManyOpeningArTasksParameterGettersProvider.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/Providers/ManyOpeningArTasksParameterGettersProvider.cs
@@ -14,6 +14,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
         private readonly Element _host;
         private readonly ICollection<IOpeningTaskIncoming> _incomingTasks;
         private readonly IPointFinder _pointFinder;
+        private readonly int _rounding;
 
 
         /// <summary>
@@ -22,9 +23,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
         /// <param name="host">Основа для отверстия КР</param>
         /// <param name="incomingTasks">Входящие задания</param>
         /// <param name="pointFinder">Провайдер точки вставки отверстия КР</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
         /// <exception cref="ArgumentException"><Исключение, если тип хоста не поддерживается, или количество элементов в коллекции меньше 1/exception>
-        public ManyOpeningArTasksParameterGettersProvider(Element host, ICollection<IOpeningTaskIncoming> incomingTasks, IPointFinder pointFinder) {
+        public ManyOpeningArTasksParameterGettersProvider(Element host, ICollection<IOpeningTaskIncoming> incomingTasks, IPointFinder pointFinder, int rounding) {
             if(host is null) { throw new ArgumentNullException(nameof(host)); }
             if(!((host is Wall) || (host is Floor))) { throw new ArgumentException(nameof(host)); }
             if(incomingTasks is null) { throw new ArgumentNullException(nameof(incomingTasks)); }
@@ -34,14 +36,15 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
             _host = host;
             _incomingTasks = incomingTasks;
             _pointFinder = pointFinder;
+            _rounding = rounding;
         }
 
 
         public IParametersGetter GetParametersGetter() {
             if(_host is Floor) {
-                return new ManyOpeningArTasksInFloorParameterGetter(_incomingTasks);
+                return new ManyOpeningArTasksInFloorParameterGetter(_incomingTasks, _rounding);
             } else if(_host is Wall wall) {
-                return new ManyOpeningArTasksInWallParameterGetter(_incomingTasks, _pointFinder, wall);
+                return new ManyOpeningArTasksInWallParameterGetter(_incomingTasks, _pointFinder, wall, _rounding);
             } else {
                 throw new ArgumentException(nameof(_host));
             }

--- a/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/Providers/ManyOpeningArTasksPointFinderProvider.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/Providers/ManyOpeningArTasksPointFinderProvider.cs
@@ -16,6 +16,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
     internal class ManyOpeningArTasksPointFinderProvider {
         private readonly Element _host;
         private readonly ICollection<IOpeningTaskIncoming> _incomingTasks;
+        private readonly int _rounding;
 
 
         /// <summary>
@@ -23,9 +24,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
         /// </summary>
         /// <param name="host">Основа для размещаемого отверстия КР</param>
         /// <param name="incomingTasks">Входящие задания на отверстия</param>
+        /// <param name="rounding">Округление отметки отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
         /// <exception cref="ArgumentException">Исключение, если тип хоста не поддерживается или количество элементов в коллизии меньше 1</exception>
-        public ManyOpeningArTasksPointFinderProvider(Element host, ICollection<IOpeningTaskIncoming> incomingTasks) {
+        public ManyOpeningArTasksPointFinderProvider(Element host, ICollection<IOpeningTaskIncoming> incomingTasks, int rounding) {
             if(host is null) { throw new ArgumentNullException(nameof(host)); }
             if(!((host is Wall) || (host is Floor))) { throw new ArgumentException(nameof(host)); }
             if(incomingTasks is null) { throw new ArgumentNullException(nameof(incomingTasks)); }
@@ -33,6 +35,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
 
             _host = host;
             _incomingTasks = incomingTasks;
+            _rounding = rounding;
         }
 
 
@@ -40,7 +43,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
             var box = GetUnitedBBox(_incomingTasks);
             if(_host is Wall) {
                 // упрощенное получение точки вставки по боксу
-                return new BoundingBoxBottomPointFinder(box);
+                return new BoundingBoxBottomPointFinder(box, _rounding);
             } else if(_host is Floor) {
                 return new BoundingBoxCenterPointFinder(box);
             } else {

--- a/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/Providers/SingleOpeningArTaskParameterGettersProvider.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/Providers/SingleOpeningArTaskParameterGettersProvider.cs
@@ -10,6 +10,7 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
     internal class SingleOpeningArTaskParameterGettersProvider {
         private readonly IOpeningTaskIncoming _incomingTask;
         private readonly IPointFinder _pointFinder;
+        private readonly int _rounding;
 
 
         /// <summary>
@@ -17,24 +18,26 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement.Providers {
         /// </summary>
         /// <param name="incomingTask">Входящее задание на отверстие</param>
         /// <param name="pointFinder">Провайдер точки вставки отверстия КР</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public SingleOpeningArTaskParameterGettersProvider(IOpeningTaskIncoming incomingTask, IPointFinder pointFinder) {
+        public SingleOpeningArTaskParameterGettersProvider(IOpeningTaskIncoming incomingTask, IPointFinder pointFinder, int rounding) {
             _incomingTask = incomingTask ?? throw new ArgumentNullException(nameof(incomingTask));
             _pointFinder = pointFinder ?? throw new ArgumentNullException(nameof(pointFinder));
+            _rounding = rounding;
         }
 
 
         public IParametersGetter GetParametersGetter() {
             switch(_incomingTask.OpeningType) {
                 case OpeningType.WallRound:
-                    return new SingleRoundOpeningArTaskInWallParameterGetter(_incomingTask, _pointFinder);
+                    return new SingleRoundOpeningArTaskInWallParameterGetter(_incomingTask, _pointFinder, _rounding);
 
                 case OpeningType.WallRectangle:
-                    return new SingleRectangleOpeningArTaskInWallParameterGetter(_incomingTask, _pointFinder);
+                    return new SingleRectangleOpeningArTaskInWallParameterGetter(_incomingTask, _pointFinder, _rounding);
 
                 case OpeningType.FloorRound:
                 case OpeningType.FloorRectangle:
-                    return new SingleOpeningArTaskInFloorParameterGetter(_incomingTask);
+                    return new SingleOpeningArTaskInFloorParameterGetter(_incomingTask, _rounding);
 
                 default:
                     throw new ArgumentException(nameof(_incomingTask.OpeningType));

--- a/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/RealOpeningKrPlacer.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningKrPlacement/RealOpeningKrPlacer.cs
@@ -247,12 +247,12 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         private void PlaceByOneTask(Element host, IOpeningTaskIncoming openingTask) {
             try {
                 var symbol = GetFamilySymbol(host, openingTask.OpeningType);
-                var pointFinder = GetPointFinder(openingTask);
+                var pointFinder = GetPointFinder(openingTask, _config.ElevationRounding);
                 var point = pointFinder.GetPoint();
 
                 var instance = _revitRepository.CreateInstance(point, symbol, host) ?? throw new OpeningNotPlacedException("Не удалось создать экземпляр семейства");
 
-                var parameterGetter = GetParameterGetter(openingTask, pointFinder);
+                var parameterGetter = GetParameterGetter(openingTask, pointFinder, _config.Rounding);
                 SetParamValues(instance, parameterGetter);
 
                 var angleFinder = GetAngleFinder(openingTask);
@@ -283,12 +283,12 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         private void PlaceUnitedByManyTasks(Element host, ICollection<IOpeningTaskIncoming> incomingTasks) {
             try {
                 var symbol = GetFamilySymbol(host);
-                var pointFinder = GetPointFinder(host, incomingTasks);
+                var pointFinder = GetPointFinder(host, incomingTasks, _config.ElevationRounding);
                 var point = pointFinder.GetPoint();
 
                 var instance = _revitRepository.CreateInstance(point, symbol, host);
 
-                var parameterGetter = GetParameterGetter(host, incomingTasks, pointFinder);
+                var parameterGetter = GetParameterGetter(host, incomingTasks, pointFinder, _config.Rounding);
                 SetParamValues(instance, parameterGetter);
 
                 _revitRepository.SetSelection(instance.Id);
@@ -331,8 +331,9 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         /// <summary>
         /// Возвращает интерфейс, предоставляющий значения параметров для размещаемого отверстия КР
         /// </summary>
-        private IParametersGetter GetParameterGetter(IOpeningTaskIncoming incomingTask, IPointFinder pointFinder) {
-            var provider = new SingleOpeningArTaskParameterGettersProvider(incomingTask, pointFinder);
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
+        private IParametersGetter GetParameterGetter(IOpeningTaskIncoming incomingTask, IPointFinder pointFinder, int rounding) {
+            var provider = new SingleOpeningArTaskParameterGettersProvider(incomingTask, pointFinder, rounding);
             return provider.GetParametersGetter();
         }
 
@@ -341,8 +342,9 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         /// </summary>
         /// <param name="host">Основа для отверстия КР</param>
         /// <param name="incomingTasks">Входящие задания на отверстия</param>
-        private IParametersGetter GetParameterGetter(Element host, ICollection<IOpeningTaskIncoming> incomingTasks, IPointFinder pointFinder) {
-            var provider = new ManyOpeningArTasksParameterGettersProvider(host, incomingTasks, pointFinder);
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
+        private IParametersGetter GetParameterGetter(Element host, ICollection<IOpeningTaskIncoming> incomingTasks, IPointFinder pointFinder, int rounding) {
+            var provider = new ManyOpeningArTasksParameterGettersProvider(host, incomingTasks, pointFinder, rounding);
             return provider.GetParametersGetter();
         }
 
@@ -350,8 +352,9 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         /// Возвращает интерфейс, предоставляющий точку вставки отверстия КР
         /// </summary>
         /// <param name="openingTask">Входящее задание на отверстие</param>
-        private IPointFinder GetPointFinder(IOpeningTaskIncoming openingTask) {
-            return new SingleOpeningArTaskPointFinder(openingTask);
+        /// <param name="rounding">Округление отметки отверстия в мм</param>
+        private IPointFinder GetPointFinder(IOpeningTaskIncoming openingTask, int rounding) {
+            return new SingleOpeningArTaskPointFinder(openingTask, rounding);
         }
 
         /// <summary>
@@ -359,8 +362,9 @@ namespace RevitOpeningPlacement.Models.RealOpeningKrPlacement {
         /// </summary>
         /// <param name="host">Основа для отверстия КР</param>
         /// <param name="incomingTasks">Входящие задания на отверстия</param>
-        private IPointFinder GetPointFinder(Element host, ICollection<IOpeningTaskIncoming> incomingTasks) {
-            var provider = new ManyOpeningArTasksPointFinderProvider(host, incomingTasks);
+        /// <param name="rounding">Округление отметки отверстия в мм</param>
+        private IPointFinder GetPointFinder(Element host, ICollection<IOpeningTaskIncoming> incomingTasks, int rounding) {
+            var provider = new ManyOpeningArTasksPointFinderProvider(host, incomingTasks, rounding);
             return provider.GetPointFinder();
         }
 

--- a/src/RevitOpeningPlacement/Models/RealOpeningsGeometryValueGetters/RealOpeningSizeValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningsGeometryValueGetters/RealOpeningSizeValueGetter.cs
@@ -17,20 +17,24 @@ namespace RevitOpeningPlacement.Models.RealOpeningsGeometryValueGetters {
         /// <summary>
         /// Значение округления высоты в мм
         /// </summary>
-        private protected const int _heightRound = 10;
+        private protected readonly int _heightRound;
 
         /// <summary>
         /// Значение округления ширины в мм
         /// </summary>
-        private protected const int _widthRound = 10;
+        private protected readonly int _widthRound;
 
         /// <summary>
         /// Значение округления диаметра в мм
         /// </summary>
-        private protected const int _diameterRound = 10;
+        private protected readonly int _diameterRound;
 
 
-        protected RealOpeningSizeValueGetter() { }
+        protected RealOpeningSizeValueGetter(int heightRounding, int widthRounding, int diameterRounding) {
+            _heightRound = heightRounding;
+            _widthRound = widthRounding;
+            _diameterRound = diameterRounding;
+        }
 
 
         private protected BoundingBoxXYZ GetUnitedBox(ICollection<IOpeningTaskIncoming> incomingTasks) {

--- a/src/RevitOpeningPlacement/Models/RealOpeningsGeometryValueGetters/RectangleOpeningInFloorHeightValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningsGeometryValueGetters/RectangleOpeningInFloorHeightValueGetter.cs
@@ -19,8 +19,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningsGeometryValueGetters {
         /// Конструктор класса, предоставляющего значение высоты для чистового прямоугольного отверстия АР/КР в перекрытии в единицах ревита
         /// </summary>
         /// <param name="openingTaskIncoming">Входящее задание на отверстие</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public RectangleOpeningInFloorHeightValueGetter(IOpeningTaskIncoming openingTaskIncoming) {
+        public RectangleOpeningInFloorHeightValueGetter(IOpeningTaskIncoming openingTaskIncoming, int rounding)
+            : base(rounding, rounding, rounding) {
             if(openingTaskIncoming is null) { throw new ArgumentNullException(nameof(openingTaskIncoming)); }
 
             _openingTasksIncoming = new IOpeningTaskIncoming[] { openingTaskIncoming };
@@ -32,9 +34,11 @@ namespace RevitOpeningPlacement.Models.RealOpeningsGeometryValueGetters {
         /// Конструктор класса, предоставляющего значение высоты для чистового прямоугольного отверстия АР/КР в перекрытии в единицах ревита
         /// </summary>
         /// <param name="openingTasksIncoming">Входящие задания на отверстия</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
         /// <exception cref="ArgumentOutOfRangeException">Исключение, если количество элементов в коллекции меньше 1</exception>
-        public RectangleOpeningInFloorHeightValueGetter(ICollection<IOpeningTaskIncoming> openingTasksIncoming) {
+        public RectangleOpeningInFloorHeightValueGetter(ICollection<IOpeningTaskIncoming> openingTasksIncoming, int rounding)
+            : base(rounding, rounding, rounding) {
             if(openingTasksIncoming == null) { throw new ArgumentNullException(nameof(openingTasksIncoming)); }
             if(openingTasksIncoming.Count < 1) { throw new ArgumentOutOfRangeException(nameof(openingTasksIncoming.Count)); }
 

--- a/src/RevitOpeningPlacement/Models/RealOpeningsGeometryValueGetters/RectangleOpeningInFloorWidthValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningsGeometryValueGetters/RectangleOpeningInFloorWidthValueGetter.cs
@@ -19,8 +19,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningsGeometryValueGetters {
         /// Конструктор класса, предоставляющего значение ширины для чистового прямоугольного отверстия АР/КР в перекрытии в единицах ревита
         /// </summary>
         /// <param name="openingTaskIncoming">Входящее задание на отверстие</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public RectangleOpeningInFloorWidthValueGetter(IOpeningTaskIncoming openingTaskIncoming) {
+        public RectangleOpeningInFloorWidthValueGetter(IOpeningTaskIncoming openingTaskIncoming, int rounding)
+            : base(rounding, rounding, rounding) {
             if(openingTaskIncoming is null) { throw new ArgumentNullException(nameof(openingTaskIncoming)); }
 
             _openingTasksIncoming = new IOpeningTaskIncoming[] { openingTaskIncoming };
@@ -32,9 +34,11 @@ namespace RevitOpeningPlacement.Models.RealOpeningsGeometryValueGetters {
         /// Конструктор класса, предоставляющего значение ширины для чистового прямоугольного отверстия АР/КР в перекрытии в единицах ревита
         /// </summary>
         /// <param name="openingTasksIncoming">Входящие задания на отверстия</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
         /// <exception cref="ArgumentOutOfRangeException">Исключение, если количество элементов в коллекции меньше 1</exception>
-        public RectangleOpeningInFloorWidthValueGetter(ICollection<IOpeningTaskIncoming> openingTasksIncoming) {
+        public RectangleOpeningInFloorWidthValueGetter(ICollection<IOpeningTaskIncoming> openingTasksIncoming, int rounding)
+            : base(rounding, rounding, rounding) {
             if(openingTasksIncoming == null) { throw new ArgumentNullException(nameof(openingTasksIncoming)); }
             if(openingTasksIncoming.Count < 1) { throw new ArgumentOutOfRangeException(nameof(openingTasksIncoming.Count)); }
 

--- a/src/RevitOpeningPlacement/Models/RealOpeningsGeometryValueGetters/RectangleOpeningInWallHeightValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningsGeometryValueGetters/RectangleOpeningInWallHeightValueGetter.cs
@@ -19,8 +19,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningsGeometryValueGetters {
         /// </summary>
         /// <param name="incomingTask">Входящее задание на отверстие</param>
         /// <param name="pointFinder">Провайдер точки вставки чистового отверстия АР/КР</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public RectangleOpeningInWallHeightValueGetter(IOpeningTaskIncoming incomingTask, IPointFinder pointFinder) {
+        public RectangleOpeningInWallHeightValueGetter(IOpeningTaskIncoming incomingTask, IPointFinder pointFinder, int rounding)
+            : base(rounding, rounding, rounding) {
             if(incomingTask == null) { throw new ArgumentNullException(nameof(incomingTask)); }
             _pointFinder = pointFinder ?? throw new ArgumentNullException(nameof(pointFinder));
             _incomingTasks = new IOpeningTaskIncoming[] { incomingTask };
@@ -31,11 +33,17 @@ namespace RevitOpeningPlacement.Models.RealOpeningsGeometryValueGetters {
         /// </summary>
         /// <param name="incomingTasks">Входящие задания на отверстия</param>
         /// <param name="pointFinder">Провайдер точки вставки чистового отверстия АР/КР</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
         /// <exception cref="ArgumentOutOfRangeException">Исключение, если количество элементов в коллекции меньше 1</exception>
-        public RectangleOpeningInWallHeightValueGetter(ICollection<IOpeningTaskIncoming> incomingTasks, IPointFinder pointFinder) {
-            if(incomingTasks is null) { throw new ArgumentNullException(nameof(incomingTasks)); }
-            if(incomingTasks.Count < 1) { throw new ArgumentOutOfRangeException(nameof(incomingTasks)); }
+        public RectangleOpeningInWallHeightValueGetter(ICollection<IOpeningTaskIncoming> incomingTasks, IPointFinder pointFinder, int rounding)
+            : base(rounding, rounding, rounding) {
+            if(incomingTasks is null) {
+                throw new ArgumentNullException(nameof(incomingTasks));
+            }
+            if(incomingTasks.Count < 1) {
+                throw new ArgumentOutOfRangeException(nameof(incomingTasks));
+            }
             _pointFinder = pointFinder ?? throw new ArgumentNullException(nameof(pointFinder));
             _incomingTasks = incomingTasks;
         }

--- a/src/RevitOpeningPlacement/Models/RealOpeningsGeometryValueGetters/RectangleOpeningInWallWidthValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningsGeometryValueGetters/RectangleOpeningInWallWidthValueGetter.cs
@@ -22,8 +22,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningsGeometryValueGetters {
         /// Конструктор класса, предоставляющего значение ширины чистового прямоугольного отверстия АР/КР в стене в единицах Revit
         /// </summary>
         /// <param name="incomingTask">Входящее задание на отверстие</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public RectangleOpeningInWallWidthValueGetter(IOpeningTaskIncoming incomingTask) {
+        public RectangleOpeningInWallWidthValueGetter(IOpeningTaskIncoming incomingTask, int rounding)
+            : base(rounding, rounding, rounding) {
             if(incomingTask == null) { throw new ArgumentNullException(nameof(incomingTask)); }
             _incomingTasks = new IOpeningTaskIncoming[] { incomingTask };
         }
@@ -33,9 +35,11 @@ namespace RevitOpeningPlacement.Models.RealOpeningsGeometryValueGetters {
         /// </summary>
         /// <param name="incomingTasks">Входящие задания на отверстия</param>
         /// <param name="wall">Стена-основа для чистового отверстия АР/КР</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
         /// <exception cref="ArgumentOutOfRangeException">Исключение, если количество элементов в коллекции меньше 1</exception>
-        public RectangleOpeningInWallWidthValueGetter(ICollection<IOpeningTaskIncoming> incomingTasks, Wall wall) {
+        public RectangleOpeningInWallWidthValueGetter(ICollection<IOpeningTaskIncoming> incomingTasks, Wall wall, int rounding)
+            : base(rounding, rounding, rounding) {
             if(incomingTasks is null) { throw new ArgumentNullException(nameof(incomingTasks)); }
             if(incomingTasks.Count < 1) { throw new ArgumentOutOfRangeException(nameof(incomingTasks)); }
             _wall = wall ?? throw new ArgumentNullException(nameof(wall));

--- a/src/RevitOpeningPlacement/Models/RealOpeningsGeometryValueGetters/RoundOpeningInFloorDiameterValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningsGeometryValueGetters/RoundOpeningInFloorDiameterValueGetter.cs
@@ -14,8 +14,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningsGeometryValueGetters {
         /// Конструктор класса, предоставляющего значение диаметра чистового отверстия АР/КР в перекрытии в единицах Revit
         /// </summary>
         /// <param name="openingTaskIncoming">Входящее задание на отверстие</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="System.ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public RoundOpeningInFloorDiameterValueGetter(IOpeningTaskIncoming openingTaskIncoming) {
+        public RoundOpeningInFloorDiameterValueGetter(IOpeningTaskIncoming openingTaskIncoming, int rounding)
+            : base(rounding, rounding, rounding) {
             _openingTaskIncoming = openingTaskIncoming ?? throw new System.ArgumentNullException(nameof(openingTaskIncoming));
         }
 

--- a/src/RevitOpeningPlacement/Models/RealOpeningsGeometryValueGetters/RoundOpeningInWallDiameterValueGetter.cs
+++ b/src/RevitOpeningPlacement/Models/RealOpeningsGeometryValueGetters/RoundOpeningInWallDiameterValueGetter.cs
@@ -18,8 +18,10 @@ namespace RevitOpeningPlacement.Models.RealOpeningsGeometryValueGetters {
         /// </summary>
         /// <param name="openingTaskIncoming">Входящее задание на отверстие</param>
         /// <param name="pointFinder">Провайдер точки вставки чистового отверстия АР/КР</param>
+        /// <param name="rounding">Округление размеров отверстия в мм</param>
         /// <exception cref="ArgumentNullException">Исключение, если обязательный параметр null</exception>
-        public RoundOpeningInWallDiameterValueGetter(IOpeningTaskIncoming openingTaskIncoming, IPointFinder pointFinder) {
+        public RoundOpeningInWallDiameterValueGetter(IOpeningTaskIncoming openingTaskIncoming, IPointFinder pointFinder, int rounding)
+            : base(rounding, rounding, rounding) {
             _openingTaskIncoming = openingTaskIncoming ?? throw new ArgumentNullException(nameof(openingTaskIncoming));
             _pointFinder = pointFinder ?? throw new ArgumentNullException(nameof(pointFinder));
         }

--- a/src/RevitOpeningPlacement/Models/RevitRepository.cs
+++ b/src/RevitOpeningPlacement/Models/RevitRepository.cs
@@ -668,7 +668,7 @@ namespace RevitOpeningPlacement.Models {
                     return MepConduitCategories.Contains(elCategory);
                 default:
                     throw new NotImplementedException(nameof(mepCategory));
-            };
+            }
         }
 
         /// <summary>

--- a/src/RevitOpeningPlacement/Models/RevitRepository.cs
+++ b/src/RevitOpeningPlacement/Models/RevitRepository.cs
@@ -542,9 +542,10 @@ namespace RevitOpeningPlacement.Models {
         /// Объединяет задания на отверстия из активного документа и удаляет старые
         /// </summary>
         /// <param name="openingTasks">Коллекция объединяемых заданий на отверстия</param>
+        /// <param name="config">Настройки расстановки заданий на отверстия</param>
         /// <exception cref="OperationCanceledException">Исключение, если пользователь отменил операцию</exception>
-        public FamilyInstance UniteOpenings(ICollection<OpeningMepTaskOutcoming> openingTasks) {
-            var placer = GetOpeningPlacer(openingTasks);
+        public FamilyInstance UniteOpenings(ICollection<OpeningMepTaskOutcoming> openingTasks, OpeningConfig config) {
+            var placer = GetOpeningPlacer(openingTasks, config);
             FamilyInstance createdOpening = null;
             try {
                 using(var t = GetTransaction("Объединение отверстий")) {
@@ -1251,11 +1252,12 @@ namespace RevitOpeningPlacement.Models {
         /// Возвращает класс, размещающий объединенное задание на отверстие
         /// </summary>
         /// <param name="openingTasks">Задания на отверстия из активного документа, которые надо объединить</param>
+        /// <param name="config">Настройки расстановки заданий на отверстия</param>
         /// <exception cref="System.OperationCanceledException">Исключение, операцию отменил пользователь</exception>
-        private OpeningPlacer GetOpeningPlacer(ICollection<OpeningMepTaskOutcoming> openingTasks) {
+        private OpeningPlacer GetOpeningPlacer(ICollection<OpeningMepTaskOutcoming> openingTasks, OpeningConfig config) {
             try {
                 OpeningsGroup group = new OpeningsGroup(openingTasks);
-                return group.GetOpeningPlacer(this);
+                return group.GetOpeningPlacer(this, config);
 
             } catch(ArgumentNullException nullEx) {
                 var dialog = GetMessageBoxService();

--- a/src/RevitOpeningPlacement/OpeningModels/Enums/OpeningTaskIncomingStatus.cs
+++ b/src/RevitOpeningPlacement/OpeningModels/Enums/OpeningTaskIncomingStatus.cs
@@ -29,6 +29,11 @@ namespace RevitOpeningPlacement.OpeningModels.Enums {
         /// Произошла ошибка обработки геометрии в процессе определения статуса
         /// </summary>
         [Description("Ошибка обработки геометрии")]
-        Invalid
+        Invalid,
+        /// <summary>
+        /// Задание на отверстие находится в разных конструкциях
+        /// </summary>
+        [Description("В разных конструкциях")]
+        DifferentConstructions
     }
 }

--- a/src/RevitOpeningPlacement/OpeningModels/Enums/OpeningTaskOutcomingStatus.cs
+++ b/src/RevitOpeningPlacement/OpeningModels/Enums/OpeningTaskOutcomingStatus.cs
@@ -46,6 +46,11 @@ namespace RevitOpeningPlacement.OpeningModels.Enums {
         /// Задание на отверстие - объединенное
         /// </summary>
         [Description("Объединенное")]
-        United
+        United,
+        /// <summary>
+        /// Задание на отверстие находится в разных конструкциях
+        /// </summary>
+        [Description("В разных конструкциях")]
+        DifferentConstructions
     }
 }

--- a/src/RevitOpeningPlacement/OpeningModels/OpeningArTaskIncoming.cs
+++ b/src/RevitOpeningPlacement/OpeningModels/OpeningArTaskIncoming.cs
@@ -172,7 +172,7 @@ namespace RevitOpeningPlacement.OpeningModels {
                 var intersectingOpenings = GetIntersectingOpeningsIds(realOpenings, thisOpeningSolid, thisOpeningBBox);
 
                 Host = FindHost(thisOpeningSolid, intersectingStructureElements, intersectingOpenings);
-
+                // TODO логика по назначению статуса для заданий в разных конструкциях
                 if((intersectingStructureElements.Count == 0) && (intersectingOpenings.Count == 0)) {
                     Status = OpeningTaskIncomingStatus.NoIntersection;
                 } else if((intersectingStructureElements.Count > 0) && (intersectingOpenings.Count == 0)) {

--- a/src/RevitOpeningPlacement/OpeningModels/OpeningArTaskIncoming.cs
+++ b/src/RevitOpeningPlacement/OpeningModels/OpeningArTaskIncoming.cs
@@ -173,7 +173,11 @@ namespace RevitOpeningPlacement.OpeningModels {
 
                 Host = FindHost(thisOpeningSolid, intersectingStructureElements, intersectingOpenings);
                 if(intersectingStructureElements
-                    .Select(id => _revitRepository.Doc.GetElement(id).Category.GetBuiltInCategory())
+                    .Select(id => _revitRepository.Doc.GetElement(id))
+                    .Union(intersectingOpenings
+                        .Select(id => (_revitRepository.Doc.GetElement(id) as FamilyInstance)?.Host)
+                        .Where(e => e != null))
+                    .Select(el => el.Category.GetBuiltInCategory())
                     .Distinct()
                     .Count() > 1) {
                     Status = OpeningTaskIncomingStatus.DifferentConstructions;

--- a/src/RevitOpeningPlacement/OpeningModels/OpeningArTaskIncoming.cs
+++ b/src/RevitOpeningPlacement/OpeningModels/OpeningArTaskIncoming.cs
@@ -172,7 +172,14 @@ namespace RevitOpeningPlacement.OpeningModels {
                 var intersectingOpenings = GetIntersectingOpeningsIds(realOpenings, thisOpeningSolid, thisOpeningBBox);
 
                 Host = FindHost(thisOpeningSolid, intersectingStructureElements, intersectingOpenings);
-                // TODO логика по назначению статуса для заданий в разных конструкциях
+                if(intersectingStructureElements
+                    .Select(id => _revitRepository.Doc.GetElement(id).Category.GetBuiltInCategory())
+                    .Distinct()
+                    .Count() > 1) {
+                    Status = OpeningTaskIncomingStatus.DifferentConstructions;
+                    return;
+                }
+
                 if((intersectingStructureElements.Count == 0) && (intersectingOpenings.Count == 0)) {
                     Status = OpeningTaskIncomingStatus.NoIntersection;
                 } else if((intersectingStructureElements.Count > 0) && (intersectingOpenings.Count == 0)) {

--- a/src/RevitOpeningPlacement/OpeningModels/OpeningMepTaskIncoming.cs
+++ b/src/RevitOpeningPlacement/OpeningModels/OpeningMepTaskIncoming.cs
@@ -255,7 +255,11 @@ namespace RevitOpeningPlacement.OpeningModels {
                 var hostId = GetOpeningTaskHostId(thisOpeningSolid, intersectingStructureElements, intersectingOpenings);
                 SetOpeningTaskHost(hostId);
                 if(intersectingStructureElements
-                    .Select(id => _revitRepository.Doc.GetElement(id).Category.GetBuiltInCategory())
+                    .Select(id => _revitRepository.Doc.GetElement(id))
+                    .Union(intersectingOpenings
+                        .Select(id => (_revitRepository.Doc.GetElement(id) as FamilyInstance)?.Host)
+                        .Where(e => e != null))
+                    .Select(el => el.Category.GetBuiltInCategory())
                     .Distinct()
                     .Count() > 1) {
                     Status = OpeningTaskIncomingStatus.DifferentConstructions;

--- a/src/RevitOpeningPlacement/OpeningModels/OpeningMepTaskIncoming.cs
+++ b/src/RevitOpeningPlacement/OpeningModels/OpeningMepTaskIncoming.cs
@@ -254,6 +254,7 @@ namespace RevitOpeningPlacement.OpeningModels {
                 var intersectingOpenings = GetIntersectingOpeningsIds(realOpenings, thisOpeningSolid, thisOpeningBBox);
                 var hostId = GetOpeningTaskHostId(thisOpeningSolid, intersectingStructureElements, intersectingOpenings);
                 SetOpeningTaskHost(hostId);
+                // TODO логика по назначению статуса для заданий в разных конструкциях
 
                 if((intersectingStructureElements.Count == 0) && (intersectingOpenings.Count == 0)) {
                     Status = OpeningTaskIncomingStatus.NoIntersection;

--- a/src/RevitOpeningPlacement/OpeningModels/OpeningMepTaskIncoming.cs
+++ b/src/RevitOpeningPlacement/OpeningModels/OpeningMepTaskIncoming.cs
@@ -254,7 +254,13 @@ namespace RevitOpeningPlacement.OpeningModels {
                 var intersectingOpenings = GetIntersectingOpeningsIds(realOpenings, thisOpeningSolid, thisOpeningBBox);
                 var hostId = GetOpeningTaskHostId(thisOpeningSolid, intersectingStructureElements, intersectingOpenings);
                 SetOpeningTaskHost(hostId);
-                // TODO логика по назначению статуса для заданий в разных конструкциях
+                if(intersectingStructureElements
+                    .Select(id => _revitRepository.Doc.GetElement(id).Category.GetBuiltInCategory())
+                    .Distinct()
+                    .Count() > 1) {
+                    Status = OpeningTaskIncomingStatus.DifferentConstructions;
+                    return;
+                }
 
                 if((intersectingStructureElements.Count == 0) && (intersectingOpenings.Count == 0)) {
                     Status = OpeningTaskIncomingStatus.NoIntersection;

--- a/src/RevitOpeningPlacement/Services/MepTaskOutcomingInfoUpdater.cs
+++ b/src/RevitOpeningPlacement/Services/MepTaskOutcomingInfoUpdater.cs
@@ -122,7 +122,11 @@ namespace RevitOpeningPlacement.Services {
                     outcomingTask.Status = OpeningTaskOutcomingStatus.NotActual;
                     return;
                 }
-                // TODO статус для заданий в разных конструкциях
+                if(OpeningTaskInDifferentConstructions(outcomingTask)) {
+                    FindAndSetHost(outcomingTask);
+                    outcomingTask.Status = OpeningTaskOutcomingStatus.DifferentConstructions;
+                    return;
+                }
                 if(OpeningTaskIsIntersecting(outcomingTask)) {
                     FindAndSetHost(outcomingTask);
                     outcomingTask.Status = OpeningTaskOutcomingStatus.Intersects;
@@ -254,6 +258,37 @@ namespace RevitOpeningPlacement.Services {
                 .WherePasses(new BoundingBoxIntersectsFilter(thisOpeningTaskSolid.GetOutline()))
                 .WherePasses(new ElementIntersectsSolidFilter(thisOpeningTaskSolid))
                 .ToElementIds();
+        }
+
+        /// <summary>
+        /// Проверяет, находится ли данное задание на отверстие в разных конструкциях
+        /// </summary>
+        /// <param name="mepTaskOutcoming">Исходящее задание на отверстие из активного файла</param>
+        /// <returns><True - задание на отверстие в разных констркуциях, False - другие случаи/returns>
+        private bool OpeningTaskInDifferentConstructions(OpeningMepTaskOutcoming mepTaskOutcoming) {
+            if(_hostConstructionsCache.Link != null && _hostConstructionsCache.HostCandidates != null) {
+                return _hostConstructionsCache.HostCandidates
+                    .Select(hostId => _hostConstructionsCache.Link.Document
+                        .GetElement(hostId)
+                        .Category
+                        .GetBuiltInCategory())
+                    .Distinct()
+                    .Count() > 1;
+            } else {
+                foreach(var link in _constructureLinks) {
+                    var hostConstructions = GetHostConstructionsForThisOpeningTask(
+                        mepTaskOutcoming,
+                        link,
+                        out _);
+                    if(hostConstructions.Count > 0) {
+                        return hostConstructions
+                            .Select(hostId => link.Document.GetElement(hostId).Category.GetBuiltInCategory())
+                            .Distinct()
+                            .Count() > 1;
+                    }
+                }
+                return false;
+            }
         }
 
         /// <summary>

--- a/src/RevitOpeningPlacement/Services/MepTaskOutcomingInfoUpdater.cs
+++ b/src/RevitOpeningPlacement/Services/MepTaskOutcomingInfoUpdater.cs
@@ -122,6 +122,7 @@ namespace RevitOpeningPlacement.Services {
                     outcomingTask.Status = OpeningTaskOutcomingStatus.NotActual;
                     return;
                 }
+                // TODO статус для заданий в разных конструкциях
                 if(OpeningTaskIsIntersecting(outcomingTask)) {
                     FindAndSetHost(outcomingTask);
                     outcomingTask.Status = OpeningTaskOutcomingStatus.Intersects;

--- a/src/RevitOpeningPlacement/SetOpeningRealsArPlacementConfigCmd.cs
+++ b/src/RevitOpeningPlacement/SetOpeningRealsArPlacementConfigCmd.cs
@@ -1,0 +1,62 @@
+using System.Windows.Interop;
+
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.UI;
+
+using dosymep.Bim4Everyone;
+using dosymep.Bim4Everyone.SimpleServices;
+
+using Ninject;
+
+using RevitClashDetective.Models.GraphicView;
+using RevitClashDetective.Models.Handlers;
+
+using RevitOpeningPlacement.Models;
+using RevitOpeningPlacement.Models.Configs;
+using RevitOpeningPlacement.ViewModels.OpeningConfig;
+
+using RevitOpeningPlacement.Views;
+
+namespace RevitOpeningPlacement {
+    /// <summary>
+    /// Команда для задания настроек расстановки чистовых отверстий в файле АР
+    /// </summary>
+    [Transaction(TransactionMode.Manual)]
+    internal class SetOpeningRealsArPlacementConfigCmd : BasePluginCommand {
+        public SetOpeningRealsArPlacementConfigCmd() {
+            PluginName = "Настройки расстановки отверстий АР";
+        }
+
+
+        public void ExecuteCommand(UIApplication uiApplication) {
+            Execute(uiApplication);
+        }
+
+
+        protected override void Execute(UIApplication uiApplication) {
+            using(IKernel kernel = uiApplication.CreatePlatformServices()) {
+                kernel.Bind<RevitRepository>()
+                    .ToSelf()
+                    .InSingletonScope();
+                kernel.Bind<RevitClashDetective.Models.RevitRepository>()
+                    .ToSelf()
+                    .InSingletonScope();
+                kernel.Bind<RevitEventHandler>()
+                    .ToSelf()
+                    .InSingletonScope();
+                kernel.Bind<ParameterFilterProvider>()
+                    .ToSelf()
+                    .InSingletonScope();
+
+                var revitRepository = kernel.Get<RevitRepository>();
+                var openingConfig = OpeningRealsArConfig.GetOpeningConfig(revitRepository.Doc);
+                var viewModel = new OpeningRealsArConfigViewModel(revitRepository, openingConfig);
+
+                var window = new OpeningRealsArSettingsView() { Title = PluginName, DataContext = viewModel };
+                var helper = new WindowInteropHelper(window) { Owner = uiApplication.MainWindowHandle };
+
+                window.ShowDialog();
+            }
+        }
+    }
+}

--- a/src/RevitOpeningPlacement/SetOpeningRealsKrPlacementConfigCmd.cs
+++ b/src/RevitOpeningPlacement/SetOpeningRealsKrPlacementConfigCmd.cs
@@ -21,8 +21,8 @@ namespace RevitOpeningPlacement {
     /// Команда для задания настроек расстановки чистовых отверстий в файле КР
     /// </summary>
     [Transaction(TransactionMode.Manual)]
-    internal class SetOpeningRealsPlacementConfigCmd : BasePluginCommand {
-        public SetOpeningRealsPlacementConfigCmd() {
+    internal class SetOpeningRealsKrPlacementConfigCmd : BasePluginCommand {
+        public SetOpeningRealsKrPlacementConfigCmd() {
             PluginName = "Настройки расстановки отверстий КР";
         }
 

--- a/src/RevitOpeningPlacement/UniteOpeningTasksCmd.cs
+++ b/src/RevitOpeningPlacement/UniteOpeningTasksCmd.cs
@@ -13,6 +13,7 @@ using RevitClashDetective.Models.GraphicView;
 using RevitClashDetective.Models.Handlers;
 
 using RevitOpeningPlacement.Models;
+using RevitOpeningPlacement.Models.Configs;
 using RevitOpeningPlacement.OpeningModels;
 
 namespace RevitOpeningPlacement {
@@ -48,8 +49,9 @@ namespace RevitOpeningPlacement {
 
                 var revitRepository = kernel.Get<RevitRepository>();
                 ICollection<OpeningMepTaskOutcoming> openingTasks = revitRepository.PickManyOpeningMepTasksOutcoming();
+                var config = OpeningConfig.GetOpeningConfig(revitRepository.Doc);
 
-                var placedOpeningTask = revitRepository.UniteOpenings(openingTasks);
+                var placedOpeningTask = revitRepository.UniteOpenings(openingTasks, config);
                 uiApplication.ActiveUIDocument.Selection.SetElementIds(new ElementId[] { placedOpeningTask.Id });
             }
         }

--- a/src/RevitOpeningPlacement/ViewModels/OpeningConfig/MepCategoryViewModel.cs
+++ b/src/RevitOpeningPlacement/ViewModels/OpeningConfig/MepCategoryViewModel.cs
@@ -22,6 +22,8 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
         private bool _isSelected;
         private ObservableCollection<StructureCategoryViewModel> _structureCategories;
         private SetViewModel _setViewModel;
+        private int _selectedRounding;
+        private int _selectedElevationRounding;
 
         public MepCategoryViewModel(RevitRepository revitRepository, MepCategory mepCategory) {
             Name = mepCategory.Name;
@@ -36,6 +38,7 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
             StructureCategories = new ObservableCollection<StructureCategoryViewModel>(
                 mepCategory.Intersections.Select(c => new StructureCategoryViewModel(revitRepository, c)));
             SelectedRounding = mepCategory.Rounding;
+            SelectedElevationRounding = mepCategory.ElevationRounding;
             var categoriesInfoViewModel = GetCategoriesInfoViewModel(revitRepository, Name);
             SetViewModel = new SetViewModel(revitRepository, categoriesInfoViewModel, mepCategory.Set);
             RenameDisplayParameters();
@@ -51,7 +54,21 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
             set => RaiseAndSetIfChanged(ref _isSelected, value);
         }
 
-        public int SelectedRounding { get; set; }
+        /// <summary>
+        /// Округление габаритов задания на отверстие в мм
+        /// </summary>
+        public int SelectedRounding {
+            get => _selectedRounding;
+            set => RaiseAndSetIfChanged(ref _selectedRounding, value);
+        }
+
+        /// <summary>
+        /// Округление отметки задания на отверстие в мм
+        /// </summary>
+        public int SelectedElevationRounding {
+            get => _selectedElevationRounding;
+            set => RaiseAndSetIfChanged(ref _selectedElevationRounding, value);
+        }
 
         public string Name {
             get => _name;
@@ -75,7 +92,7 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
             set => RaiseAndSetIfChanged(ref _structureCategories, value);
         }
 
-        public List<int> Roundings { get; set; } = new List<int> { 0, 10, 50 };
+        public IReadOnlyCollection<int> Roundings { get; } = new int[] { 1, 5, 10, 25, 50 };
 
         public SetViewModel SetViewModel {
             get => _setViewModel;
@@ -126,6 +143,7 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
                 })
                 .ToList(),
                 Rounding = SelectedRounding,
+                ElevationRounding = SelectedElevationRounding,
                 Set = SetViewModel.GetSet()
             };
         }

--- a/src/RevitOpeningPlacement/ViewModels/OpeningConfig/OpeningRealsArConfigViewModel.cs
+++ b/src/RevitOpeningPlacement/ViewModels/OpeningConfig/OpeningRealsArConfigViewModel.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Input;
+
+using dosymep.WPF.Commands;
+using dosymep.WPF.ViewModels;
+
+using RevitOpeningPlacement.Models;
+using RevitOpeningPlacement.Models.Configs;
+
+namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
+    internal class OpeningRealsArConfigViewModel : BaseViewModel {
+        private readonly RevitRepository _revitRepository;
+
+        public OpeningRealsArConfigViewModel(RevitRepository revitRepository, OpeningRealsArConfig openingRealsArConfig) {
+            _revitRepository = revitRepository ?? throw new ArgumentNullException(nameof(revitRepository));
+            if(openingRealsArConfig is null) {
+                throw new ArgumentNullException(nameof(openingRealsArConfig));
+            }
+
+            RoundElevation = openingRealsArConfig.ElevationRounding > 0;
+            SelectedRoundElevation = openingRealsArConfig.ElevationRounding;
+            RoundSize = openingRealsArConfig.Rounding > 0;
+            SelectedRoundSize = openingRealsArConfig.Rounding;
+
+            SaveConfigCommand = RelayCommand.Create(SaveConfig);
+        }
+
+
+        private bool _roundSize;
+
+        /// <summary>
+        /// Включает/выключает округление размеров
+        /// </summary>
+        public bool RoundSize {
+            get => _roundSize;
+            set {
+                RaiseAndSetIfChanged(ref _roundSize, value);
+                SelectedRoundSize = value ? EnabledRoundings.First() : 0;
+            }
+        }
+
+        private bool _roundElevation;
+
+        /// <summary>
+        /// Включает/выключает округление отметки
+        /// </summary>
+        public bool RoundElevation {
+            get => _roundElevation;
+            set {
+                RaiseAndSetIfChanged(ref _roundElevation, value);
+                SelectedRoundElevation = value ? EnabledRoundings.First() : 0;
+            }
+        }
+
+        private int _selectedRoundElevation;
+
+        /// <summary>
+        /// Округление высотной отметки в мм
+        /// </summary>
+        public int SelectedRoundElevation {
+            get => _selectedRoundElevation;
+            set => RaiseAndSetIfChanged(ref _selectedRoundElevation, value);
+        }
+
+        private int _selectedRoundSize;
+
+        /// <summary>
+        /// Округление размеров в мм
+        /// </summary>
+        public int SelectedRoundSize {
+            get => _selectedRoundSize;
+            set => RaiseAndSetIfChanged(ref _selectedRoundSize, value);
+        }
+
+        /// <summary>
+        /// Доступные для выбора значения округления в мм
+        /// </summary>
+        public IReadOnlyCollection<int> EnabledRoundings { get; } = new int[] { 1, 5, 10, 25, 50 };
+
+
+        public ICommand SaveConfigCommand { get; }
+
+        private void SaveConfig() {
+            GetOpeningConfig().SaveProjectConfig();
+        }
+
+
+        private OpeningRealsArConfig GetOpeningConfig() {
+            var config = OpeningRealsArConfig.GetOpeningConfig(_revitRepository.Doc);
+            config.Rounding = SelectedRoundSize;
+            config.ElevationRounding = SelectedRoundElevation;
+            return config;
+        }
+    }
+}

--- a/src/RevitOpeningPlacement/ViewModels/OpeningConfig/OpeningRealsKrConfigViewModel.cs
+++ b/src/RevitOpeningPlacement/ViewModels/OpeningConfig/OpeningRealsKrConfigViewModel.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Input;
 
 using dosymep.WPF.Commands;
@@ -19,6 +21,10 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
 
             PlaceByMep = openingRealsKrConfig.PlacementType == OpeningRealKrPlacementType.PlaceByMep;
             PlaceByAr = !PlaceByMep;
+            RoundElevation = openingRealsKrConfig.ElevationRounding > 0;
+            SelectedRoundElevation = openingRealsKrConfig.ElevationRounding;
+            RoundSize = openingRealsKrConfig.Rounding > 0;
+            SelectedRoundSize = openingRealsKrConfig.Rounding;
 
             SaveConfigCommand = RelayCommand.Create(SaveConfig);
         }
@@ -39,6 +45,57 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
             set => RaiseAndSetIfChanged(ref _placeByAr, value);
         }
 
+        private bool _roundSize;
+
+        /// <summary>
+        /// Включает/выключает округление размеров
+        /// </summary>
+        public bool RoundSize {
+            get => _roundSize;
+            set {
+                RaiseAndSetIfChanged(ref _roundSize, value);
+                SelectedRoundSize = value ? EnabledRoundings.First() : 0;
+            }
+        }
+
+        private bool _roundElevation;
+
+        /// <summary>
+        /// Включает/выключает округление отметки
+        /// </summary>
+        public bool RoundElevation {
+            get => _roundElevation;
+            set {
+                RaiseAndSetIfChanged(ref _roundElevation, value);
+                SelectedRoundElevation = value ? EnabledRoundings.First() : 0;
+            }
+        }
+
+        private int _selectedRoundElevation;
+
+        /// <summary>
+        /// Округление высотной отметки в мм
+        /// </summary>
+        public int SelectedRoundElevation {
+            get => _selectedRoundElevation;
+            set => RaiseAndSetIfChanged(ref _selectedRoundElevation, value);
+        }
+
+        private int _selectedRoundSize;
+
+        /// <summary>
+        /// Округление размеров в мм
+        /// </summary>
+        public int SelectedRoundSize {
+            get => _selectedRoundSize;
+            set => RaiseAndSetIfChanged(ref _selectedRoundSize, value);
+        }
+
+        /// <summary>
+        /// Доступные для выбора значения округления в мм
+        /// </summary>
+        public IReadOnlyCollection<int> EnabledRoundings { get; } = new int[] { 1, 5, 10, 25, 50 };
+
 
         public ICommand SaveConfigCommand { get; }
 
@@ -52,6 +109,8 @@ namespace RevitOpeningPlacement.ViewModels.OpeningConfig {
             config.PlacementType = PlaceByAr
                 ? OpeningRealKrPlacementType.PlaceByAr
                 : OpeningRealKrPlacementType.PlaceByMep;
+            config.Rounding = SelectedRoundSize;
+            config.ElevationRounding = SelectedRoundElevation;
             return config;
         }
     }

--- a/src/RevitOpeningPlacement/Views/MainWindow.xaml
+++ b/src/RevitOpeningPlacement/Views/MainWindow.xaml
@@ -66,8 +66,16 @@
         <dxdo:DockLayoutManager Grid.Row="1">
             <dxdo:LayoutGroup LastChildFill="True">
                 <dxdo:LayoutControlItem ItemWidth="310">
-                    <local:CategoryView x:Name="_categoryView"
+                    <DockPanel LastChildFill="True">
+                        <Button Margin="0 10 0 0"
+                                DockPanel.Dock="Bottom"
+                                HorizontalAlignment="Stretch"
+                                Content="Настройки объединения"
+                                ToolTip="Настройки объединения используются&#x0a;при ручном объединении заданий на отверстия,&#x0a;а также при автообъединении заданий на отверстия в многослойных конструкциях."
+                                Command="{Binding OpenUnionTaskSettingsCommand}"/>
+                        <local:CategoryView x:Name="_categoryView"
                                         DataContext="{Binding ElementName=_this, Path=DataContext}" />
+                    </DockPanel>
                 </dxdo:LayoutControlItem>
                 <dxdo:LayoutControlItem Margin="-13">
                     <local:SettingView DataContext="{Binding SelectedMepCategoryViewModel}" />

--- a/src/RevitOpeningPlacement/Views/MainWindow.xaml
+++ b/src/RevitOpeningPlacement/Views/MainWindow.xaml
@@ -71,7 +71,7 @@
                                 DockPanel.Dock="Bottom"
                                 HorizontalAlignment="Stretch"
                                 Content="Настройки объединения"
-                                ToolTip="Настройки объединения используются&#x0a;при ручном объединении заданий на отверстия,&#x0a;а также при автообъединении заданий на отверстия в многослойных конструкциях."
+                                ToolTip="Настройки объединения используются&#x0a;при ручном объединении заданий на отверстия,&#x0a;а также при автообъединении заданий на отверстия, в том числе в многослойных конструкциях."
                                 Command="{Binding OpenUnionTaskSettingsCommand}"/>
                         <local:CategoryView x:Name="_categoryView"
                                         DataContext="{Binding ElementName=_this, Path=DataContext}" />

--- a/src/RevitOpeningPlacement/Views/OpeningRealsArSettingsView.xaml
+++ b/src/RevitOpeningPlacement/Views/OpeningRealsArSettingsView.xaml
@@ -1,0 +1,85 @@
+﻿<base:ThemedPlatformWindow
+    x:Class="RevitOpeningPlacement.Views.OpeningRealsArSettingsView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:base="clr-namespace:dosymep.WPF.Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:RevitOpeningPlacement.Views"
+    xmlns:vms="clr-namespace:RevitOpeningPlacement.ViewModels.OpeningConfig"
+    xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+    xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+    xmlns:dxdo="http://schemas.devexpress.com/winfx/2008/xaml/docking"
+    WindowStartupLocation="CenterOwner"
+    x:Name="_this"
+    mc:Ignorable="d"
+    Title="Настройки расстановки отверстий АР"
+    MinHeight="140"
+    MinWidth="350"
+    MaxHeight="140"
+    MaxWidth="350"
+    ResizeMode="NoResize"
+    d:DataContext="{d:DesignInstance vms:OpeningRealsArConfigViewModel, IsDesignTimeCreatable=False}">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition
+                Height="*" />
+            <RowDefinition
+                Height="45" />
+        </Grid.RowDefinitions>
+        <StackPanel
+            Width="210"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Center">
+            <DockPanel
+                Margin="0 5"
+                HorizontalAlignment="Stretch">
+                <dxe:CheckEdit
+                    Content="Округлять габариты"
+                    IsChecked="{Binding RoundSize, UpdateSourceTrigger=PropertyChanged}" />
+                <dxe:ComboBoxEdit
+                    Width="70"
+                    IsTextEditable="False"
+                    HorizontalAlignment="Right"
+                    ToolTip="Значение округления, мм"
+                    IsEnabled="{Binding RoundSize}"
+                    ItemsSource="{Binding EnabledRoundings}"
+                    SelectedItem="{Binding SelectedRoundSize, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+            <DockPanel
+                HorizontalAlignment="Stretch">
+                <dxe:CheckEdit
+                    Content="Округлять отметку"
+                    IsChecked="{Binding RoundElevation, UpdateSourceTrigger=PropertyChanged}" />
+                <dxe:ComboBoxEdit
+                    Width="70"
+                    IsTextEditable="False"
+                    HorizontalAlignment="Right"
+                    ToolTip="Значение округления, мм"
+                    IsEnabled="{Binding RoundElevation}"
+                    ItemsSource="{Binding EnabledRoundings}"
+                    SelectedItem="{Binding SelectedRoundElevation, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+        </StackPanel>
+        <DockPanel
+            Grid.Row="2"
+            Margin="10 "
+            HorizontalAlignment="Right"
+            VerticalAlignment="Bottom">
+            <dx:SimpleButton
+                Content="OK"
+                Height="25"
+                Width="80"
+                Margin="0 0 10 0"
+                IsDefault="True"
+                Click="ButtonOk_Click"
+                Command="{Binding SaveConfigCommand}" />
+            <dx:SimpleButton
+                Content="Отмена"
+                Height="25"
+                Width="80"
+                IsCancel="True"
+                Click="ButtonCancel_Click" />
+        </DockPanel>
+    </Grid>
+</base:ThemedPlatformWindow>

--- a/src/RevitOpeningPlacement/Views/OpeningRealsArSettingsView.xaml.cs
+++ b/src/RevitOpeningPlacement/Views/OpeningRealsArSettingsView.xaml.cs
@@ -1,13 +1,13 @@
 using System.Windows;
 
 namespace RevitOpeningPlacement.Views {
-    public partial class OpeningRealsKrSettingsView {
-        public OpeningRealsKrSettingsView() {
+    public partial class OpeningRealsArSettingsView {
+        public OpeningRealsArSettingsView() {
             InitializeComponent();
         }
 
         public override string PluginName => nameof(RevitOpeningPlacement);
-        public override string ProjectConfigName => nameof(OpeningRealsKrSettingsView);
+        public override string ProjectConfigName => nameof(OpeningRealsArSettingsView);
 
         private void ButtonOk_Click(object sender, RoutedEventArgs e) {
             DialogResult = true;

--- a/src/RevitOpeningPlacement/Views/OpeningRealsKrSettingsView.xaml
+++ b/src/RevitOpeningPlacement/Views/OpeningRealsKrSettingsView.xaml
@@ -1,50 +1,96 @@
-﻿<base:ThemedPlatformWindow x:Class="RevitOpeningPlacement.Views.OpeningRealsKrSettingsView"
-                           xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                           xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                           xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                           xmlns:base="clr-namespace:dosymep.WPF.Views"
-                           xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                           xmlns:local="clr-namespace:RevitOpeningPlacement.Views"
-                           xmlns:vms="clr-namespace:RevitOpeningPlacement.ViewModels.OpeningConfig"
-                           xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
-                           xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
-                           xmlns:dxdo="http://schemas.devexpress.com/winfx/2008/xaml/docking"
-                           WindowStartupLocation="CenterOwner"
-                           x:Name="_this"
-                           mc:Ignorable="d"
-                           Title="Настройки расстановки отверстий КР"
-                           MinHeight="140"
-                           MinWidth="350"
-                           MaxHeight="140"
-                           MaxWidth="350"
-                           ResizeMode="NoResize"
-                           d:DataContext="{d:DesignInstance vms:OpeningRealsKrConfigViewModel, IsDesignTimeCreatable=False}">
+﻿<base:ThemedPlatformWindow
+    x:Class="RevitOpeningPlacement.Views.OpeningRealsKrSettingsView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:base="clr-namespace:dosymep.WPF.Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:RevitOpeningPlacement.Views"
+    xmlns:vms="clr-namespace:RevitOpeningPlacement.ViewModels.OpeningConfig"
+    xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+    xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+    xmlns:dxdo="http://schemas.devexpress.com/winfx/2008/xaml/docking"
+    WindowStartupLocation="CenterOwner"
+    x:Name="_this"
+    mc:Ignorable="d"
+    Title="Настройки расстановки отверстий КР"
+    MinHeight="240"
+    MinWidth="350"
+    MaxHeight="240"
+    MaxWidth="350"
+    ResizeMode="NoResize"
+    d:DataContext="{d:DesignInstance vms:OpeningRealsKrConfigViewModel, IsDesignTimeCreatable=False}">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="45"/>
+            <RowDefinition
+                Height="*" />
+            <RowDefinition
+                Height="45" />
         </Grid.RowDefinitions>
-        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-            <RadioButton GroupName="PlacementType"
-                         Content="Размещать отверстия по заданиям из АР"
-                         IsChecked="{Binding PlaceByAr}" />
-            <RadioButton GroupName="PlacementType"
-                         Content="Размещать отверстия по заданиям из ВИС"
-                         IsChecked="{Binding PlaceByMep}" />
+        <StackPanel
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center">
+            <StackPanel>
+                <RadioButton
+                    GroupName="PlacementType"
+                    Content="Размещать отверстия по заданиям из АР"
+                    IsChecked="{Binding PlaceByAr}" />
+                <RadioButton
+                    Margin="0 5 0 0"
+                    GroupName="PlacementType"
+                    Content="Размещать отверстия по заданиям из ВИС"
+                    IsChecked="{Binding PlaceByMep}" />
+
+                <DockPanel
+                    Margin="0 5"
+                    HorizontalAlignment="Stretch">
+                    <dxe:CheckEdit
+                        Content="Округлять габариты"
+                        IsChecked="{Binding RoundSize, UpdateSourceTrigger=PropertyChanged}" />
+                    <dxe:ComboBoxEdit
+                        Width="70"
+                        IsTextEditable="False"
+                        HorizontalAlignment="Right"
+                        ToolTip="Значение округления, мм"
+                        IsEnabled="{Binding RoundSize}"
+                        ItemsSource="{Binding EnabledRoundings}"
+                        SelectedItem="{Binding SelectedRoundSize, UpdateSourceTrigger=PropertyChanged}" />
+                </DockPanel>
+                <DockPanel
+                    HorizontalAlignment="Stretch">
+                    <dxe:CheckEdit
+                        Content="Округлять отметку"
+                        IsChecked="{Binding RoundElevation, UpdateSourceTrigger=PropertyChanged}" />
+                    <dxe:ComboBoxEdit
+                        Width="70"
+                        IsTextEditable="False"
+                        HorizontalAlignment="Right"
+                        ToolTip="Значение округления, мм"
+                        IsEnabled="{Binding RoundElevation}"
+                        ItemsSource="{Binding EnabledRoundings}"
+                        SelectedItem="{Binding SelectedRoundElevation, UpdateSourceTrigger=PropertyChanged}" />
+                </DockPanel>
+            </StackPanel>
         </StackPanel>
-        <DockPanel Grid.Row="2" Margin="10 " HorizontalAlignment="Right" VerticalAlignment="Bottom">
-            <dx:SimpleButton Content="OK"
-                             Height="25"
-                             Width="80"
-                             Margin="0 0 10 0"
-                             IsDefault="True"
-                             Click="ButtonOk_Click"
-                             Command="{Binding SaveConfigCommand}" />
-            <dx:SimpleButton Content="Отмена"
-                             Height="25"
-                             Width="80"
-                             IsCancel="True"
-                             Click="ButtonCancel_Click" />
+        <DockPanel
+            Grid.Row="2"
+            Margin="10 "
+            HorizontalAlignment="Right"
+            VerticalAlignment="Bottom">
+            <dx:SimpleButton
+                Content="OK"
+                Height="25"
+                Width="80"
+                Margin="0 0 10 0"
+                IsDefault="True"
+                Click="ButtonOk_Click"
+                Command="{Binding SaveConfigCommand}" />
+            <dx:SimpleButton
+                Content="Отмена"
+                Height="25"
+                Width="80"
+                IsCancel="True"
+                Click="ButtonCancel_Click" />
         </DockPanel>
     </Grid>
 </base:ThemedPlatformWindow>

--- a/src/RevitOpeningPlacement/Views/OpeningRealsKrSettingsView.xaml
+++ b/src/RevitOpeningPlacement/Views/OpeningRealsKrSettingsView.xaml
@@ -1,35 +1,30 @@
-﻿<base:ThemedPlatformWindow
-    x:Class="RevitOpeningPlacement.Views.OpeningRealsKrSettingsView"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:base="clr-namespace:dosymep.WPF.Views"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:local="clr-namespace:RevitOpeningPlacement.Views"
-    xmlns:vms="clr-namespace:RevitOpeningPlacement.ViewModels.OpeningConfig"
-    xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
-    xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
-    xmlns:dxdo="http://schemas.devexpress.com/winfx/2008/xaml/docking"
-    WindowStartupLocation="CenterOwner"
-    x:Name="_this"
-    mc:Ignorable="d"
-    Title="Настройки расстановки отверстий КР"
-    MinHeight="240"
-    MinWidth="350"
-    MaxHeight="240"
-    MaxWidth="350"
-    ResizeMode="NoResize"
-    d:DataContext="{d:DesignInstance vms:OpeningRealsKrConfigViewModel, IsDesignTimeCreatable=False}">
+﻿<base:ThemedPlatformWindow x:Class="RevitOpeningPlacement.Views.OpeningRealsKrSettingsView"
+                           xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                           xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                           xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                           xmlns:base="clr-namespace:dosymep.WPF.Views"
+                           xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                           xmlns:local="clr-namespace:RevitOpeningPlacement.Views"
+                           xmlns:vms="clr-namespace:RevitOpeningPlacement.ViewModels.OpeningConfig"
+                           xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+                           xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+                           xmlns:dxdo="http://schemas.devexpress.com/winfx/2008/xaml/docking"
+                           WindowStartupLocation="CenterOwner"
+                           x:Name="_this"
+                           mc:Ignorable="d"
+                           Title="Настройки расстановки отверстий КР"
+                           MinHeight="240"
+                           MinWidth="350"
+                           MaxHeight="240"
+                           MaxWidth="350"
+                           ResizeMode="NoResize"
+                           d:DataContext="{d:DesignInstance vms:OpeningRealsKrConfigViewModel, IsDesignTimeCreatable=False}">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition
-                Height="*" />
-            <RowDefinition
-                Height="45" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="45" />
         </Grid.RowDefinitions>
-        <StackPanel
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
             <StackPanel>
                 <RadioButton
                     GroupName="PlacementType"
@@ -72,25 +67,19 @@
                 </DockPanel>
             </StackPanel>
         </StackPanel>
-        <DockPanel
-            Grid.Row="2"
-            Margin="10 "
-            HorizontalAlignment="Right"
-            VerticalAlignment="Bottom">
-            <dx:SimpleButton
-                Content="OK"
-                Height="25"
-                Width="80"
-                Margin="0 0 10 0"
-                IsDefault="True"
-                Click="ButtonOk_Click"
-                Command="{Binding SaveConfigCommand}" />
-            <dx:SimpleButton
-                Content="Отмена"
-                Height="25"
-                Width="80"
-                IsCancel="True"
-                Click="ButtonCancel_Click" />
+        <DockPanel Grid.Row="2" Margin="10 " HorizontalAlignment="Right" VerticalAlignment="Bottom">
+            <dx:SimpleButton Content="OK"
+                             Height="25"
+                             Width="80"
+                             Margin="0 0 10 0"
+                             IsDefault="True"
+                             Click="ButtonOk_Click"
+                             Command="{Binding SaveConfigCommand}" />
+            <dx:SimpleButton Content="Отмена"
+                             Height="25"
+                             Width="80"
+                             IsCancel="True"
+                             Click="ButtonCancel_Click" />
         </DockPanel>
     </Grid>
 </base:ThemedPlatformWindow>

--- a/src/RevitOpeningPlacement/Views/SettingView.xaml
+++ b/src/RevitOpeningPlacement/Views/SettingView.xaml
@@ -84,15 +84,33 @@
                             </dxdo:LayoutControlItem>
                         </dxdo:LayoutGroup>
                         <dxdo:LayoutGroup>
-                            <dxdo:LayoutControlItem ItemWidth="2*">
-                                <lc:GroupBox Header="Округление размеров, мм"
-                                             ToolTip="Например, если через стену проходит труба диаметром 110 и выставлен Зазор=50 и Округление=50 мм,&#x0a;то будет создано отверстие диаметром 200 мм,&#x0a;так как диаметр отверстия с учетом зазоров 50 мм станет 110+2*50=210 мм, после чего будет округлен по правилам математики кратно 50 мм, то есть до 200 мм.">
-                                    <dxe:ComboBoxEdit ItemsSource="{Binding Roundings}"
-                                                      SelectedItem="{Binding SelectedRounding}"
-                                                      IsTextEditable="False"
-                                                      Height="20"
-                                                      VerticalAlignment="Top" />
-                                </lc:GroupBox>
+                            <dxdo:LayoutControlItem ItemWidth="2*"
+                                                    MinHeight="150">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                    </Grid.RowDefinitions>
+                                    <lc:GroupBox Header="Округление размеров, мм"
+                                                 Grid.Row="0"
+                                                 DockPanel.Dock="Top"
+                                                 ToolTip="Например, если через стену проходит труба диаметром 110 и выставлен Зазор=50 и Округление=50 мм,&#x0a;то будет создано отверстие диаметром 200 мм,&#x0a;так как диаметр отверстия с учетом зазоров 50 мм станет 110+2*50=210 мм, после чего будет округлен по правилам математики кратно 50 мм, то есть до 200 мм.">
+                                        <dxe:ComboBoxEdit ItemsSource="{Binding Roundings}"
+                                                          SelectedItem="{Binding SelectedRounding}"
+                                                          IsTextEditable="False"
+                                                          Height="20"
+                                                          VerticalAlignment="Top" />
+                                    </lc:GroupBox>
+                                    <lc:GroupBox Header="Округление отметок, мм"
+                                                 Grid.Row="1"
+                                                 ToolTip="Округление будет произведено относительно начала проекта.">
+                                        <dxe:ComboBoxEdit ItemsSource="{Binding Roundings}"
+                                                          SelectedItem="{Binding SelectedElevationRounding}"
+                                                          IsTextEditable="False"
+                                                          Height="20"
+                                                          VerticalAlignment="Top" />
+                                    </lc:GroupBox>
+                                </Grid>
                             </dxdo:LayoutControlItem>
                         </dxdo:LayoutGroup>
                     </dxdo:LayoutGroup>

--- a/src/RevitOpeningPlacement/Views/UnionTaskSettingsView.xaml
+++ b/src/RevitOpeningPlacement/Views/UnionTaskSettingsView.xaml
@@ -1,0 +1,84 @@
+﻿<base:ThemedPlatformWindow
+    x:Class="RevitOpeningPlacement.Views.UnionTaskSettingsView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:base="clr-namespace:dosymep.WPF.Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:RevitOpeningPlacement.Views"
+    xmlns:vms="clr-namespace:RevitOpeningPlacement.ViewModels.OpeningConfig"
+    xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+    xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+    xmlns:dxdo="http://schemas.devexpress.com/winfx/2008/xaml/docking"
+    WindowStartupLocation="CenterOwner"
+    x:Name="_this"
+    mc:Ignorable="d"
+    Title="Настройки объединения"
+    MinHeight="140"
+    MinWidth="350"
+    MaxHeight="140"
+    MaxWidth="350"
+    ResizeMode="NoResize"
+    d:DataContext="{d:DesignInstance vms:MainViewModel, IsDesignTimeCreatable=False}">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition
+                Height="*" />
+            <RowDefinition
+                Height="45" />
+        </Grid.RowDefinitions>
+        <StackPanel
+            Width="210"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Center">
+            <DockPanel
+                Margin="0 5"
+                HorizontalAlignment="Stretch">
+                <dxe:CheckEdit
+                    Content="Округлять габариты"
+                    IsChecked="{Binding RoundUnitedTaskSize, UpdateSourceTrigger=PropertyChanged}" />
+                <dxe:ComboBoxEdit
+                    Width="70"
+                    IsTextEditable="False"
+                    HorizontalAlignment="Right"
+                    ToolTip="Значение округления, мм"
+                    IsEnabled="{Binding RoundUnitedTaskSize}"
+                    ItemsSource="{Binding EnabledRoundings}"
+                    SelectedItem="{Binding SelectedSizeRoundForUnitedTask, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+            <DockPanel
+                HorizontalAlignment="Stretch">
+                <dxe:CheckEdit
+                    Content="Округлять отметку"
+                    IsChecked="{Binding RoundUnitedTaskElevation, UpdateSourceTrigger=PropertyChanged}" />
+                <dxe:ComboBoxEdit
+                    Width="70"
+                    IsTextEditable="False"
+                    HorizontalAlignment="Right"
+                    ToolTip="Значение округления, мм"
+                    IsEnabled="{Binding RoundUnitedTaskElevation}"
+                    ItemsSource="{Binding EnabledRoundings}"
+                    SelectedItem="{Binding SelectedElevationRoundingForUnitedTask, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+        </StackPanel>
+        <DockPanel
+            Grid.Row="2"
+            Margin="10 "
+            HorizontalAlignment="Right"
+            VerticalAlignment="Bottom">
+            <dx:SimpleButton
+                Content="OK"
+                Height="25"
+                Width="80"
+                Margin="0 0 10 0"
+                IsDefault="True"
+                Click="ButtonOk_Click"/>
+            <dx:SimpleButton
+                Content="Отмена"
+                Height="25"
+                Width="80"
+                IsCancel="True"
+                Click="ButtonCancel_Click" />
+        </DockPanel>
+    </Grid>
+</base:ThemedPlatformWindow>

--- a/src/RevitOpeningPlacement/Views/UnionTaskSettingsView.xaml.cs
+++ b/src/RevitOpeningPlacement/Views/UnionTaskSettingsView.xaml.cs
@@ -1,0 +1,20 @@
+using System.Windows;
+
+namespace RevitOpeningPlacement.Views {
+    public partial class UnionTaskSettingsView {
+        public UnionTaskSettingsView() {
+            InitializeComponent();
+        }
+
+        public override string PluginName => nameof(RevitOpeningPlacement);
+        public override string ProjectConfigName => nameof(UnionTaskSettingsView);
+
+        private void ButtonOk_Click(object sender, RoutedEventArgs e) {
+            DialogResult = true;
+        }
+
+        private void ButtonCancel_Click(object sender, RoutedEventArgs e) {
+            DialogResult = false;
+        }
+    }
+}


### PR DESCRIPTION
# Обновления

## Новые статусы

Добавлен статус "В разных конструкциях" для исходящих заданий на отверстия от ВИС, а также для входящих заданий в АР от ВИС, в КР от ВИС и в КР от АР. Статус назначается, если задание на отверстие находится в разных конструкциях - одновременно в стене и в перекрытии.

<img src="https://github.com/user-attachments/assets/bf8317dc-fe33-4e90-b230-b0cf8f5a1d33" width=1000>

## Обновление настроек

### Настройки ВИС

Теперь в настройках расстановки заданий от ВИС можно задать округление высотной отметки дял каждой категории элементов ВИС. Также можно задать округление размеров и высотной отметки для объединенных заданий.

Пример настроек ВИС

<img src="https://github.com/user-attachments/assets/1065d7e0-9a24-4649-bff5-67fb063acf2a" width=1000>

### Настройки КР

В настройках КР также теперь есть функционал по настройке округлений габаритов и высотной отметки чистовых отверстий с возможностью выключения округления.

Пример настроек КР

<img src="https://github.com/user-attachments/assets/3949672f-e502-49f3-b0b0-e987627b5cdc" width=300>

### Настройки АР

Для настроек округления АР сделана аналогичная кнопка с таким же функционалом.

Пример настроек АР

<img src="https://github.com/user-attachments/assets/3c8ee0f1-6291-4661-b0a5-4f63a380cabf" width=200>
<img src="https://github.com/user-attachments/assets/808cecf4-df62-4b33-8c14-110d5f23785e" width=300>

## Исправление багов

Обнаружен и исправлен баг, когда задания от ВИС не объединяются в одно, если одно находится внутри другого

| было | стало |
| - | - |
| <img src="https://github.com/user-attachments/assets/04c15cbf-2894-4a5e-8988-b1ff30a6e8f7" width=300> | <img src="https://github.com/user-attachments/assets/e3023016-b796-48e1-98d2-c7bf0cc7cc2b" width=300> |
