### PR TITLE
Коллизии: Убрана лишняя проверка названия импортируемого проекта

### DIFF
--- a/src/RevitClashes/Models/RevitClashReport/NavisXmlClashesLoader.cs
+++ b/src/RevitClashes/Models/RevitClashReport/NavisXmlClashesLoader.cs
@@ -120,9 +120,6 @@ namespace RevitClashDetective.Models.RevitClashReport {
             }
 
             var xmlDoc = XDocument.Load(FilePath);
-            if(!IsCorrectFileName(xmlDoc)) {
-                throw new ArgumentException("Попытка загрузки файла отчета, созданного в другом проекте.");
-            }
 
             return xmlDoc.Descendants("clashtest")
                 .Select(ct => new ReportModel((string) ct.Attribute("name"), GetClashModels(ct)));
@@ -186,22 +183,6 @@ namespace RevitClashDetective.Models.RevitClashReport {
             } else {
                 return new ElementModel() { Id = ElementId.InvalidElementId };
             }
-        }
-
-        private bool IsCorrectFileName(XDocument xDoc) {
-            if(xDoc is null) {
-                return false;
-            }
-            const string rvtEnd = ".rvt";
-            var fileName = xDoc.Descendants("smarttag")
-                .FirstOrDefault(tag => tag.Element("value")?.Value?.EndsWith(rvtEnd) ?? false)?.Element("value").Value
-                ?? string.Empty;
-            var title = fileName.Length > rvtEnd.Length
-                ? fileName.Substring(0, fileName.Length - rvtEnd.Length)
-                : fileName;
-            return _revitRepository.DocInfos.Any(d => d.Name.Equals(
-                RevitRepository.GetDocumentName(title),
-                StringComparison.CurrentCultureIgnoreCase));
         }
 
         private ClashStatus GetClashStatus(string status) {

--- a/src/RevitClashes/Models/RevitClashReport/NavisXmlClashesLoader.cs
+++ b/src/RevitClashes/Models/RevitClashReport/NavisXmlClashesLoader.cs
@@ -192,11 +192,13 @@ namespace RevitClashDetective.Models.RevitClashReport {
             if(xDoc is null) {
                 return false;
             }
+            const string rvtEnd = ".rvt";
             var file = xDoc.Descendants("smarttag")
-                .FirstOrDefault(tag => tag.Element("value")?.Value?.EndsWith(".rvt") ?? false)?.Element("value").Value
+                .FirstOrDefault(tag => tag.Element("value")?.Value?.EndsWith(rvtEnd) ?? false)?.Element("value").Value
                 ?? string.Empty;
+            var title = file.Substring(0, file.Length - rvtEnd.Length);
             return _revitRepository.DocInfos.Any(d => d.Name.Equals(
-                RevitRepository.GetDocumentName(file),
+                RevitRepository.GetDocumentName(title),
                 StringComparison.CurrentCultureIgnoreCase));
         }
 

--- a/src/RevitClashes/Models/RevitClashReport/NavisXmlClashesLoader.cs
+++ b/src/RevitClashes/Models/RevitClashReport/NavisXmlClashesLoader.cs
@@ -193,10 +193,12 @@ namespace RevitClashDetective.Models.RevitClashReport {
                 return false;
             }
             const string rvtEnd = ".rvt";
-            var file = xDoc.Descendants("smarttag")
+            var fileName = xDoc.Descendants("smarttag")
                 .FirstOrDefault(tag => tag.Element("value")?.Value?.EndsWith(rvtEnd) ?? false)?.Element("value").Value
                 ?? string.Empty;
-            var title = file.Substring(0, file.Length - rvtEnd.Length);
+            var title = fileName.Length > rvtEnd.Length
+                ? fileName.Substring(0, fileName.Length - rvtEnd.Length)
+                : fileName;
             return _revitRepository.DocInfos.Any(d => d.Name.Equals(
                 RevitRepository.GetDocumentName(title),
                 StringComparison.CurrentCultureIgnoreCase));


### PR DESCRIPTION
# Исправления

Название проекта Revit, которое приходит для валидации из xml, содержит расширение в конце (rvt). Старая логика валидации не учитывала, что надо отбрасывать этот суффикс. На тестовом файле это не было видно, потому что у него был дополнительный суффикс "_отсоединено", который отбрасывается в методе `GetDocumentName`.

Так как метод по валидации названия проекта из xml не играет никакой роли (элементы каждой коллизии потом снова проверяются на существование в активном документе или в какой-нибудь связи), принято решение его полностью удалить.