### PR TITLE
RevitClashDetective: Сохранение файлов отчетов перенесено в документы пользователя

### DIFF
--- a/src/RevitClashDetective/ViewModels/Navigator/ReportsViewModel.cs
+++ b/src/RevitClashDetective/ViewModels/Navigator/ReportsViewModel.cs
@@ -72,7 +72,7 @@ namespace RevitClashDetective.ViewModels.Navigator {
 
 
         private void InitializeFiles(string selectedFile) {
-            var profilePath = RevitRepository.ProfilePath;
+            var profilePath = RevitRepository.LocalProfilePath;
             Reports = new ObservableCollection<ReportViewModel>(Directory.GetFiles(Path.Combine(profilePath, ModuleEnvironment.RevitVersion, nameof(RevitClashDetective), _revitRepository.GetObjectName()))
                 .Select(path => new ReportViewModel(_revitRepository, Path.GetFileNameWithoutExtension(path)))
                 .Where(item => item.Name.Equals(selectedFile, StringComparison.CurrentCultureIgnoreCase)));
@@ -80,7 +80,7 @@ namespace RevitClashDetective.ViewModels.Navigator {
         }
 
         private void InitializeFiles() {
-            var profilePath = RevitRepository.ProfilePath;
+            var profilePath = RevitRepository.LocalProfilePath;
             var path = Path.Combine(profilePath, ModuleEnvironment.RevitVersion, nameof(RevitClashDetective), _revitRepository.GetObjectName());
             if(Directory.Exists(path)) {
                 Reports = new ObservableCollection<ReportViewModel>(Directory.GetFiles(path)

--- a/src/RevitClashes/Models/Clashes/ClashesConfig.cs
+++ b/src/RevitClashes/Models/Clashes/ClashesConfig.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 using dosymep.Bim4Everyone;
 using dosymep.Bim4Everyone.ProjectConfigs;
@@ -13,13 +13,13 @@ namespace RevitClashDetective.Models.Clashes {
         [JsonIgnore]
         public override IConfigSerializer Serializer { get; set; }
         public List<ClashModel> Clashes { get; set; } = new List<ClashModel>();
-        public static ClashesConfig GetClashesConfig(string revitObjectName, string congfigName) {
+        public static ClashesConfig GetClashesConfig(string revitObjectName, string configName) {
             return new ProjectConfigBuilder()
                 .SetSerializer(new ConfigSerializer())
                 .SetPluginName(nameof(RevitClashDetective))
                 .SetRelativePath(revitObjectName)
                 .SetRevitVersion(ModuleEnvironment.RevitVersion)
-                .SetProjectConfigName(congfigName + ".json")
+                .SetProjectConfigName(configName + ".json")
                 .Build<ClashesConfig>();
         }
     }

--- a/src/RevitClashes/Models/Clashes/ClashesConfig.cs
+++ b/src/RevitClashes/Models/Clashes/ClashesConfig.cs
@@ -17,6 +17,7 @@ namespace RevitClashDetective.Models.Clashes {
             return new ProjectConfigBuilder()
                 .SetSerializer(new ConfigSerializer())
                 .SetPluginName(nameof(RevitClashDetective))
+                .SetProfilePath(RevitRepository.LocalProfilePath)
                 .SetRelativePath(revitObjectName)
                 .SetRevitVersion(ModuleEnvironment.RevitVersion)
                 .SetProjectConfigName(configName + ".json")

--- a/src/RevitClashes/Models/ProjectConfigBuilder.cs
+++ b/src/RevitClashes/Models/ProjectConfigBuilder.cs
@@ -16,6 +16,8 @@ namespace RevitClashDetective.Models {
 
         private string _revitVersion;
 
+        private string _profilePath;
+
         public ProjectConfigBuilder SetPluginName(string pluginName) {
             _pluginName = pluginName;
             return this;
@@ -38,6 +40,11 @@ namespace RevitClashDetective.Models {
 
         public ProjectConfigBuilder SetRevitVersion(string revitVersion) {
             _revitVersion = revitVersion;
+            return this;
+        }
+
+        public ProjectConfigBuilder SetProfilePath(string profilePath) {
+            _profilePath = profilePath;
             return this;
         }
 
@@ -76,11 +83,11 @@ namespace RevitClashDetective.Models {
             return new T() { Serializer = _serializer, ProjectConfigPath = projectConfigPath };
         }
 
-        private static string GetConfigPath(string pluginName, string projectConfigName, string revitVersion) {
-            string _profilePath = RevitRepository.ProfilePath;
+        private string GetConfigPath(string pluginName, string projectConfigName, string revitVersion) {
+            string profilePath = string.IsNullOrWhiteSpace(_profilePath) ? RevitRepository.ProfilePath : _profilePath;
             return string.IsNullOrEmpty(revitVersion)
-                ? Path.Combine(_profilePath, pluginName, projectConfigName)
-                : Path.Combine(_profilePath, revitVersion, pluginName, projectConfigName);
+                ? Path.Combine(profilePath, pluginName, projectConfigName)
+                : Path.Combine(profilePath, revitVersion, pluginName, projectConfigName);
         }
     }
 }

--- a/src/RevitClashes/Models/RevitRepository.cs
+++ b/src/RevitClashes/Models/RevitRepository.cs
@@ -78,9 +78,15 @@ namespace RevitClashDetective.Models {
             get {
                 var path = @"W:\Проектный институт\Отд.стандарт.BIM и RD\BIM-Ресурсы\5-Надстройки\Bim4Everyone\A101";
                 if(!Directory.Exists(path)) {
-                    path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "dosymep");
+                    path = LocalProfilePath;
                 }
                 return path;
+            }
+        }
+
+        public static string LocalProfilePath {
+            get {
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "dosymep");
             }
         }
 
@@ -607,19 +613,19 @@ namespace RevitClashDetective.Models {
                         $"{FiltersNamePrefix}не_элементы_категории_коллизии_{username}"));
             } else {
                 if(firstEl != null) {
-                filters.Add(
-                    _parameterFilterProvider.GetHighlightFilter(
-                        _document,
-                        firstEl,
-                        $"{FiltersNamePrefix}не_первый_элемент_{username}"));
+                    filters.Add(
+                        _parameterFilterProvider.GetHighlightFilter(
+                            _document,
+                            firstEl,
+                            $"{FiltersNamePrefix}не_первый_элемент_{username}"));
                 }
                 if(secondEl != null) {
-                filters.Add(
-                    _parameterFilterProvider.GetHighlightFilter(
-                        _document,
-                        secondEl,
-                        $"{FiltersNamePrefix}не_второй_элемент_{username}"));
-            }
+                    filters.Add(
+                        _parameterFilterProvider.GetHighlightFilter(
+                            _document,
+                            secondEl,
+                            $"{FiltersNamePrefix}не_второй_элемент_{username}"));
+                }
             }
             return filters;
         }


### PR DESCRIPTION
# Обновления

Из-за невозможности совместной работы в файле отчета о коллизиях на общем диске, все файлы отчетов о коллизиях сохраняются теперь всегда в документы пользователя. Таки мобразом каждый пользователь будет всегда работать только со своей версией отчета.