### PR TITLE
RevitDeclarations: Обновлен список выводимых параметров для количества комнат 

### DIFF
--- a/src/RevitDeclarations/Models/Export/DeclarationData/DeclarationDataTable.cs
+++ b/src/RevitDeclarations/Models/Export/DeclarationData/DeclarationDataTable.cs
@@ -62,8 +62,5 @@ namespace RevitDeclarations.Models {
         protected abstract void FillTableHeader();
         protected abstract void FillMainTable();
         protected abstract void FillAdditionalInfo();
-
-
     }
-
 }

--- a/src/RevitDeclarations/Models/RevitRepository.cs
+++ b/src/RevitDeclarations/Models/RevitRepository.cs
@@ -154,5 +154,19 @@ namespace RevitDeclarations.Models {
                 .Where(x => x.StorageType == storageType)
                 .ToList();
         }
+
+        public IReadOnlyCollection<Parameter> GetRoomsParamsByDataType(RevitDocumentViewModel document,
+                                                                       ForgeTypeId dataType) {
+            Room room = document?.Room;
+
+            if(room == null) {
+                return new List<Parameter>();
+            }
+
+            return room
+                .GetOrderedParameters()
+                .Where(x => x.Definition.GetDataType() == dataType)
+                .ToList();
+        }
     }
 }

--- a/src/RevitDeclarations/Models/Rooms/Apartment.cs
+++ b/src/RevitDeclarations/Models/Rooms/Apartment.cs
@@ -58,7 +58,7 @@ namespace RevitDeclarations.Models {
         [JsonProperty("area_non_summer")]
         public double AreaNonSummer => _firstRoom.GetAreaParamValue(_settings.ApartmentAreaNonSumParam, _accuracyForArea);
         [JsonProperty("room_size")]
-        public int RoomsAmount => _firstRoom.GetIntParamValue(_settings.RoomsAmountParam);
+        public double RoomsAmount => _firstRoom.GetIntAndCurrencyParamValue(_settings.RoomsAmountParam);
         [JsonProperty("building_number")]
         public string BuildingNumber => _firstRoom.GetTextParamValue(_settings.BuildingNumberParam);
         [JsonProperty("construction_works")]

--- a/src/RevitDeclarations/Models/Rooms/RoomElement.cs
+++ b/src/RevitDeclarations/Models/Rooms/RoomElement.cs
@@ -77,8 +77,12 @@ namespace RevitDeclarations.Models
             return ParamConverter.ConvertLength(value, accuracy);
         }
 
-        public int GetIntParamValue(Parameter parameter) {
-            return RevitRoom.GetParamValueOrDefault<int>(parameter.Definition.Name);
+        public double GetIntAndCurrencyParamValue(Parameter parameter) {
+            if(parameter.StorageType == StorageType.Double) {
+                return RevitRoom.GetParamValueOrDefault<double>(parameter.Definition.Name);
+            } else {
+                return RevitRoom.GetParamValueOrDefault<int>(parameter.Definition.Name);
+            }
         }
 
         public IReadOnlyList<ElementId> GetBoundaries() {

--- a/src/RevitDeclarations/ViewModels/ParametersViewModels/ApartmentsParamsVM.cs
+++ b/src/RevitDeclarations/ViewModels/ParametersViewModels/ApartmentsParamsVM.cs
@@ -141,7 +141,7 @@ namespace RevitDeclarations.ViewModels {
                 .FirstOrDefault(x => x.Definition.Name == apartsConfigSettings.ApartmentAreaCoefParam);
             SelectedApartAreaLivingParam = DoubleParameters
                 .FirstOrDefault(x => x.Definition.Name == apartsConfigSettings.ApartmentAreaLivingParam);
-            SelectedRoomsAmountParam = IntParameters
+            SelectedRoomsAmountParam = IntAndCurrencyParameters
                 .FirstOrDefault(x => x.Definition.Name == apartsConfigSettings.RoomsAmountParam);
             ProjectName = apartsConfigSettings.ProjectNameID;
             SelectedApartAreaNonSumParam = DoubleParameters

--- a/src/RevitDeclarations/ViewModels/ParametersViewModels/ParametersViewModel.cs
+++ b/src/RevitDeclarations/ViewModels/ParametersViewModels/ParametersViewModel.cs
@@ -20,7 +20,7 @@ namespace RevitDeclarations.ViewModels {
 
         private IReadOnlyCollection<Parameter> _textParameters;
         private IReadOnlyCollection<Parameter> _doubleParameters;
-        private IReadOnlyCollection<Parameter> _intParameters;
+        private IReadOnlyCollection<Parameter> _intAndCurrencyParameters;
 
         private Parameter _selectedFilterRoomsParam;
         private string _filterRoomsValue;
@@ -46,12 +46,7 @@ namespace RevitDeclarations.ViewModels {
 
             SelectedDocument = RevitDocuments.FirstOrDefault();
 
-            _textParameters = _revitRepository
-                .GetRoomsParamsByStorageType(SelectedDocument, StorageType.String);
-            _doubleParameters = _revitRepository
-                .GetRoomsParamsByStorageType(SelectedDocument, StorageType.Double);
-            _intParameters = _revitRepository
-                .GetRoomsParamsByStorageType(SelectedDocument, StorageType.Integer);
+            UpdateParameters();
 
             _filterRoomsValues = new ObservableCollection<FilterRoomValueVM>();
 
@@ -70,20 +65,17 @@ namespace RevitDeclarations.ViewModels {
             get => _selectedDocument;
             set {
                 RaiseAndSetIfChanged(ref _selectedDocument, value);
-                _textParameters = _revitRepository
-                    .GetRoomsParamsByStorageType(SelectedDocument, StorageType.String);
-                _doubleParameters = _revitRepository
-                    .GetRoomsParamsByStorageType(SelectedDocument, StorageType.Double);
-                _intParameters = _revitRepository
-                    .GetRoomsParamsByStorageType(SelectedDocument, StorageType.Integer);
+
+                UpdateParameters();
+
                 OnPropertyChanged(nameof(TextParameters));
                 OnPropertyChanged(nameof(DoubleParameters));
-                OnPropertyChanged(nameof(IntParameters));
+                OnPropertyChanged(nameof(IntAndCurrencyParameters));
             }
         }
         public IReadOnlyCollection<Parameter> TextParameters => _textParameters;
         public IReadOnlyCollection<Parameter> DoubleParameters => _doubleParameters;
-        public IReadOnlyCollection<Parameter> IntParameters => _intParameters;
+        public IReadOnlyCollection<Parameter> IntAndCurrencyParameters => _intAndCurrencyParameters;
 
         public Parameter SelectedFilterRoomsParam {
             get => _selectedFilterRoomsParam;
@@ -183,5 +175,16 @@ namespace RevitDeclarations.ViewModels {
         public virtual void SetCompanyParamConfig(object obj) { }
 
         public virtual void SetParametersFromConfig(ProjectSettings configSettings) { }
+
+        private void UpdateParameters() {
+            _textParameters = _revitRepository
+                .GetRoomsParamsByStorageType(SelectedDocument, StorageType.String);
+            _doubleParameters = _revitRepository
+                .GetRoomsParamsByStorageType(SelectedDocument, StorageType.Double);
+            _intAndCurrencyParameters = _revitRepository
+                .GetRoomsParamsByDataType(SelectedDocument, SpecTypeId.Int.Integer)
+                .Concat(_revitRepository.GetRoomsParamsByDataType(SelectedDocument, SpecTypeId.Currency))
+                .ToList();
+        }
     }
 }

--- a/src/RevitDeclarations/Views/TabItems/ParamsApartmentsTabItem.xaml
+++ b/src/RevitDeclarations/Views/TabItems/ParamsApartmentsTabItem.xaml
@@ -544,7 +544,7 @@
                 Grid.Column="2"
                 Grid.Row="8"
                 Margin="10, 0"
-                ItemsSource="{Binding IntParameters}"
+                ItemsSource="{Binding IntAndCurrencyParameters}"
                 DisplayMemberPath="Definition.Name"
                 SelectedItem="{Binding SelectedRoomsAmountParam}"/>
 


### PR DESCRIPTION
В плагине RevitRooms для параметра количества комнат изменен тип данных на "Денежная единица".
Соответственно для этого плагина должны теперь выводиться параметры и типа "Целое", и типа "Денежная единица".

Для этих изменений исправлен код:
- Добавлен метод получения параметров по ForgeTypeId 
- Изменен тип данных с int на double для свойства RoomsAmount 
- При получении значения параметра добавлена проверка на StorageType