### PR TITLE
RevitPylonDocumentation: Изменение фильтрации каркаса

### DIFF
--- a/src/RevitPylonDocumentation/Models/PluginConfig.cs
+++ b/src/RevitPylonDocumentation/Models/PluginConfig.cs
@@ -402,7 +402,6 @@ namespace RevitPylonDocumentation.Models {
         public string TransverseViewThirdElevation { get; set; }
         public string TransverseViewTemplateName { get; set; }
         public string TransverseRebarViewTemplateName { get; set; }
-        public string TransverseRebarViewSecondTemplateName { get; set; }
         public string TransverseViewXOffset { get; set; }
         public string TransverseViewYOffset { get; set; }
         public string ViewFamilyTypeName { get; set; }

--- a/src/RevitPylonDocumentation/Models/RebarFinder.cs
+++ b/src/RevitPylonDocumentation/Models/RebarFinder.cs
@@ -38,7 +38,7 @@ namespace RevitPylonDocumentation.Models {
                 if(rebarType is null) {
                     continue;
                 }
-                if(rebarType.FamilyName.Equals("IFC_Пилон_Верт.Арм.")) {
+                if(rebarType.FamilyName.Equals("IFC_Пилон_Верт.Арм.") || rebarType.FamilyName.Contains("IFC_Каркас_Пилон")) {
                     return rebar as FamilyInstance;
                 }
             }


### PR DESCRIPTION
Были изменены правила поиска на виде экземпляра семейства каркаса армирования в связи с тем, что были разработаны новые семейства. По ТЗ фильтрацию старого семейства временно оставили