### PR TITLE
RevitMechanicalSpecification: Правка группирований

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -188,7 +188,8 @@
           "description": "Plugin type name",
           "enum": [
             "Default",
-            "DevExpress"
+            "DevExpress",
+            "WpfUI"
           ]
         },
         "PublishDirectory": {

--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamGroupFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamGroupFiller.cs
@@ -111,7 +111,7 @@ namespace RevitMechanicalSpecification.Models.Fillers {
         private string GetDetailedGroup(SpecificationElement specificationElement) {
             string name = specificationElement.ElementName;
             string famylyTypeName = string.Empty;
-            // Имя типоразмера имеет значение только для узлов. Обычные элементы могут быть разного типа, но одинакового типоразмера. 
+            // Имя типоразмера имеет значение только для узлов. Обычные элементы могут быть разного типа, но с одинаковыми экземплярными параметрами. 
             if(specificationElement.ElementType.IsExistsParam(Config.IsManiFoldParamName)
                 && specificationElement.ElementType.GetParamValue<int>(Config.IsManiFoldParamName) == 1) {
                 famylyTypeName = specificationElement.Element.GetParam(BuiltInParameter.ELEM_FAMILY_AND_TYPE_PARAM).AsValueString();

--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamGroupFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamGroupFiller.cs
@@ -110,6 +110,12 @@ namespace RevitMechanicalSpecification.Models.Fillers {
         /// </summary>
         private string GetDetailedGroup(SpecificationElement specificationElement) {
             string name = specificationElement.ElementName;
+            string famylyTypeName = string.Empty;
+            // Имя типоразмера имеет значение только для узлов. Обычные элементы могут быть разного типа, но одинакового типоразмера. 
+            if(specificationElement.ElementType.IsExistsParam(Config.IsManiFoldParamName)
+                && specificationElement.ElementType.GetParamValue<int>(Config.IsManiFoldParamName) == 1) {
+                famylyTypeName = specificationElement.Element.GetParam(BuiltInParameter.ELEM_FAMILY_AND_TYPE_PARAM).AsValueString();
+            }
             string mark = !string.IsNullOrEmpty(specificationElement.ElementMark)
                    ? specificationElement.ElementMark
                    : specificationElement.GetTypeOrInstanceParamStringValue(Config.OriginalParamNameMark);
@@ -117,7 +123,7 @@ namespace RevitMechanicalSpecification.Models.Fillers {
             string code = specificationElement.GetTypeOrInstanceParamStringValue(Config.OriginalParamNameCode);
             string creator = specificationElement.GetTypeOrInstanceParamStringValue(Config.OriginalParamNameCreator);
 
-            return $"{name}_{mark}_{code}_{creator}";
+            return $"{famylyTypeName}_{name}_{mark}_{code}_{creator}";
         }
     }
 }

--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamGroupFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamGroupFiller.cs
@@ -3,6 +3,8 @@ using System.Windows;
 
 using Autodesk.Revit.DB;
 
+using dosymep.Bim4Everyone;
+using dosymep.Bim4Everyone.SystemParams;
 using dosymep.Revit;
 
 using Ninject.Planning.Targets;
@@ -112,9 +114,11 @@ namespace RevitMechanicalSpecification.Models.Fillers {
             string name = specificationElement.ElementName;
             string famylyTypeName = string.Empty;
             // Имя типоразмера имеет значение только для узлов. Обычные элементы могут быть разного типа, но с одинаковыми экземплярными параметрами. 
-            if(specificationElement.ElementType.IsExistsParam(Config.IsManiFoldParamName)
-                && specificationElement.ElementType.GetParamValue<int>(Config.IsManiFoldParamName) == 1) {
-                famylyTypeName = specificationElement.Element.GetParam(BuiltInParameter.ELEM_FAMILY_AND_TYPE_PARAM).AsValueString();
+            if(specificationElement.ElementType.GetParamValueOrDefault<int>(Config.IsManiFoldParamName, 0) == 1) {                
+                RevitParam familyTypeParam = SystemParamsConfig.Instance.CreateRevitParam(
+                    Document, 
+                    BuiltInParameter.ELEM_FAMILY_AND_TYPE_PARAM);
+                famylyTypeName = specificationElement.Element.GetParamValueString(familyTypeParam);
             }
             string mark = !string.IsNullOrEmpty(specificationElement.ElementMark)
                    ? specificationElement.ElementMark


### PR DESCRIPTION
Модификация группирования для работы с узлами с одинаковым именем но различным содержимым. Сортировка должна идти по имени типоразмера узлов. 