### PR TITLE
RevitClashes: Переделано получение иконок статусов коллизий

### DIFF
--- a/src/RevitClashDetective/Resources/ClashStatusToImageConverter.cs
+++ b/src/RevitClashDetective/Resources/ClashStatusToImageConverter.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media.Imaging;
+
+using DevExpress.Mvvm;
+
+namespace RevitClashDetective.Resources {
+    internal class ClashStatusToImageConverter : IValueConverter {
+        private static readonly BitmapImage _high = new BitmapImage(
+            new Uri("pack://application:,,,/DevExpress.Images.v21.2;component/Images/XAF/State_Priority_High.png"));
+        private static readonly BitmapImage _low = new BitmapImage(
+            new Uri("pack://application:,,,/DevExpress.Images.v21.2;component/Images/XAF/State_Priority_Low.png"));
+        private static readonly BitmapImage _normal = new BitmapImage(
+            new Uri("pack://application:,,,/DevExpress.Images.v21.2;component/Images/XAF/State_Priority_Normal.png"));
+
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            if(value is EnumMemberInfo enumInfo) {
+                return GetImage(enumInfo.Name);
+            }
+
+            return null;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
+            throw new NotImplementedException();
+        }
+
+        private BitmapImage GetImage(string statusName) {
+            switch(statusName) {
+                case "Активно":
+                    return _high;
+                case "Проанализировано":
+                    return _low;
+                case "Исправлено":
+                    return _normal;
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/src/RevitClashDetective/Views/NavigatorView.xaml
+++ b/src/RevitClashDetective/Views/NavigatorView.xaml
@@ -13,6 +13,7 @@
                            xmlns:base="clr-namespace:dosymep.WPF.Views"
                            xmlns:converters="clr-namespace:dosymep.WPF.Converters"
                            xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
+                           xmlns:res="clr-namespace:RevitClashDetective.Resources"
                            mc:Ignorable="d"
                            Title="Навигатор"
                            Height="450"
@@ -27,6 +28,7 @@
     </b:Interaction.Triggers>
     <base:ThemedPlatformWindow.Resources>
         <converters:IndexConverter x:Key="IndexConverter" />
+        <res:ClashStatusToImageConverter x:Key="ClashStatusToImageConverter" />
         <Style TargetType="dxg:GridColumn"
                x:Key="ReadOnlyColumn">
             <Setter Property="ReadOnly"
@@ -122,7 +124,19 @@
                                               IsTextEditable="False"
                                               EditMode="InplaceActive"
                                               EditValue="{Binding Row.ClashStatus, UpdateSourceTrigger=PropertyChanged}"
-                                              ItemsSource="{dxe:EnumItemsSource EnumType={x:Type m:ClashStatus}}" />
+                                              ItemsSource="{dxe:EnumItemsSource EnumType={x:Type m:ClashStatus}}">
+                                <dxe:ComboBoxEdit.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal">
+                                            <Image Width="16"
+                                                   Height="16"
+                                                   Source="{Binding ., Converter={StaticResource ClashStatusToImageConverter}}"
+                                                   Margin="0 0 4 0" />
+                                            <TextBlock Text="{Binding}" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </dxe:ComboBoxEdit.ItemTemplate>
+                            </dxe:ComboBoxEdit>
                         </DataTemplate>
                     </dxg:GridColumn.CellTemplate>
                 </dxg:GridColumn>

--- a/src/RevitClashes/Models/Clashes/ClashModel.cs
+++ b/src/RevitClashes/Models/Clashes/ClashModel.cs
@@ -5,8 +5,6 @@ using System.Linq;
 
 using Autodesk.Revit.DB;
 
-using DevExpress.Mvvm.DataAnnotations;
-
 using dosymep.Revit;
 
 using pyRevitLabs.Json;
@@ -156,11 +154,11 @@ namespace RevitClashDetective.Models.Clashes {
     }
 
     internal enum ClashStatus {
-        [Display(Name = "Активно"), Image("pack://application:,,,/DevExpress.Images.v21.2;component/Images/XAF/State_Priority_High.png")]
+        [Display(Name = "Активно")]
         Active,
-        [Display(Name = "Проанализировано"), Image("pack://application:,,,/DevExpress.Images.v21.2;component/Images/XAF/State_Priority_Low.png")]
+        [Display(Name = "Проанализировано")]
         Analized,
-        [Display(Name = "Исправлено"), Image("pack://application:,,,/DevExpress.Images.v21.2;component/Images/XAF/State_Priority_Normal.png")]
+        [Display(Name = "Исправлено")]
         Solved
     }
 }


### PR DESCRIPTION
Вместо использования атрибута `DevExpress.Mvvm.DataAnnotations.Image` в `ClashStatus` сделан отдельный конвертер