### PR TITLE
RevitClashDetective: Добавлены столбцы для % пересечения каждого элемента коллизии

### DIFF
--- a/src/RevitClashDetective/Views/NavigatorView.xaml
+++ b/src/RevitClashDetective/Views/NavigatorView.xaml
@@ -178,8 +178,15 @@
                                 Header="Имя файла 2"
                                 FieldName="SecondDocumentName" />
                 <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
-                                Header="% пересечения"
-                                FieldName="IntersectionPercentage">
+                                Header="% пересечения 1"
+                                FieldName="MainElementIntersectionPercentage">
+                    <dxg:GridColumn.EditSettings>
+                        <dxe:TextEditSettings HorizontalContentAlignment="Left" />
+                    </dxg:GridColumn.EditSettings>
+                </dxg:GridColumn>
+                <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
+                                Header="% пересечения 2"
+                                FieldName="SecondElementIntersectionPercentage">
                     <dxg:GridColumn.EditSettings>
                         <dxe:TextEditSettings HorizontalContentAlignment="Left" />
                     </dxg:GridColumn.EditSettings>


### PR DESCRIPTION
 # Обновления
 
В навигатор по коллизиям вместо одного столбца с % пересечения объема относительно меньшего элемента добавлено 2 столбца для % пересечения объема по каждому элементу соответственно: 
 
<img width="500" alt="image" src="https://github.com/user-attachments/assets/34f7c295-ca3f-4a8a-a9be-8e11c52e0057" />

