### PR TITLE
RevitBatchPrint: Исправить ошибку падения Revit

### DIFF
--- a/src/RevitBatchPrint/BatchPrintCommand.cs
+++ b/src/RevitBatchPrint/BatchPrintCommand.cs
@@ -42,6 +42,9 @@ public class BatchPrintCommand : BasePluginCommand {
         kernel.Bind<PluginConfig>()
             .ToMethod(c => PluginConfig.GetPluginConfig(c.Kernel.Get<IConfigSerializer>()));
 
+        // Настройка сервиса окошек сообщений
+        kernel.UseWpfUIMessageBox<MainViewModel>();
+
         // Используем сервис обновления тем для WinUI
         kernel.UseWpfUIThemeUpdater();
 

--- a/src/RevitBatchPrint/Models/RevitRepository.cs
+++ b/src/RevitBatchPrint/Models/RevitRepository.cs
@@ -10,6 +10,8 @@ using Autodesk.Revit.UI;
 using dosymep.Revit;
 using dosymep.SimpleServices;
 
+using InvalidOperationException = Autodesk.Revit.Exceptions.InvalidOperationException;
+
 namespace RevitBatchPrint.Models {
     internal class RevitRepository {
         private readonly PrintManager _printManager;
@@ -102,7 +104,8 @@ namespace RevitBatchPrint.Models {
             FamilyInstance familyInstance = GetTitleBlock(viewSheet);
 
             if(familyInstance is null) {
-                throw new ArgumentNullException(nameof(familyInstance));
+                throw new System.InvalidOperationException(
+                    _localizationService.GetLocalizedString("ViewSheet.NotFoundTitleBlock", viewSheet.Name));
             }
 
             double sheetWidth = (double) familyInstance.GetParamValueOrDefault(BuiltInParameter.SHEET_WIDTH);

--- a/src/RevitBatchPrint/Models/RevitRepository.cs
+++ b/src/RevitBatchPrint/Models/RevitRepository.cs
@@ -95,9 +95,10 @@ namespace RevitBatchPrint.Models {
                 .Where(item => item.CanBePrinted)
                 .Where(item => item.IsTemplate == false)
                 .Where(item => item.ViewType == ViewType.DrawingSheet)
-                .Select(item => (item, 
-                    GetValueOrDefault(item.Id, titleBlocks), 
+                .Select(item => (item,
+                    GetValueOrDefault(item.Id, titleBlocks),
                     GetValueOrDefault(item.Id, viewPorts)))
+                .Where(item => item.Item2 is not null)
                 .ToList();
         }
 

--- a/src/RevitBatchPrint/Models/RevitRepository.cs
+++ b/src/RevitBatchPrint/Models/RevitRepository.cs
@@ -114,11 +114,12 @@ namespace RevitBatchPrint.Models {
         private Dictionary<ElementId, FamilyInstance> GetFamilyInstances() {
             return new FilteredElementCollector(Document)
                 .OfClass(typeof(FamilyInstance))
+                .OfCategory(BuiltInCategory.OST_TitleBlocks)
                 .OfType<FamilyInstance>()
                 .GroupBy(item => item.OwnerViewId)
                 .ToDictionary(item => item.Key, item => item.FirstOrDefault());
         }
-        
+
         public PrintSheetSettings GetPrintSettings(FamilyInstance familyInstance) {
             double sheetWidth = (double) familyInstance.GetParamValueOrDefault(BuiltInParameter.SHEET_WIDTH);
             double sheetHeight = (double) familyInstance.GetParamValueOrDefault(BuiltInParameter.SHEET_HEIGHT);

--- a/src/RevitBatchPrint/Models/RevitRepository.cs
+++ b/src/RevitBatchPrint/Models/RevitRepository.cs
@@ -88,6 +88,7 @@ namespace RevitBatchPrint.Models {
                 .Where(item => item.CanBePrinted)
                 .Where(item => item.IsTemplate == false)
                 .Where(item => item.ViewType == ViewType.DrawingSheet)
+                .Where(item => GetTitleBlock(item) != null)
                 .ToList();
         }
 

--- a/src/RevitBatchPrint/ViewModels/AlbumViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/AlbumViewModel.cs
@@ -22,6 +22,7 @@ internal sealed class AlbumViewModel : BaseViewModel {
     private bool? _isSelected;
     private ObservableCollection<SheetViewModel> _mainSheets;
     private ObservableCollection<SheetViewModel> _filteredSheets;
+    private ObservableCollection<string> _viewsWithoutCrop;
 
     public AlbumViewModel(
         string albumName,
@@ -60,6 +61,18 @@ internal sealed class AlbumViewModel : BaseViewModel {
         get => _filteredSheets;
         set => this.RaiseAndSetIfChanged(ref _filteredSheets, value);
     }
+
+    public ObservableCollection<string> ViewsWithoutCrop {
+        get => _viewsWithoutCrop;
+        set => this.RaiseAndSetIfChanged(ref _viewsWithoutCrop, value);
+    }
+
+    public string ViewsWithoutCropText =>
+        ViewsWithoutCrop.Count == 0
+            ? null
+            : " - "
+              + string.Join(" - " + Environment.NewLine, ViewsWithoutCrop.Take(5))
+              + (ViewsWithoutCrop.Count > 5 ? ".." : null);
 
     public void FilterSheets(string searchText) {
         if(string.IsNullOrWhiteSpace(searchText)) {

--- a/src/RevitBatchPrint/ViewModels/AlbumViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/AlbumViewModel.cs
@@ -18,6 +18,7 @@ namespace RevitBatchPrint.ViewModels;
 
 internal sealed class AlbumViewModel : BaseViewModel {
     private readonly IPrintContext _printContext;
+    private readonly ILocalizationService _localizationService;
 
     private bool? _isSelected;
     private ObservableCollection<SheetViewModel> _mainSheets;
@@ -29,6 +30,7 @@ internal sealed class AlbumViewModel : BaseViewModel {
         IPrintContext printContext,
         ILocalizationService localizationService) {
         _printContext = printContext;
+        _localizationService = localizationService;
 
         IsSelected = false;
 
@@ -70,7 +72,8 @@ internal sealed class AlbumViewModel : BaseViewModel {
     public string ViewsWithoutCropText =>
         ViewsWithoutCrop.Count == 0
             ? null
-            : " - "
+            : _localizationService.GetLocalizedString("TreeView.SheetsWithoutCropToolTip")
+              + Environment.NewLine + " - "
               + string.Join(Environment.NewLine + " - ", ViewsWithoutCrop.Take(5))
               + (ViewsWithoutCrop.Count > 5 ? "..." : null);
 

--- a/src/RevitBatchPrint/ViewModels/AlbumViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/AlbumViewModel.cs
@@ -18,6 +18,7 @@ namespace RevitBatchPrint.ViewModels;
 
 internal sealed class AlbumViewModel : BaseViewModel {
     private readonly IPrintContext _printContext;
+    private readonly IMessageBoxService _messageBoxService;
     private readonly ILocalizationService _localizationService;
 
     private bool? _isSelected;
@@ -28,8 +29,10 @@ internal sealed class AlbumViewModel : BaseViewModel {
     public AlbumViewModel(
         string albumName,
         IPrintContext printContext,
+        IMessageBoxService messageBoxService,
         ILocalizationService localizationService) {
         _printContext = printContext;
+        _messageBoxService = messageBoxService;
         _localizationService = localizationService;
 
         IsSelected = false;
@@ -116,6 +119,17 @@ internal sealed class AlbumViewModel : BaseViewModel {
     }
 
     private void ExecutePrintExport() {
+        if(MainSheets.Any(item => item.ViewsWithoutCrop.Count > 0)) {
+            var messageBoxResult = _messageBoxService.Show(
+                _localizationService.GetLocalizedString("MainWindow.SheetsWithoutCropMessage"), 
+                _localizationService.GetLocalizedString("MainWindow.Title"),
+                MessageBoxButton.YesNo, MessageBoxImage.Question);
+
+            if(messageBoxResult == MessageBoxResult.No) {
+                throw new OperationCanceledException();
+            }
+        }
+        
         _printContext.ExecutePrintExport(MainSheets);
     }
 

--- a/src/RevitBatchPrint/ViewModels/AlbumViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/AlbumViewModel.cs
@@ -71,8 +71,8 @@ internal sealed class AlbumViewModel : BaseViewModel {
         ViewsWithoutCrop.Count == 0
             ? null
             : " - "
-              + string.Join(" - " + Environment.NewLine, ViewsWithoutCrop.Take(5))
-              + (ViewsWithoutCrop.Count > 5 ? ".." : null);
+              + string.Join(Environment.NewLine + " - ", ViewsWithoutCrop.Take(5))
+              + (ViewsWithoutCrop.Count > 5 ? "..." : null);
 
     public void FilterSheets(string searchText) {
         if(string.IsNullOrWhiteSpace(searchText)) {

--- a/src/RevitBatchPrint/ViewModels/AlbumViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/AlbumViewModel.cs
@@ -123,7 +123,7 @@ internal sealed class AlbumViewModel : BaseViewModel {
             var messageBoxResult = _messageBoxService.Show(
                 _localizationService.GetLocalizedString("MainWindow.SheetsWithoutCropMessage"), 
                 _localizationService.GetLocalizedString("MainWindow.Title"),
-                MessageBoxButton.YesNo, MessageBoxImage.Question);
+                MessageBoxButton.YesNo, MessageBoxImage.Warning);
 
             if(messageBoxResult == MessageBoxResult.No) {
                 throw new OperationCanceledException();

--- a/src/RevitBatchPrint/ViewModels/MainViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/MainViewModel.cs
@@ -270,7 +270,7 @@ internal class MainViewModel : BaseViewModel, IPrintContext {
     }
 
     private SheetViewModel CreateSheet(ViewSheet viewSheet, AlbumViewModel album) {
-        return new SheetViewModel(viewSheet, album, this) {
+        return new SheetViewModel(viewSheet, album, this, _localizationService) {
             PrintSheetSettings = _revitRepository.GetPrintSettings(viewSheet),
             ViewsWithoutCrop = new ObservableCollection<string>(
                 _revitRepository.GetViewsWithoutCrop(viewSheet)

--- a/src/RevitBatchPrint/ViewModels/MainViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/MainViewModel.cs
@@ -265,7 +265,10 @@ internal class MainViewModel : BaseViewModel, IPrintContext {
 
     private SheetViewModel CreateSheet(ViewSheet viewSheet, AlbumViewModel album) {
         return new SheetViewModel(viewSheet, album, this) {
-            PrintSheetSettings = _revitRepository.GetPrintSettings(viewSheet)
+            PrintSheetSettings = _revitRepository.GetPrintSettings(viewSheet),
+            ViewsWithoutCrop = new ObservableCollection<string>(
+                _revitRepository.GetViewsWithoutCrop(viewSheet)
+                    .Select(item => item.Name))
         };
     }
 

--- a/src/RevitBatchPrint/ViewModels/MainViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/MainViewModel.cs
@@ -67,7 +67,7 @@ internal class MainViewModel : BaseViewModel, IPrintContext {
         MessageBoxService = messageBoxService;
 
         LoadViewCommand = RelayCommand.Create(LoadView);
-        AcceptVewCommand = RelayCommand.Create(AcceptView, CanAcceptView);
+        AcceptVewCommand = RelayCommand.Create<Window>(AcceptView, CanAcceptView);
 
         ChangeModeCommand = RelayCommand.Create(ChangeMode);
         ChooseSaveFileCommand = RelayCommand.Create(ChooseSaveFile);
@@ -171,7 +171,7 @@ internal class MainViewModel : BaseViewModel, IPrintContext {
         }
     }
 
-    private void AcceptView() {
+    private void AcceptView(Window window) {
         SaveConfig();
 
         IEnumerable<SheetViewModel> sheets = MainAlbums
@@ -191,6 +191,7 @@ internal class MainViewModel : BaseViewModel, IPrintContext {
         }
 
         ExecutePrintExport(sheets);
+        window.DialogResult = true;
     }
 
     public void ExecutePrintExport(IEnumerable<SheetViewModel> sheets) {
@@ -205,7 +206,7 @@ internal class MainViewModel : BaseViewModel, IPrintContext {
         return CanAcceptView(false);
     }
 
-    private bool CanAcceptView() {
+    private bool CanAcceptView(Window window) {
         return CanAcceptView(true);
     }
 

--- a/src/RevitBatchPrint/ViewModels/MainViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/MainViewModel.cs
@@ -252,7 +252,13 @@ internal class MainViewModel : BaseViewModel, IPrintContext {
         SheetViewModel[] sheets = CreateSheetCollection(viewModel, viewSheets);
         viewModel.MainSheets = new ObservableCollection<SheetViewModel>(sheets);
         viewModel.FilteredSheets = new ObservableCollection<SheetViewModel>(sheets);
-
+        
+        viewModel.ViewsWithoutCrop = new ObservableCollection<string>(
+            viewModel.MainSheets
+                .Where(item => item.ViewsWithoutCrop.Count > 0)
+                .Select(item => item.Name)
+                .ToList());
+        
         return viewModel;
     }
 

--- a/src/RevitBatchPrint/ViewModels/MainViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/MainViewModel.cs
@@ -183,7 +183,7 @@ internal class MainViewModel : BaseViewModel, IPrintContext {
             var messageBoxResult = MessageBoxService.Show(
                 _localizationService.GetLocalizedString("MainWindow.SheetsWithoutCropMessage"), 
                 _localizationService.GetLocalizedString("MainWindow.Title"),
-                MessageBoxButton.YesNo, MessageBoxImage.Question);
+                MessageBoxButton.YesNo, MessageBoxImage.Warning);
 
             if(messageBoxResult == MessageBoxResult.No) {
                 throw new OperationCanceledException();

--- a/src/RevitBatchPrint/ViewModels/SheetViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/SheetViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Windows;
 using System.Windows.Input;
 
 using Autodesk.Revit.DB;
@@ -16,6 +17,7 @@ namespace RevitBatchPrint.ViewModels;
 internal sealed class SheetViewModel : BaseViewModel {
     private readonly ViewSheet _viewSheet;
     private readonly IPrintContext _printContext;
+    private readonly IMessageBoxService _messageBoxService;
     private readonly ILocalizationService _localizationService;
 
     private string _errorText;
@@ -27,9 +29,11 @@ internal sealed class SheetViewModel : BaseViewModel {
         ViewSheet viewSheet,
         AlbumViewModel album,
         IPrintContext printContext,
+        IMessageBoxService messageBoxService,
         ILocalizationService localizationService) {
         _viewSheet = viewSheet;
         _printContext = printContext;
+        _messageBoxService = messageBoxService;
         _localizationService = localizationService;
 
         Name = _viewSheet.Name;
@@ -76,6 +80,17 @@ internal sealed class SheetViewModel : BaseViewModel {
     }
     
     private void ExecutePrintExport() {
+        if(ViewsWithoutCrop.Count > 0) {
+            var messageBoxResult = _messageBoxService.Show(
+                _localizationService.GetLocalizedString("MainWindow.ViewsWithoutCropMessage"), 
+                _localizationService.GetLocalizedString("MainWindow.Title"),
+                MessageBoxButton.YesNo, MessageBoxImage.Question);
+
+            if(messageBoxResult == MessageBoxResult.No) {
+                throw new OperationCanceledException();
+            }
+        }
+        
         _printContext.ExecutePrintExport([this]);
     }
     

--- a/src/RevitBatchPrint/ViewModels/SheetViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/SheetViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Windows.Input;
 
 using Autodesk.Revit.DB;
@@ -59,7 +60,9 @@ internal sealed class SheetViewModel : BaseViewModel {
     public string ViewsWithoutCropText =>
         ViewsWithoutCrop.Count == 0
             ? null
-            : " - " + string.Join(" - " + Environment.NewLine, ViewsWithoutCrop);
+            : " - "
+              + string.Join(" - " + Environment.NewLine, ViewsWithoutCrop.Take(5))
+              + (ViewsWithoutCrop.Count > 5 ? ".." : null);
     
     public SheetElement CreateSheetElement() {
         return new SheetElement() {ViewSheet = _viewSheet, PrintSheetSettings = PrintSheetSettings};

--- a/src/RevitBatchPrint/ViewModels/SheetViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/SheetViewModel.cs
@@ -61,8 +61,8 @@ internal sealed class SheetViewModel : BaseViewModel {
         ViewsWithoutCrop.Count == 0
             ? null
             : " - "
-              + string.Join(" - " + Environment.NewLine, ViewsWithoutCrop.Take(5))
-              + (ViewsWithoutCrop.Count > 5 ? ".." : null);
+              + string.Join(Environment.NewLine + " - ", ViewsWithoutCrop.Take(5))
+              + (ViewsWithoutCrop.Count > 5 ? "..." : null);
     
     public SheetElement CreateSheetElement() {
         return new SheetElement() {ViewSheet = _viewSheet, PrintSheetSettings = PrintSheetSettings};

--- a/src/RevitBatchPrint/ViewModels/SheetViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/SheetViewModel.cs
@@ -84,7 +84,7 @@ internal sealed class SheetViewModel : BaseViewModel {
             var messageBoxResult = _messageBoxService.Show(
                 _localizationService.GetLocalizedString("MainWindow.ViewsWithoutCropMessage"), 
                 _localizationService.GetLocalizedString("MainWindow.Title"),
-                MessageBoxButton.YesNo, MessageBoxImage.Question);
+                MessageBoxButton.YesNo, MessageBoxImage.Warning);
 
             if(messageBoxResult == MessageBoxResult.No) {
                 throw new OperationCanceledException();

--- a/src/RevitBatchPrint/ViewModels/SheetViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/SheetViewModel.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.ObjectModel;
 using System.Windows.Input;
 
 using Autodesk.Revit.DB;
@@ -17,6 +19,7 @@ internal sealed class SheetViewModel : BaseViewModel {
     private string _errorText;
     private bool _isSelected;
     private PrintSheetSettings _printSheetSettings;
+    private ObservableCollection<string> _viewsWithoutCrop;
 
     public SheetViewModel(ViewSheet viewSheet, AlbumViewModel album, IPrintContext printContext) {
         _viewSheet = viewSheet;
@@ -48,6 +51,16 @@ internal sealed class SheetViewModel : BaseViewModel {
         set => this.RaiseAndSetIfChanged(ref _printSheetSettings, value);
     }
 
+    public ObservableCollection<string> ViewsWithoutCrop {
+        get => _viewsWithoutCrop;
+        set => this.RaiseAndSetIfChanged(ref _viewsWithoutCrop, value);
+    }
+
+    public string ViewsWithoutCropText =>
+        ViewsWithoutCrop.Count == 0
+            ? null
+            : " - " + string.Join(" - " + Environment.NewLine, ViewsWithoutCrop);
+    
     public SheetElement CreateSheetElement() {
         return new SheetElement() {ViewSheet = _viewSheet, PrintSheetSettings = PrintSheetSettings};
     }

--- a/src/RevitBatchPrint/ViewModels/SheetViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/SheetViewModel.cs
@@ -16,15 +16,21 @@ namespace RevitBatchPrint.ViewModels;
 internal sealed class SheetViewModel : BaseViewModel {
     private readonly ViewSheet _viewSheet;
     private readonly IPrintContext _printContext;
+    private readonly ILocalizationService _localizationService;
 
     private string _errorText;
     private bool _isSelected;
     private PrintSheetSettings _printSheetSettings;
     private ObservableCollection<string> _viewsWithoutCrop;
 
-    public SheetViewModel(ViewSheet viewSheet, AlbumViewModel album, IPrintContext printContext) {
+    public SheetViewModel(
+        ViewSheet viewSheet,
+        AlbumViewModel album,
+        IPrintContext printContext,
+        ILocalizationService localizationService) {
         _viewSheet = viewSheet;
         _printContext = printContext;
+        _localizationService = localizationService;
 
         Name = _viewSheet.Name;
         Album = album;
@@ -60,7 +66,8 @@ internal sealed class SheetViewModel : BaseViewModel {
     public string ViewsWithoutCropText =>
         ViewsWithoutCrop.Count == 0
             ? null
-            : " - "
+            : _localizationService.GetLocalizedString("TreeView.ViewsWithoutCropToolTip")
+              + Environment.NewLine + " - "
               + string.Join(Environment.NewLine + " - ", ViewsWithoutCrop.Take(5))
               + (ViewsWithoutCrop.Count > 5 ? "..." : null);
     

--- a/src/RevitBatchPrint/Views/MainWindow.xaml
+++ b/src/RevitBatchPrint/Views/MainWindow.xaml
@@ -47,7 +47,7 @@
                 FalseValue="Collapsed" />
         </ResourceDictionary>
     </Window.Resources>
-    
+
     <b:Interaction.Behaviors>
         <behaviors:WpfAttachServiceBehavior
             AttachableService="{Binding MessageBoxService}">
@@ -151,8 +151,8 @@
                 Width="80"
                 Appearance="Info"
                 Content="{me:LocalizationSource MainWindow.PrintCommandName}"
-                Click="ButtonOk_Click"
                 Command="{Binding AcceptVewCommand}"
+                CommandParameter="{Binding ElementName=_this}"
                 Visibility="{Binding ShowPrint,
                     Converter={StaticResource BoolToVisibilityConverter}}" />
 
@@ -161,8 +161,8 @@
                 Width="80"
                 Appearance="Info"
                 Content="{me:LocalizationSource MainWindow.ExportCommandName}"
-                Click="ButtonOk_Click"
                 Command="{Binding AcceptVewCommand}"
+                CommandParameter="{Binding ElementName=_this}"
                 Visibility="{Binding ShowExport,
                     Converter={StaticResource BoolToVisibilityConverter}}" />
 

--- a/src/RevitBatchPrint/Views/MainWindow.xaml
+++ b/src/RevitBatchPrint/Views/MainWindow.xaml
@@ -113,6 +113,7 @@
                     <ui:ToggleSwitch
                         x:Name="_settingsSwitch"
                         IsChecked="False"
+                        ToolTip="{me:LocalizationSource MainWindow.Settings}"
                         OnContent="{ui:SymbolIcon Settings48, Filled=True, FontSize=20}"
                         OffContent="{ui:SymbolIcon Settings48, Filled=False, FontSize=20}"
                         Style="{StaticResource CustomToggleSwitchStyle}" />

--- a/src/RevitBatchPrint/Views/MainWindow.xaml
+++ b/src/RevitBatchPrint/Views/MainWindow.xaml
@@ -14,6 +14,7 @@
     xmlns:me="clr-namespace:dosymep.WpfCore.MarkupExtensions;assembly=dosymep.WpfCore"
     xmlns:views="clr-namespace:RevitBatchPrint.Views"
     xmlns:converters="clr-namespace:dosymep.WpfCore.Converters;assembly=dosymep.WpfCore"
+    xmlns:behaviors="clr-namespace:dosymep.WpfCore.Behaviors;assembly=dosymep.WpfCore"
 
     x:Name="_this"
     mc:Ignorable="d"
@@ -46,6 +47,12 @@
                 FalseValue="Collapsed" />
         </ResourceDictionary>
     </Window.Resources>
+    
+    <b:Interaction.Behaviors>
+        <behaviors:WpfAttachServiceBehavior
+            AttachableService="{Binding MessageBoxService}">
+        </behaviors:WpfAttachServiceBehavior>
+    </b:Interaction.Behaviors>
 
     <b:Interaction.Triggers>
         <b:EventTrigger

--- a/src/RevitBatchPrint/Views/MainWindow.xaml.cs
+++ b/src/RevitBatchPrint/Views/MainWindow.xaml.cs
@@ -45,10 +45,6 @@ public partial class MainWindow {
     /// </remarks>
     public override string ProjectConfigName => nameof(MainWindow);
 
-    private void ButtonOk_Click(object sender, RoutedEventArgs e) {
-        DialogResult = true;
-    }
-
     private void ButtonCancel_Click(object sender, RoutedEventArgs e) {
         DialogResult = false;
     }

--- a/src/RevitBatchPrint/ViewsTemplates/TreeViewTemplate.xaml
+++ b/src/RevitBatchPrint/ViewsTemplates/TreeViewTemplate.xaml
@@ -171,7 +171,7 @@
                 Binding="{Binding Path=IsMouseOver,
                     RelativeSource={RelativeSource AncestorType=TreeViewItem}}">
                 <Setter TargetName="Buttons" Property="Visibility" Value="Visible" />
-                <Setter TargetName="FormatName" Property="Margin" Value="0 0 70 0" />
+                <Setter TargetName="FormatName" Property="Margin" Value="0 0 58 0" />
             </DataTrigger>
         </HierarchicalDataTemplate.Triggers>
 

--- a/src/RevitBatchPrint/ViewsTemplates/TreeViewTemplate.xaml
+++ b/src/RevitBatchPrint/ViewsTemplates/TreeViewTemplate.xaml
@@ -114,16 +114,8 @@
                 <ui:SymbolIcon
                     Symbol="Warning24"
                     Margin="12 0 0 0"
-                    VerticalAlignment="Center">
-                    
-                    <ui:SymbolIcon.ToolTip>
-                        <TextBlock>
-                            <Run Text="{me:LocalizationSource TreeView.ViewsWithoutCropToolTip}" />
-                            <LineBreak />
-                            <Run Text="{Binding ViewsWithoutCropText, Mode=OneWay}" />
-                        </TextBlock>
-                
-                    </ui:SymbolIcon.ToolTip>
+                    VerticalAlignment="Center"
+                    ToolTip="{Binding ViewsWithoutCropText, Mode=OneWay}">
                 
                     <ui:SymbolIcon.Style>
                         <Style TargetType="ui:SymbolIcon">

--- a/src/RevitBatchPrint/ViewsTemplates/TreeViewTemplate.xaml
+++ b/src/RevitBatchPrint/ViewsTemplates/TreeViewTemplate.xaml
@@ -5,7 +5,8 @@
                     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
                     xmlns:converters="clr-namespace:dosymep.WpfCore.Converters;assembly=dosymep.WpfCore"
                     xmlns:db="clr-namespace:Autodesk.Revit.DB;assembly=RevitAPI"
-                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+                    xmlns:system="clr-namespace:System;assembly=mscorlib"
+                    xmlns:me="clr-namespace:dosymep.WpfCore.MarkupExtensions;assembly=dosymep.WpfCore">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Controls/Button/Button.xaml" />
@@ -97,15 +98,47 @@
                 </b:Interaction.Triggers>
             </CheckBox>
 
-            <ui:TextBlock
+            <StackPanel
                 Grid.Column="1"
                 x:Name="FormatName"
-                Margin="0 0 12 0"
-                FontTypography="Body"
-                HorizontalAlignment="Right"
+                Orientation="Horizontal"
                 VerticalAlignment="Center"
-                Text="{Binding PrintSheetSettings.SheetFormat.Name}" />
+                HorizontalAlignment="Right"
+                Margin="0 0 12 0">
+                
+                <ui:TextBlock
+                    FontTypography="Body"
+                    VerticalAlignment="Center"
+                    Text="{Binding PrintSheetSettings.SheetFormat.Name}" />
 
+                <ui:SymbolIcon
+                    Symbol="Warning24"
+                    Margin="12 0 0 0"
+                    VerticalAlignment="Center">
+                    
+                    <ui:SymbolIcon.ToolTip>
+                        <TextBlock>
+                            <Run Text="{me:LocalizationSource TreeView.ViewsWithoutCropToolTip}" />
+                            <LineBreak />
+                            <Run Text="{Binding ViewsWithoutCropText, Mode=OneWay}" />
+                        </TextBlock>
+                
+                    </ui:SymbolIcon.ToolTip>
+                
+                    <ui:SymbolIcon.Style>
+                        <Style TargetType="ui:SymbolIcon">
+                            <Setter Property="Visibility" Value="Visible" />
+                
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding ViewsWithoutCrop.Count}" Value="0">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ui:SymbolIcon.Style>
+                </ui:SymbolIcon>
+            </StackPanel>
+            
             <StackPanel
                 Grid.Column="1"
                 x:Name="Buttons"

--- a/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
@@ -71,13 +71,15 @@
 
     <system:String xml:space="preserve"
                    x:Key="MainWindow.ViewsWithoutCropMessage">
-Warning! You are printing sheets with views without cropping.
+Warning!
+You are printing sheets with views without cropping.
 Continue?
 </system:String>
     
     <system:String xml:space="preserve"
                    x:Key="MainWindow.SheetsWithoutCropMessage">
-Warning! You are printing sheets with views without cropping.
+Warning!
+You are printing sheets with views without cropping.
 Continue?
     </system:String>
 

--- a/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
@@ -17,7 +17,7 @@
 
     <system:String x:Key="MainWindow.ButtonOk">OK</system:String>
     <system:String x:Key="MainWindow.ButtonCancel">Cancel</system:String>
-    
+
     <system:String x:Key="MainWindow.NotSelectedAlbumParamName">Please select album param name</system:String>
     <system:String x:Key="MainWindow.NotSelectedPrinter">Please select printer name</system:String>
     <system:String x:Key="MainWindow.NotSelectedFilePath">Please select export file path</system:String>
@@ -52,24 +52,33 @@
 
     <system:String x:Key="Settings.ReplaceHalftoneWithThinLines">Replace halftone with thinLines</system:String>
     <system:String x:Key="Settings.ReplaceHalftoneWithThinLinesDescription">Halftones are displayed as thin lines</system:String>
-    
+
     <system:String x:Key="ColorDepthType.BlackLine">Black line</system:String>
     <system:String x:Key="ColorDepthType.GrayScale">Gray scale</system:String>
     <system:String x:Key="ColorDepthType.Color">Color</system:String>
-    
+
     <system:String x:Key="RasterQualityType.Low">Low</system:String>
     <system:String x:Key="RasterQualityType.Medium">Medium</system:String>
     <system:String x:Key="RasterQualityType.High">High</system:String>
     <system:String x:Key="RasterQualityType.Presentation">Presentation</system:String>
-    
+
     <system:String x:Key="ToggleSwitch.On">On</system:String>
     <system:String x:Key="ToggleSwitch.Off">Off</system:String>
-    
+
     <system:String x:Key="ViewSheet.NotFoundTitleBlock">Not found title block on a sheet "{0}".</system:String>
     <system:String x:Key="TreeView.ViewsWithoutCropToolTip">Views without crop:</system:String>
     <system:String x:Key="TreeView.SheetsWithoutCropToolTip">Sheets without crop:</system:String>
+
+    <system:String xml:space="preserve"
+                   x:Key="MainWindow.ViewsWithoutCropMessage">
+Warning! You are printing views without cropping.
+Continue?
+</system:String>
     
-    <system:String x:Key="MainWindow.ViewsWithoutCropMessage">Warning! You are printing views without cropping. Continue?</system:String>
-    <system:String x:Key="MainWindow.SheetsWithoutCropMessage">Warning! You are printing sheets without cropping. Continue?</system:String>
-    
+    <system:String xml:space="preserve"
+                   x:Key="MainWindow.SheetsWithoutCropMessage">
+Warning! You are printing sheets without cropping.
+Continue?
+    </system:String>
+
 </ResourceDictionary>

--- a/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
@@ -66,5 +66,6 @@
     <system:String x:Key="ToggleSwitch.Off">Off</system:String>
     
     <system:String x:Key="ViewSheet.NotFoundTitleBlock">Not found title block on a sheet "{0}".</system:String>
+    <system:String x:Key="TreeView.ViewsWithoutCropToolTip">Views without crop:</system:String>
     
 </ResourceDictionary>

--- a/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
@@ -65,4 +65,6 @@
     <system:String x:Key="ToggleSwitch.On">On</system:String>
     <system:String x:Key="ToggleSwitch.Off">Off</system:String>
     
+    <system:String x:Key="ViewSheet.NotFoundTitleBlock">Not found title block on a sheet "{0}".</system:String>
+    
 </ResourceDictionary>

--- a/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
@@ -9,6 +9,7 @@
     <system:String x:Key="MainWindow.EmptyAlbumNameParam">Noname</system:String>
     <system:String x:Key="MainWindow.ChooseFileName">Choose the path to save the file</system:String>
 
+    <system:String x:Key="MainWindow.Settings">Settings</system:String>
     <system:String x:Key="MainWindow.PrintMode">Print Mode</system:String>
     <system:String x:Key="MainWindow.ExportMode">Export Mode</system:String>
 

--- a/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
@@ -72,14 +72,16 @@
     <system:String xml:space="preserve"
                    x:Key="MainWindow.ViewsWithoutCropMessage">
 Warning!
-You are printing sheets with views without cropping.
+You are printing sheets 
+with views without cropping.
 Continue?
 </system:String>
     
     <system:String xml:space="preserve"
                    x:Key="MainWindow.SheetsWithoutCropMessage">
 Warning!
-You are printing sheets with views without cropping.
+You are printing sheets 
+with views without cropping.
 Continue?
     </system:String>
 

--- a/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
@@ -71,13 +71,13 @@
 
     <system:String xml:space="preserve"
                    x:Key="MainWindow.ViewsWithoutCropMessage">
-Warning! You are printing views without cropping.
+Warning! You are printing sheets with views without cropping.
 Continue?
 </system:String>
     
     <system:String xml:space="preserve"
                    x:Key="MainWindow.SheetsWithoutCropMessage">
-Warning! You are printing sheets without cropping.
+Warning! You are printing sheets with views without cropping.
 Continue?
     </system:String>
 

--- a/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
@@ -67,5 +67,6 @@
     
     <system:String x:Key="ViewSheet.NotFoundTitleBlock">Not found title block on a sheet "{0}".</system:String>
     <system:String x:Key="TreeView.ViewsWithoutCropToolTip">Views without crop:</system:String>
+    <system:String x:Key="TreeView.SheetsWithoutCropToolTip">Sheets without crop:</system:String>
     
 </ResourceDictionary>

--- a/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
@@ -69,4 +69,7 @@
     <system:String x:Key="TreeView.ViewsWithoutCropToolTip">Views without crop:</system:String>
     <system:String x:Key="TreeView.SheetsWithoutCropToolTip">Sheets without crop:</system:String>
     
+    <system:String x:Key="MainWindow.ViewsWithoutCropMessage">Warning, you print views without a crop. Continue?</system:String>
+    <system:String x:Key="MainWindow.SheetsWithoutCropMessage">Warning, you print sheets without a crop. Continue?</system:String>
+    
 </ResourceDictionary>

--- a/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.en-US.xaml
@@ -69,7 +69,7 @@
     <system:String x:Key="TreeView.ViewsWithoutCropToolTip">Views without crop:</system:String>
     <system:String x:Key="TreeView.SheetsWithoutCropToolTip">Sheets without crop:</system:String>
     
-    <system:String x:Key="MainWindow.ViewsWithoutCropMessage">Warning, you print views without a crop. Continue?</system:String>
-    <system:String x:Key="MainWindow.SheetsWithoutCropMessage">Warning, you print sheets without a crop. Continue?</system:String>
+    <system:String x:Key="MainWindow.ViewsWithoutCropMessage">Warning! You are printing views without cropping. Continue?</system:String>
+    <system:String x:Key="MainWindow.SheetsWithoutCropMessage">Warning! You are printing sheets without cropping. Continue?</system:String>
     
 </ResourceDictionary>

--- a/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
@@ -67,4 +67,5 @@
     
     <system:String x:Key="ViewSheet.NotFoundTitleBlock">Не была найдена основная надпись на листе "{0}".</system:String>
     <system:String x:Key="TreeView.ViewsWithoutCropToolTip">Виды без подрезки:</system:String>
+    <system:String x:Key="TreeView.SheetsWithoutCropToolTip">Листы без подрезки:</system:String>
 </ResourceDictionary>

--- a/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
@@ -70,12 +70,12 @@
     <system:String x:Key="TreeView.SheetsWithoutCropToolTip">Листы без подрезки:</system:String>
 
     <system:String xml:space="preserve" x:Key="MainWindow.ViewsWithoutCropMessage">
-Предупреждение! Вы печатаете виды без подрезки.
+Предупреждение! Вы печатаете листы с видами без подрезки.
 Продолжить?
 </system:String>
 
     <system:String xml:space="preserve" x:Key="MainWindow.SheetsWithoutCropMessage">
-Предупреждение! Вы печатаете листы без подрезки.
+Предупреждение! Вы печатаете листы с видами без подрезки.
 Продолжить?
 </system:String>
 </ResourceDictionary>

--- a/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
@@ -9,6 +9,7 @@
     <system:String x:Key="MainWindow.EmptyAlbumNameParam">Без имени</system:String>
     <system:String x:Key="MainWindow.ChooseFileName">Выберите файл для сохранения</system:String>
 
+    <system:String x:Key="MainWindow.Settings">Настройки</system:String>
     <system:String x:Key="MainWindow.PrintMode">Режим печати</system:String>
     <system:String x:Key="MainWindow.ExportMode">Режим экспорта</system:String>
 

--- a/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
@@ -64,4 +64,6 @@
     
     <system:String x:Key="ToggleSwitch.On">Включено</system:String>
     <system:String x:Key="ToggleSwitch.Off">Выключено</system:String>
+    
+    <system:String x:Key="ViewSheet.NotFoundTitleBlock">Не была найдена основная надпись на листе "{0}".</system:String>
 </ResourceDictionary>

--- a/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
@@ -66,4 +66,5 @@
     <system:String x:Key="ToggleSwitch.Off">Выключено</system:String>
     
     <system:String x:Key="ViewSheet.NotFoundTitleBlock">Не была найдена основная надпись на листе "{0}".</system:String>
+    <system:String x:Key="TreeView.ViewsWithoutCropToolTip">Виды без подрезки:</system:String>
 </ResourceDictionary>

--- a/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
@@ -70,12 +70,14 @@
     <system:String x:Key="TreeView.SheetsWithoutCropToolTip">Листы без подрезки:</system:String>
 
     <system:String xml:space="preserve" x:Key="MainWindow.ViewsWithoutCropMessage">
-Предупреждение! Вы печатаете листы с видами без подрезки.
+Предупреждение!
+Вы печатаете листы с видами без подрезки.
 Продолжить?
 </system:String>
 
     <system:String xml:space="preserve" x:Key="MainWindow.SheetsWithoutCropMessage">
-Предупреждение! Вы печатаете листы с видами без подрезки.
+Предупреждение!
+Вы печатаете листы с видами без подрезки.
 Продолжить?
 </system:String>
 </ResourceDictionary>

--- a/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
@@ -69,6 +69,6 @@
     <system:String x:Key="TreeView.ViewsWithoutCropToolTip">Виды без подрезки:</system:String>
     <system:String x:Key="TreeView.SheetsWithoutCropToolTip">Листы без подрезки:</system:String>
     
-    <system:String x:Key="MainWindow.ViewsWithoutCropMessage">Предупреждение, вы печатаете виды без подрезки. Продолжить?</system:String>
-    <system:String x:Key="MainWindow.SheetsWithoutCropMessage">Предупреждение, вы печатаете листы без подрезки. Продолжить?</system:String>
+    <system:String x:Key="MainWindow.ViewsWithoutCropMessage">Предупреждение! Вы печатаете виды без подрезки. Продолжить?</system:String>
+    <system:String x:Key="MainWindow.SheetsWithoutCropMessage">Предупреждение! Вы печатаете листы без подрезки. Продолжить?</system:String>
 </ResourceDictionary>

--- a/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
@@ -17,7 +17,7 @@
 
     <system:String x:Key="MainWindow.ButtonOk">ОК</system:String>
     <system:String x:Key="MainWindow.ButtonCancel">Отмена</system:String>
-    
+
     <system:String x:Key="MainWindow.NotSelectedAlbumParamName">Выберите параметр группировки альбома</system:String>
     <system:String x:Key="MainWindow.NotSelectedPrinter">Выберите принтер для печати</system:String>
     <system:String x:Key="MainWindow.NotSelectedFilePath">Выберите путь до файла для экспорта</system:String>
@@ -52,23 +52,30 @@
 
     <system:String x:Key="Settings.ReplaceHalftoneWithThinLines">Заменить полутона тонкими линиями</system:String>
     <system:String x:Key="Settings.ReplaceHalftoneWithThinLinesDescription">Полутона отображаются тонкими линиями</system:String>
-    
+
     <system:String x:Key="ColorDepthType.BlackLine">Черные линии</system:String>
     <system:String x:Key="ColorDepthType.GrayScale">Оттенки серого</system:String>
     <system:String x:Key="ColorDepthType.Color">Цветное</system:String>
-    
+
     <system:String x:Key="RasterQualityType.Low">Низкое</system:String>
     <system:String x:Key="RasterQualityType.Medium">Среднее</system:String>
     <system:String x:Key="RasterQualityType.High">Высокое</system:String>
     <system:String x:Key="RasterQualityType.Presentation">Презентационное</system:String>
-    
+
     <system:String x:Key="ToggleSwitch.On">Включено</system:String>
     <system:String x:Key="ToggleSwitch.Off">Выключено</system:String>
-    
+
     <system:String x:Key="ViewSheet.NotFoundTitleBlock">Не была найдена основная надпись на листе "{0}".</system:String>
     <system:String x:Key="TreeView.ViewsWithoutCropToolTip">Виды без подрезки:</system:String>
     <system:String x:Key="TreeView.SheetsWithoutCropToolTip">Листы без подрезки:</system:String>
-    
-    <system:String x:Key="MainWindow.ViewsWithoutCropMessage">Предупреждение! Вы печатаете виды без подрезки. Продолжить?</system:String>
-    <system:String x:Key="MainWindow.SheetsWithoutCropMessage">Предупреждение! Вы печатаете листы без подрезки. Продолжить?</system:String>
+
+    <system:String xml:space="preserve" x:Key="MainWindow.ViewsWithoutCropMessage">
+Предупреждение! Вы печатаете виды без подрезки.
+Продолжить?
+</system:String>
+
+    <system:String xml:space="preserve" x:Key="MainWindow.SheetsWithoutCropMessage">
+Предупреждение! Вы печатаете листы без подрезки.
+Продолжить?
+</system:String>
 </ResourceDictionary>

--- a/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
+++ b/src/RevitBatchPrint/assets/localization/Language.ru-RU.xaml
@@ -68,4 +68,7 @@
     <system:String x:Key="ViewSheet.NotFoundTitleBlock">Не была найдена основная надпись на листе "{0}".</system:String>
     <system:String x:Key="TreeView.ViewsWithoutCropToolTip">Виды без подрезки:</system:String>
     <system:String x:Key="TreeView.SheetsWithoutCropToolTip">Листы без подрезки:</system:String>
+    
+    <system:String x:Key="MainWindow.ViewsWithoutCropMessage">Предупреждение, вы печатаете виды без подрезки. Продолжить?</system:String>
+    <system:String x:Key="MainWindow.SheetsWithoutCropMessage">Предупреждение, вы печатаете листы без подрезки. Продолжить?</system:String>
 </ResourceDictionary>


### PR DESCRIPTION
- была исправлена ошибка падения ревита, когда у какого-нибудь листа не было основной надписи
- добавил отображение предупреждения, когда выводят на печать листы, у которых есть виды без подрезки
- добавил оптимизацию первого запуска плагина
- изменил режим работы по умолчанию на экспорт в Revit 2022+