### PR TITLE
RevitCorrectNamingCheck: Доработка плагина

### DIFF
--- a/src/RevitCorrectNamingCheck/Localization/Language.en-US.xaml
+++ b/src/RevitCorrectNamingCheck/Localization/Language.en-US.xaml
@@ -11,8 +11,8 @@
 
 
     <system:String x:Key="WorksetNameStatus.WorksetCorrect">The bond is distributed by WS correctly</system:String>
-    <system:String x:Key="WorksetNameStatus.PartialCorrect">"The link was added to the working set without the label 'Link'"</system:String>
-    <system:String x:Key="WorksetNameStatus.Incorrect">There are several labels for different sections in the name of the working set. It is impossible to determine the correspondence unambiguously</system:String>
+    <system:String x:Key="WorksetNameStatus.Incorrect">"The link was added to the working set without the label 'Link'"</system:String>
+    <system:String x:Key="WorksetNameStatus.PartialCorrect">There are several labels for different sections in the name of the working set. It is impossible to determine the correspondence unambiguously</system:String>
     <system:String x:Key="WorksetNameStatus.NoMatch">The working set of the unsuitable section is selected</system:String>
 
     <system:String x:Key="FileNameStatus.NotFoundTags">No section tags found</system:String>
@@ -22,6 +22,7 @@
     <system:String x:Key="GeneralSettings.ErrorMessage">Error</system:String>
 
     <system:String x:Key="MainWindow.Undefined">Undefined</system:String>
+    <system:String x:Key="MainWindow.Pinned">Pinned</system:String>
     <system:String x:Key="MainWindow.ButtonRefresh">Refresh</system:String>
     <system:String x:Key="MainWindow.ButtonCancel">Cancel</system:String>
 </ResourceDictionary>

--- a/src/RevitCorrectNamingCheck/Localization/Language.ru-RU.xaml
+++ b/src/RevitCorrectNamingCheck/Localization/Language.ru-RU.xaml
@@ -10,8 +10,8 @@
     <system:String x:Key="MainWindow.Instance">РН экземпляра</system:String>
 
     <system:String x:Key="WorksetNameStatus.WorksetCorrect">Связь распределена по РН верно</system:String>
-    <system:String x:Key="WorksetNameStatus.PartialCorrect">Связь добавлена в рабочий набор без метки 'Связь'</system:String>
-    <system:String x:Key="WorksetNameStatus.Incorrect">В имени рабочего набора несколько меток разных разделов. Однозначно определить соответствие невозможно</system:String>
+    <system:String x:Key="WorksetNameStatus.Incorrect">Связь добавлена в рабочий набор без метки 'Связь'</system:String>
+    <system:String x:Key="WorksetNameStatus.PartialCorrect">В имени рабочего набора несколько меток разных разделов. Однозначно определить соответствие невозможно</system:String>
     <system:String x:Key="WorksetNameStatus.NoMatch">Выбран рабочий набор неподходящего раздела</system:String>
     
     <system:String x:Key="FileNameStatus.NotFoundTags">Не найдено меток раздела</system:String>
@@ -21,6 +21,7 @@
     <system:String x:Key="GeneralSettings.ErrorMessage">Ошибка</system:String>
 
     <system:String x:Key="MainWindow.Undefined">Не определено</system:String>
+    <system:String x:Key="MainWindow.Pinned">Закреплена</system:String>
     <system:String x:Key="MainWindow.ButtonRefresh">Обновить</system:String>
     <system:String x:Key="MainWindow.ButtonCancel">Отмена</system:String>
 </ResourceDictionary>

--- a/src/RevitCorrectNamingCheck/Models/LinkedFile.cs
+++ b/src/RevitCorrectNamingCheck/Models/LinkedFile.cs
@@ -5,13 +5,14 @@ namespace RevitCorrectNamingCheck.Models;
 internal class LinkedFile {
     public ElementId Id { get; set; }
     public string Name { get; set; }
+    public bool IsPinned { get; set; }
     public NameStatus FileNameStatus { get; set; }
     public WorksetInfo TypeWorkset { get; set; }
     public WorksetInfo InstanceWorkset { get; set; }
-
-    public LinkedFile(ElementId id, string name, WorksetInfo typeWorkset, WorksetInfo instanceWorkset) {
+    public LinkedFile(ElementId id, string name, bool isPinned, WorksetInfo typeWorkset, WorksetInfo instanceWorkset) {
         Id = id;
         Name = name;
+        IsPinned = isPinned;
         TypeWorkset = typeWorkset;
         InstanceWorkset = instanceWorkset;
     }

--- a/src/RevitCorrectNamingCheck/Models/LinkedFileEnricher.cs
+++ b/src/RevitCorrectNamingCheck/Models/LinkedFileEnricher.cs
@@ -10,6 +10,18 @@ namespace RevitCorrectNamingCheck.Models;
 
 internal class LinkedFileEnricher {
 
+    private static readonly Dictionary<string, string> _partFileToRnMap = new() {
+    { "AR", "AR" },
+    { "KR", "KR" },
+    { "OV", "OV" },
+    { "ITP", "OV" },     // ITP считается частью OV в РН
+    { "VK", "VK" },
+    { "EOM", "EOM" },
+    { "EG", "EOM" },     // EG считается частью EOM в РН
+    { "SS", "SS" }
+    };
+
+
     private readonly IBimModelPartsService _bimModelPartsService;
 
     public LinkedFileEnricher(IBimModelPartsService bimModelPartsService) {
@@ -27,18 +39,43 @@ internal class LinkedFileEnricher {
     }
 
     private NameStatus GetWorksetNameStatus(string worksetName, BimModelPart currentPart, List<string> identifiers) {
-        int matches = identifiers.Count(part => NamingRulesHelper.ContainsPart(worksetName, part));
-        bool isCurrent = NamingRulesHelper.MatchesCurrentPart(worksetName, currentPart);
+        var mappedIdentifiers = identifiers
+            .Select(i => _partFileToRnMap.TryGetValue(i, out var mapped) ? mapped : i)
+            .Distinct()
+            .ToList();
+
         bool isLink = NamingRulesHelper.IsLinkWorkset(worksetName);
 
-        return matches == 0
-            ? NameStatus.None
-            : matches == 1 ? isCurrent ? isLink ? NameStatus.Correct : NameStatus.PartialCorrect : NameStatus.None : NameStatus.Incorrect;
+        bool isCurrent = false;
+        if (currentPart != null) {
+            isCurrent = NamingRulesHelper.MatchesCurrentPart(worksetName, currentPart);
+        }
+        int matches = mappedIdentifiers.Count(part => NamingRulesHelper.ContainsPart(worksetName, part));
+
+        if(!isLink) {
+            return NameStatus.Incorrect;
+        }
+
+        if(matches == 1 && isCurrent) {
+            return NameStatus.Correct;
+        }
+
+        if(matches > 1) {
+            return NameStatus.PartialCorrect;
+        }
+
+        return NameStatus.None;
     }
+
 
     public LinkedFile Enrich(LinkedFile linkedFile) {
 
-        var bimModelParts = _bimModelPartsService.GetBimModelParts().ToList();
+        var requiredParts = new[] { "AR", "KR", "OV", "ITP", "VK", "EOM", "EG", "SS" };
+
+        var bimModelParts = _bimModelPartsService
+            .GetBimModelParts()
+            .Where(p => requiredParts.Contains(p.Id))
+            .ToList();
 
         var bimIdentifiers = bimModelParts
             .SelectMany(p => new[] { p.Id, p.Name })
@@ -47,12 +84,10 @@ internal class LinkedFileEnricher {
 
         linkedFile.FileNameStatus = GetFileNameStatus(linkedFile.Name, bimIdentifiers);
 
-        if(linkedFile.FileNameStatus == NameStatus.Correct) {
-            var currentPart = _bimModelPartsService.GetBimModelPart(linkedFile.Name);
+        var currentPart = _bimModelPartsService.GetBimModelPart(linkedFile.Name);
 
-            SetWorksetInfo(linkedFile.TypeWorkset, currentPart, bimIdentifiers);
-            SetWorksetInfo(linkedFile.InstanceWorkset, currentPart, bimIdentifiers);
-        }
+        SetWorksetInfo(linkedFile.TypeWorkset, currentPart, bimIdentifiers);
+        SetWorksetInfo(linkedFile.InstanceWorkset, currentPart, bimIdentifiers);
 
         return linkedFile;
     }

--- a/src/RevitCorrectNamingCheck/Models/RevitRepository.cs
+++ b/src/RevitCorrectNamingCheck/Models/RevitRepository.cs
@@ -95,7 +95,7 @@ internal class RevitRepository {
             foreach(var instance in instances) {
                 var typeWorkset = new WorksetInfo(linkType.WorksetId, GetWorksetName(linkType));
                 var instanceWorkset = new WorksetInfo(instance.WorksetId, GetWorksetName(instance));
-                var linkedFile = new LinkedFile(linkType.Id, linkType.Name, typeWorkset, instanceWorkset);
+                var linkedFile = new LinkedFile(linkType.Id, linkType.Name, instance.Pinned, typeWorkset, instanceWorkset);
 
                 linkedFileEnricher.Enrich(linkedFile);
                 result.Add(linkedFile);

--- a/src/RevitCorrectNamingCheck/Views/MainWindow.xaml
+++ b/src/RevitCorrectNamingCheck/Views/MainWindow.xaml
@@ -16,10 +16,10 @@
     WindowStartupLocation="CenterOwner"
     Title="{me:LocalizationSource MainWindow.Title}"
 
-    Width="700"
+    Width="750"
     Height="400"
     
-    MinWidth="700"
+    MinWidth="750"
     MinHeight="400"
 
     d:DataContext="{d:DesignInstance vms:MainViewModel, IsDesignTimeCreatable=False}">
@@ -49,83 +49,91 @@
         <ui:TitleBar
             Grid.Row="0"
             Title="{me:LocalizationSource MainWindow.Title}" />
-
-        <DataGrid
-            CanUserDeleteRows="False"
-            AutoGenerateColumns="False"
-            CanUserAddRows="False"
-            IsReadOnly="True"
+        <Border
             Grid.Row="1"
+            CornerRadius="8"
+            Padding="5"
             Margin="10,0,10,0"
-            HeadersVisibility="Column"
-            GridLinesVisibility="All"
-            ItemsSource="{Binding LinkedFiles}">
+            Background="{DynamicResource CardBackground}">
+            
+            <DataGrid
+                CanUserDeleteRows="False"
+                AutoGenerateColumns="False"
+                CanUserAddRows="False"
+                IsReadOnly="True"
+                Grid.Row="1"
+                Margin="10,0,10,0"
+                HeadersVisibility="Column"
+                GridLinesVisibility="All"
+                ItemsSource="{Binding LinkedFiles}">
 
-            <DataGrid.Columns>
-                <DataGridTemplateColumn>
-                    <DataGridTemplateColumn.Header>
-                        <TextBlock 
-                            Text="{DynamicResource MainWindow.LinkedFile}" />
-                        
-                    </DataGridTemplateColumn.Header>
-                    <DataGridTemplateColumn.CellTemplate>
-                        <StaticResource ResourceKey="LinkedFileTemplate" />
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
+                <DataGrid.Columns>
+                    <DataGridTemplateColumn>
+                        <DataGridTemplateColumn.Header>
+                            <TextBlock
+                                Text="{DynamicResource MainWindow.LinkedFile}" />
 
-                <DataGridTemplateColumn>
-                    <DataGridTemplateColumn.Header>
-                        <TextBlock 
-                            Text="{DynamicResource MainWindow.WorksetType}" />
-                        
-                    </DataGridTemplateColumn.Header>
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <ContentControl 
-                                Content="{Binding TypeWorkset}"
-                                ContentTemplateSelector="{StaticResource WorksetSelector}" />
-                            
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <StaticResource
+                                ResourceKey="LinkedFileTemplate" />
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
 
-                <DataGridTemplateColumn>
-                    <DataGridTemplateColumn.Header>
-                        <TextBlock 
-                            Text="{DynamicResource MainWindow.Instance}" />
-                        
-                    </DataGridTemplateColumn.Header>
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <ContentControl 
-                                Content="{Binding InstanceWorkset}"
-                                ContentTemplateSelector="{StaticResource WorksetSelector}" />
-                            
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
+                    <DataGridTemplateColumn>
+                        <DataGridTemplateColumn.Header>
+                            <TextBlock
+                                Text="{DynamicResource MainWindow.WorksetType}" />
 
-                <DataGridTemplateColumn
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <ContentControl
+                                    Content="{Binding TypeWorkset}"
+                                    ContentTemplateSelector="{StaticResource WorksetSelector}" />
+
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+
+                    <DataGridTemplateColumn>
+                        <DataGridTemplateColumn.Header>
+                            <TextBlock
+                                Text="{DynamicResource MainWindow.Instance}" />
+
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <ContentControl
+                                    Content="{Binding InstanceWorkset}"
+                                    ContentTemplateSelector="{StaticResource WorksetSelector}" />
+
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+
+                    <DataGridTemplateColumn
                         Width="100">
-                    <DataGridTemplateColumn.Header>
-                        <TextBlock
-                            Text="{me:LocalizationSource MainWindow.Pinned}" />
-                    </DataGridTemplateColumn.Header>
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <CheckBox
-                                IsHitTestVisible="False"
-                                Focusable="False"
-                                HorizontalAlignment="Center"
-                                VerticalAlignment="Center"
-                                IsChecked="{Binding IsPinned}" />
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
+                        <DataGridTemplateColumn.Header>
+                            <TextBlock
+                                Text="{me:LocalizationSource MainWindow.Pinned}" />
+                            
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <CheckBox
+                                    IsHitTestVisible="False"
+                                    Focusable="False"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    IsChecked="{Binding IsPinned}" />
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
 
-            </DataGrid.Columns>
-        </DataGrid>
-
+                </DataGrid.Columns>
+            </DataGrid>
+        </Border>
         <StackPanel
             Grid.Row="2"
             Orientation="Horizontal"

--- a/src/RevitCorrectNamingCheck/Views/MainWindow.xaml
+++ b/src/RevitCorrectNamingCheck/Views/MainWindow.xaml
@@ -16,10 +16,10 @@
     WindowStartupLocation="CenterOwner"
     Title="{me:LocalizationSource MainWindow.Title}"
 
-    Width="600"
+    Width="700"
     Height="400"
-
-    MinWidth="600"
+    
+    MinWidth="700"
     MinHeight="400"
 
     d:DataContext="{d:DesignInstance vms:MainViewModel, IsDesignTimeCreatable=False}">
@@ -42,7 +42,6 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -51,34 +50,23 @@
             Grid.Row="0"
             Title="{me:LocalizationSource MainWindow.Title}" />
 
-        <StackPanel
-            Grid.Row="1"
-            Orientation="Horizontal"
-            HorizontalAlignment="Left"
-            Margin="10,10">
-            <ui:Button
-                Width="140"
-                Padding="10,5"
-                Appearance="Info"
-                Content="{me:LocalizationSource MainWindow.ButtonRefresh}"
-                Command="{Binding LoadViewCommand}" />
-        </StackPanel>
-
         <DataGrid
-            Grid.Row="2"
-            AutoGenerateColumns="False"
-            HeadersVisibility="Column"
-            CanUserAddRows="False"
             CanUserDeleteRows="False"
-            GridLinesVisibility="All"
-            Margin="10,10,10,10"
+            AutoGenerateColumns="False"
+            CanUserAddRows="False"
             IsReadOnly="True"
+            Grid.Row="1"
+            Margin="10,0,10,0"
+            HeadersVisibility="Column"
+            GridLinesVisibility="All"
             ItemsSource="{Binding LinkedFiles}">
 
             <DataGrid.Columns>
                 <DataGridTemplateColumn>
                     <DataGridTemplateColumn.Header>
-                        <TextBlock Text="{DynamicResource MainWindow.LinkedFile}" />
+                        <TextBlock 
+                            Text="{DynamicResource MainWindow.LinkedFile}" />
+                        
                     </DataGridTemplateColumn.Header>
                     <DataGridTemplateColumn.CellTemplate>
                         <StaticResource ResourceKey="LinkedFileTemplate" />
@@ -87,41 +75,76 @@
 
                 <DataGridTemplateColumn>
                     <DataGridTemplateColumn.Header>
-                        <TextBlock Text="{DynamicResource MainWindow.WorksetType}" />
+                        <TextBlock 
+                            Text="{DynamicResource MainWindow.WorksetType}" />
+                        
                     </DataGridTemplateColumn.Header>
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <ContentControl Content="{Binding TypeWorkset}"
-                                            ContentTemplateSelector="{StaticResource WorksetSelector}" />
+                            <ContentControl 
+                                Content="{Binding TypeWorkset}"
+                                ContentTemplateSelector="{StaticResource WorksetSelector}" />
+                            
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
 
                 <DataGridTemplateColumn>
                     <DataGridTemplateColumn.Header>
-                        <TextBlock Text="{DynamicResource MainWindow.Instance}" />
+                        <TextBlock 
+                            Text="{DynamicResource MainWindow.Instance}" />
+                        
                     </DataGridTemplateColumn.Header>
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <ContentControl Content="{Binding InstanceWorkset}"
-                                            ContentTemplateSelector="{StaticResource WorksetSelector}" />
+                            <ContentControl 
+                                Content="{Binding InstanceWorkset}"
+                                ContentTemplateSelector="{StaticResource WorksetSelector}" />
+                            
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
+
+                <DataGridTemplateColumn
+                        Width="100">
+                    <DataGridTemplateColumn.Header>
+                        <TextBlock
+                            Text="{me:LocalizationSource MainWindow.Pinned}" />
+                    </DataGridTemplateColumn.Header>
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <CheckBox
+                                IsHitTestVisible="False"
+                                Focusable="False"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                IsChecked="{Binding IsPinned}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+
             </DataGrid.Columns>
         </DataGrid>
 
         <StackPanel
-            Grid.Row="3"
+            Grid.Row="2"
             Orientation="Horizontal"
             HorizontalAlignment="Right">
 
             <ui:Button
+                Width="100"
+                Margin="10"
+                Appearance="Info"
+                Content="{me:LocalizationSource MainWindow.ButtonRefresh}"
+                Command="{Binding LoadViewCommand}" />
+            
+            <ui:Button
+                IsCancel="True"
                 Margin="10"
                 Width="80"
-                IsCancel="True"
                 Click="ButtonCancel_Click"
                 Content="{me:LocalizationSource MainWindow.ButtonCancel}" />
+            
         </StackPanel>
     </Grid>
 </core:WpfUIPlatformWindow>

--- a/src/RevitCorrectNamingCheck/Views/Selectors/WorksetTemplateSelector.cs
+++ b/src/RevitCorrectNamingCheck/Views/Selectors/WorksetTemplateSelector.cs
@@ -1,8 +1,10 @@
+using System.Windows.Controls;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 
 using RevitCorrectNamingCheck.Models;
+using System.Windows.Media;
 
 namespace RevitCorrectNamingCheck.Views.Selectors;
 
@@ -24,16 +26,17 @@ public class WorksetTemplateSelector : DataTemplateSelector {
     public override DataTemplate SelectTemplate(object item, DependencyObject container) {
         var linkedFile = FindParent<DataGridRow>(container)?.DataContext as LinkedFile;
 
-        return linkedFile.FileNameStatus == NameStatus.Incorrect
-            ? DisabledTemplate
-            : item is WorksetInfo worksetInfo
-            ? worksetInfo.WorksetNameStatus switch {
-                NameStatus.Correct => CorrectTemplate,
-                NameStatus.PartialCorrect => PartialCorrectTemplate,
-                NameStatus.Incorrect => IncorrectTemplate,
-                NameStatus.None => NoMatchTemplate,
-                _ => base.SelectTemplate(item, container)
+            if(item is WorksetInfo worksetInfo) {
+                return worksetInfo.WorksetNameStatus switch {
+                    NameStatus.Correct => CorrectTemplate,
+                    NameStatus.PartialCorrect => PartialCorrectTemplate,
+                    NameStatus.Incorrect => IncorrectTemplate,
+                    NameStatus.None => NoMatchTemplate,
+                    _ => base.SelectTemplate(item, container)
+                };
             }
-            : base.SelectTemplate(item, container);
+
+            return base.SelectTemplate(item, container);
+        }
     }
 }

--- a/src/RevitCorrectNamingCheck/Views/Selectors/WorksetTemplateSelector.cs
+++ b/src/RevitCorrectNamingCheck/Views/Selectors/WorksetTemplateSelector.cs
@@ -1,10 +1,8 @@
 using System.Windows.Controls;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Media;
 
 using RevitCorrectNamingCheck.Models;
-using System.Windows.Media;
 
 namespace RevitCorrectNamingCheck.Views.Selectors;
 
@@ -39,4 +37,4 @@ public class WorksetTemplateSelector : DataTemplateSelector {
             return base.SelectTemplate(item, container);
         }
     }
-}
+

--- a/src/RevitCorrectNamingCheck/Views/Selectors/WorksetTemplateSelector.cs
+++ b/src/RevitCorrectNamingCheck/Views/Selectors/WorksetTemplateSelector.cs
@@ -35,6 +35,6 @@ public class WorksetTemplateSelector : DataTemplateSelector {
             }
 
             return base.SelectTemplate(item, container);
-        }
     }
+}
 

--- a/src/RevitCorrectNamingCheck/Views/Templates/LinkedFileTemplates.xaml
+++ b/src/RevitCorrectNamingCheck/Views/Templates/LinkedFileTemplates.xaml
@@ -25,7 +25,7 @@
                 <Setter
                     TargetName="StatusBorder"
                     Property="Background"
-                    Value="MistyRose" />
+                    Value="LightYellow" />
 
                 <Setter
                     TargetName="StatusBorder"

--- a/src/RevitCorrectNamingCheck/Views/Templates/LinkedFileTemplates.xaml
+++ b/src/RevitCorrectNamingCheck/Views/Templates/LinkedFileTemplates.xaml
@@ -1,26 +1,34 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:models="clr-namespace:RevitCorrectNamingCheck.Models">
+    xmlns:models="clr-namespace:RevitCorrectNamingCheck.Models"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml">
 
     <DataTemplate
         x:Key="LinkedFileTemplate"
         DataType="{x:Type models:LinkedFile}">
         <Border
+            CornerRadius="3"
+            Padding="5,3"
             x:Name="StatusBorder"
-            Padding="6,2"
-            CornerRadius="6"
             Background="Transparent">
 
             <TextBlock
-                Foreground="Black"
+                x:Name="StatusText"
+                Foreground="{ui:ThemeResource TextFillColorPrimaryBrush}"
                 Text="{Binding Name}" />
+            
         </Border>
 
         <DataTemplate.Triggers>
             <DataTrigger
                 Value="None"
                 Binding="{Binding FileNameStatus}">
+
+                <Setter
+                    TargetName="StatusText"
+                    Property="Foreground"
+                    Value="Black" />
 
                 <Setter
                     TargetName="StatusBorder"
@@ -36,6 +44,11 @@
             <DataTrigger
                 Value="Incorrect"
                 Binding="{Binding FileNameStatus}">
+
+                <Setter
+                    TargetName="StatusText"
+                    Property="Foreground"
+                    Value="Black" />
 
                 <Setter
                     TargetName="StatusBorder"

--- a/src/RevitCorrectNamingCheck/Views/Templates/WorksetTemplates.xaml
+++ b/src/RevitCorrectNamingCheck/Views/Templates/WorksetTemplates.xaml
@@ -8,52 +8,57 @@
         x:Key="CorrectTemplate"
         DataType="{x:Type models:LinkedFile}">
         <Border
+            SnapsToDevicePixels="True"
             CornerRadius="6"
             Padding="4,2"
             Margin="2"
-            SnapsToDevicePixels="True">
+            Background="Honeydew">
 
             <TextBlock
                 MinWidth="150"
+                Background="Honeydew"
                 Text="{Binding Name}"
                 ToolTip="{DynamicResource WorksetNameStatus.WorksetCorrect}" />
+            
         </Border>
 
-    </DataTemplate>
-
-    <DataTemplate
-        x:Key="PartialCorrectTemplate"
-        DataType="{x:Type models:LinkedFile}">
-        <Border
-            Background="Khaki"
-            CornerRadius="6"
-            Padding="4,2"
-            Margin="2"
-            SnapsToDevicePixels="True">
-
-            <TextBlock
-                MinWidth="150"
-                Background="Khaki"
-                Text="{Binding Name}"
-                ToolTip="{DynamicResource WorksetNameStatus.PartialCorrect}" />
-        </Border>
     </DataTemplate>
 
     <DataTemplate
         x:Key="IncorrectTemplate"
         DataType="{x:Type models:LinkedFile}">
         <Border
-            Background="MistyRose"
+            SnapsToDevicePixels="True"
             CornerRadius="6"
             Padding="4,2"
             Margin="2"
-            SnapsToDevicePixels="True">
+            Background="MistyRose">
 
             <TextBlock
                 MinWidth="150"
                 Background="MistyRose"
                 Text="{Binding Name}"
                 ToolTip="{DynamicResource WorksetNameStatus.Incorrect}" />
+            
+        </Border>
+    </DataTemplate>
+
+    <DataTemplate
+        x:Key="PartialCorrectTemplate"
+        DataType="{x:Type models:LinkedFile}">
+        <Border
+            SnapsToDevicePixels="True"
+            CornerRadius="6"
+            Padding="4,2"
+            Margin="2"
+            Background="LightYellow">
+
+            <TextBlock
+                MinWidth="150"
+                Background="LightYellow"
+                Text="{Binding Name}"
+                ToolTip="{DynamicResource WorksetNameStatus.PartialCorrect}" />
+            
         </Border>
     </DataTemplate>
 
@@ -61,45 +66,27 @@
         x:Key="NoMatchTemplate"
         DataType="{x:Type models:LinkedFile}">
         <Border
-            Background="MistyRose"
+            SnapsToDevicePixels="True"
             CornerRadius="6"
             Padding="4,2"
             Margin="2"
-            SnapsToDevicePixels="True">
+            Background="LightYellow">
 
             <TextBlock
                 MinWidth="150"
-                Background="MistyRose"
+                Background="LightYellow"
                 Text="{Binding Name}"
                 ToolTip="{DynamicResource WorksetNameStatus.NoMatch}" />
+            
         </Border>
     </DataTemplate>
 
-    <DataTemplate
-        x:Key="DisabledTemplate"
-        DataType="{x:Type models:LinkedFile}">
-        <Border
-            Background="LightGray"
-            CornerRadius="6"
-            Padding="4,2"
-            Margin="2"
-            SnapsToDevicePixels="True">
-
-            <TextBlock
-                Background="LightGray"
-                Foreground="Gray"
-                MinWidth="150"
-                FontStyle="Italic"
-                Text="{Binding Name}" />
-        </Border>
-
-    </DataTemplate>
 
     <local:WorksetTemplateSelector
         x:Key="WorksetSelector"
         CorrectTemplate="{StaticResource CorrectTemplate}"
         PartialCorrectTemplate="{StaticResource PartialCorrectTemplate}"
         IncorrectTemplate="{StaticResource IncorrectTemplate}"
-        NoMatchTemplate="{StaticResource NoMatchTemplate}"
-        DisabledTemplate="{StaticResource DisabledTemplate}" />
+        NoMatchTemplate="{StaticResource NoMatchTemplate}"/>
+    
 </ResourceDictionary>

--- a/src/RevitCorrectNamingCheck/Views/Templates/WorksetTemplates.xaml
+++ b/src/RevitCorrectNamingCheck/Views/Templates/WorksetTemplates.xaml
@@ -9,14 +9,15 @@
         DataType="{x:Type models:LinkedFile}">
         <Border
             SnapsToDevicePixels="True"
-            CornerRadius="6"
-            Padding="4,2"
-            Margin="2"
+            CornerRadius="3"
+            Padding="5,3"
+            Margin="3"
             Background="Honeydew">
 
             <TextBlock
                 MinWidth="150"
                 Background="Honeydew"
+                Foreground="Black"
                 Text="{Binding Name}"
                 ToolTip="{DynamicResource WorksetNameStatus.WorksetCorrect}" />
             
@@ -29,14 +30,15 @@
         DataType="{x:Type models:LinkedFile}">
         <Border
             SnapsToDevicePixels="True"
-            CornerRadius="6"
-            Padding="4,2"
-            Margin="2"
+            CornerRadius="3"
+            Padding="5,3"
+            Margin="3"
             Background="MistyRose">
 
             <TextBlock
                 MinWidth="150"
                 Background="MistyRose"
+                Foreground="Black"
                 Text="{Binding Name}"
                 ToolTip="{DynamicResource WorksetNameStatus.Incorrect}" />
             
@@ -48,14 +50,15 @@
         DataType="{x:Type models:LinkedFile}">
         <Border
             SnapsToDevicePixels="True"
-            CornerRadius="6"
-            Padding="4,2"
-            Margin="2"
+            CornerRadius="3"
+            Padding="5,3"
+            Margin="3"
             Background="LightYellow">
 
             <TextBlock
                 MinWidth="150"
                 Background="LightYellow"
+                Foreground="Black"
                 Text="{Binding Name}"
                 ToolTip="{DynamicResource WorksetNameStatus.PartialCorrect}" />
             
@@ -67,14 +70,15 @@
         DataType="{x:Type models:LinkedFile}">
         <Border
             SnapsToDevicePixels="True"
-            CornerRadius="6"
-            Padding="4,2"
-            Margin="2"
+            CornerRadius="3"
+            Padding="5,3"
+            Margin="3"
             Background="LightYellow">
 
             <TextBlock
                 MinWidth="150"
                 Background="LightYellow"
+                Foreground="Black"
                 Text="{Binding Name}"
                 ToolTip="{DynamicResource WorksetNameStatus.NoMatch}" />
             


### PR DESCRIPTION
Внесены следующие изменения:
- Добавлена колонка статуса закрепления связи
- Изменена логика заполнения статуса РН и связанного файла
- Изменены цвета статуса имени РН и связанного файла

<img width="759" height="405" alt="image" src="https://github.com/user-attachments/assets/0cddd0af-24ed-48c5-90b5-4064d8dcd1db" />
<img width="753" height="409" alt="image" src="https://github.com/user-attachments/assets/940dcde5-93bc-433d-b877-dc17a00bf5d4" />
