### PR TITLE
RevitCopyViews: Исправлен возможный NullReferenceException

### DIFF
--- a/src/RevitCopyViews/Models/RevitRepository.cs
+++ b/src/RevitCopyViews/Models/RevitRepository.cs
@@ -99,6 +99,7 @@ internal class RevitRepository {
     public IEnumerable<string> GetViewNames(IEnumerable<View> views) {
         return views
             .Select(item => item.Name)
+            .Distinct()
             .OrderBy(item => item);
     }
     

--- a/src/RevitCopyViews/ViewModels/RenameViewViewModel.cs
+++ b/src/RevitCopyViews/ViewModels/RenameViewViewModel.cs
@@ -132,7 +132,9 @@ internal class RenameViewViewModel : BaseViewModel {
                 .Select(item => new RevitViewViewModel(item)));
 
         RestrictedViewNames =
-            new ObservableCollection<string>(_revitRepository.GetViewNames(_revitRepository.GetViews()));
+            new ObservableCollection<string>(
+                _revitRepository.GetViewNames(_revitRepository.GetViews())
+                    .Except(SelectedViews.Select(item => item.OriginalName)));
 
         Prefixes = new ObservableCollection<string>(
             SelectedViews


### PR DESCRIPTION
- был исправлен NRE при запуске плагина "Переименовать виды". 

Ошибка заключалась в том, что обработчик `CanAcceptView` может вызываться до события `Load` у вида, поэтому `MainViewModel` может быть еще не инициализирована на момент вызова `CanAcceptView`.