### PR TITLE
RevitFinishing: Исправлен плагин

### DIFF
--- a/src/RevitFinishing/Models/Finishing/FinishingElements/FinishingElement.cs
+++ b/src/RevitFinishing/Models/Finishing/FinishingElements/FinishingElement.cs
@@ -148,4 +148,11 @@ internal abstract class FinishingElement {
     /// Заполнение параметров отделки, уникальных для определенного типа отделки.
     /// </summary>
     public abstract void UpdateCategoryParameters(FinishingCalculator calculator);
+
+    public void ClearFinishingParameters() {
+        _revitElement.RemoveParamValue(_paramConfig.FloorFinishingOrder);
+        _revitElement.RemoveParamValue(_paramConfig.CeilingFinishingOrder);
+        _revitElement.RemoveParamValue(_paramConfig.WallFinishingOrder);
+        _revitElement.RemoveParamValue(_paramConfig.BaseboardFinishingOrder);
+    }
 }

--- a/src/RevitFinishing/Models/Finishing/FinishingType.cs
+++ b/src/RevitFinishing/Models/Finishing/FinishingType.cs
@@ -35,6 +35,10 @@ internal class FinishingType {
     }
 
     public IEnumerable<RoomElement> Rooms => _rooms;
+    public int WallTypesNumber => _wallTypesByOrder.Count;
+    public int FloorTypesNumber => _floorTypesByOrder.Count;
+    public int CeilingTypesNumber => _ceilingTypesByOrder.Count;
+    public int BaseboardTypesNumber => _baseboardTypesByOrder.Count;
 
 
     public int GetWallOrder(string typeName) {

--- a/src/RevitFinishing/Models/Finishing/FinishingType.cs
+++ b/src/RevitFinishing/Models/Finishing/FinishingType.cs
@@ -40,7 +40,6 @@ internal class FinishingType {
     public int CeilingTypesNumber => _ceilingTypesByOrder.Count;
     public int BaseboardTypesNumber => _baseboardTypesByOrder.Count;
 
-
     public int GetWallOrder(string typeName) {
         return _wallTypesByOrder.IndexOf(typeName) + 1;
     }

--- a/src/RevitFinishing/Models/KeyFinishingType.cs
+++ b/src/RevitFinishing/Models/KeyFinishingType.cs
@@ -11,14 +11,15 @@ namespace RevitFinishing.Models;
 
 internal class KeyFinishingType {
     private readonly string _name;
+    private readonly Element _element;
     private readonly int _numberOfWalls;
     private readonly int _numberOfFloors;
     private readonly int _numberOfBaseboards;
     private readonly int _numberOCeilings;
 
-    private static SharedParamsConfig _paramConfig = SharedParamsConfig.Instance;
+    private static readonly  SharedParamsConfig _paramConfig = SharedParamsConfig.Instance;
 
-    private IList<SharedParam> _wallParams = [
+    private readonly IList<SharedParam> _wallParams = [
         _paramConfig.WallFinishingType1,
         _paramConfig.WallFinishingType2,
         _paramConfig.WallFinishingType3,
@@ -31,15 +32,41 @@ internal class KeyFinishingType {
         _paramConfig.WallFinishingType10
     ];
 
+    private readonly IList<SharedParam> _floorParams = [
+        _paramConfig.FloorFinishingType1,
+        _paramConfig.FloorFinishingType2,
+        _paramConfig.FloorFinishingType3,
+        _paramConfig.FloorFinishingType4,
+        _paramConfig.FloorFinishingType5
+    ];
+
+    private readonly IList<SharedParam> _baseboardParams = [
+        _paramConfig.BaseboardFinishingType1,
+        _paramConfig.BaseboardFinishingType2,
+        _paramConfig.BaseboardFinishingType3,
+        _paramConfig.BaseboardFinishingType4,
+        _paramConfig.BaseboardFinishingType5
+    ];
+
+    private readonly IList<SharedParam> _ceilingParams = [
+        _paramConfig.CeilingFinishingType1,
+        _paramConfig.CeilingFinishingType2,
+        _paramConfig.CeilingFinishingType3,
+        _paramConfig.CeilingFinishingType4,
+        _paramConfig.CeilingFinishingType5
+    ];
+
     public KeyFinishingType(Element keyScheduleValue) {
         _name = keyScheduleValue.Name;
+        _element = keyScheduleValue;
         _numberOfWalls = _wallParams.Count(x => keyScheduleValue.GetParam(x).HasValue);
-        _numberOfFloors = _wallParams.Count(x => keyScheduleValue.GetParam(x).HasValue);
-        _numberOfBaseboards = _wallParams.Count(x => keyScheduleValue.GetParam(x).HasValue);
-        _numberOCeilings = _wallParams.Count(x => keyScheduleValue.GetParam(x).HasValue);
+        _numberOfFloors = _floorParams.Count(x => keyScheduleValue.GetParam(x).HasValue);
+        _numberOfBaseboards = _baseboardParams.Count(x => keyScheduleValue.GetParam(x).HasValue);
+        _numberOCeilings = _ceilingParams.Count(x => keyScheduleValue.GetParam(x).HasValue);
     }
 
     public string Name => _name;
+    public Element Element => _element;
     public int NumberOfWalls => _numberOfWalls;
     public int NumberOfFloors => _numberOfFloors;
     public int NumberOfBaseboards => _numberOfBaseboards;

--- a/src/RevitFinishing/Models/KeyFinishingType.cs
+++ b/src/RevitFinishing/Models/KeyFinishingType.cs
@@ -1,0 +1,48 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+using Autodesk.Revit.DB;
+
+using dosymep.Bim4Everyone;
+using dosymep.Bim4Everyone.SharedParams;
+
+namespace RevitFinishing.Models;
+
+internal class KeyFinishingType {
+    private readonly string _name;
+    private readonly int _numberOfWalls;
+    private readonly int _numberOfFloors;
+    private readonly int _numberOfBaseboards;
+    private readonly int _numberOCeilings;
+
+    private static SharedParamsConfig _paramConfig = SharedParamsConfig.Instance;
+
+    private IList<SharedParam> _wallParams = [
+        _paramConfig.WallFinishingType1,
+        _paramConfig.WallFinishingType2,
+        _paramConfig.WallFinishingType3,
+        _paramConfig.WallFinishingType4,
+        _paramConfig.WallFinishingType5,
+        _paramConfig.WallFinishingType6,
+        _paramConfig.WallFinishingType7,
+        _paramConfig.WallFinishingType8,
+        _paramConfig.WallFinishingType9,
+        _paramConfig.WallFinishingType10
+    ];
+
+    public KeyFinishingType(Element keyScheduleValue) {
+        _name = keyScheduleValue.Name;
+        _numberOfWalls = _wallParams.Count(x => keyScheduleValue.GetParam(x).HasValue);
+        _numberOfFloors = _wallParams.Count(x => keyScheduleValue.GetParam(x).HasValue);
+        _numberOfBaseboards = _wallParams.Count(x => keyScheduleValue.GetParam(x).HasValue);
+        _numberOCeilings = _wallParams.Count(x => keyScheduleValue.GetParam(x).HasValue);
+    }
+
+    public string Name => _name;
+    public int NumberOfWalls => _numberOfWalls;
+    public int NumberOfFloors => _numberOfFloors;
+    public int NumberOfBaseboards => _numberOfBaseboards;
+    public int NumberOfCeilings => _numberOCeilings;
+
+}

--- a/src/RevitFinishing/Models/KeyFinishingType.cs
+++ b/src/RevitFinishing/Models/KeyFinishingType.cs
@@ -71,5 +71,4 @@ internal class KeyFinishingType {
     public int NumberOfFloors => _numberOfFloors;
     public int NumberOfBaseboards => _numberOfBaseboards;
     public int NumberOfCeilings => _numberOCeilings;
-
 }

--- a/src/RevitFinishing/Models/RevitRepository.cs
+++ b/src/RevitFinishing/Models/RevitRepository.cs
@@ -69,6 +69,7 @@ internal class RevitRepository {
             .WherePasses(parameterFilter)
             .OfType<Room>()
             .Select(x => x.Level)
+            .Where(x => x != null)
             .GroupBy(x => new { x.Id, x.Name })
             .Select(g => g.First());
     }

--- a/src/RevitFinishing/Models/RevitRepository.cs
+++ b/src/RevitFinishing/Models/RevitRepository.cs
@@ -68,7 +68,7 @@ internal class RevitRepository {
             .OfCategory(BuiltInCategory.OST_Rooms)
             .WherePasses(parameterFilter)
             .OfType<Room>()
-            .Select(x => x.UpperLimit)
+            .Select(x => x.Level)
             .GroupBy(x => new { x.Id, x.Name })
             .Select(g => g.First());
     }

--- a/src/RevitFinishing/Models/RevitRepository.cs
+++ b/src/RevitFinishing/Models/RevitRepository.cs
@@ -112,6 +112,6 @@ internal class RevitRepository {
     }
 
     public IList<KeyFinishingType> GetKeyFinishingTypes() {
-
+        return new List<KeyFinishingType>();
     }
 }

--- a/src/RevitFinishing/Models/RevitRepository.cs
+++ b/src/RevitFinishing/Models/RevitRepository.cs
@@ -110,4 +110,8 @@ internal class RevitRepository {
             .OfType<Room>()
             .ToList();
     }
+
+    public IList<KeyFinishingType> GetKeyFinishingTypes() {
+
+    }
 }

--- a/src/RevitFinishing/Models/RevitRepository.cs
+++ b/src/RevitFinishing/Models/RevitRepository.cs
@@ -7,6 +7,7 @@ using Autodesk.Revit.DB.Architecture;
 using Autodesk.Revit.UI;
 
 using dosymep.Bim4Everyone;
+using dosymep.Bim4Everyone.KeySchedules;
 using dosymep.Revit;
 
 using RevitFinishing.Models.Finishing;
@@ -112,6 +113,14 @@ internal class RevitRepository {
     }
 
     public IList<KeyFinishingType> GetKeyFinishingTypes() {
-        return new List<KeyFinishingType>();
+        Element schedule = new FilteredElementCollector(Document)
+            .OfClass(typeof(ViewSchedule))
+            .Where(x => x.Name == KeySchedulesConfig.Instance.RoomsFinishing.ScheduleName)
+            .First();
+
+       return new FilteredElementCollector(Document, schedule.Id)
+            .ToElements()
+            .Select(x => new KeyFinishingType(x))
+            .ToList();
     }
 }

--- a/src/RevitFinishing/Models/RevitRepository.cs
+++ b/src/RevitFinishing/Models/RevitRepository.cs
@@ -115,8 +115,7 @@ internal class RevitRepository {
     public IList<KeyFinishingType> GetKeyFinishingTypes() {
         Element schedule = new FilteredElementCollector(Document)
             .OfClass(typeof(ViewSchedule))
-            .Where(x => x.Name == KeySchedulesConfig.Instance.RoomsFinishing.ScheduleName)
-            .First();
+            .FirstOrDefault(x => x.Name == KeySchedulesConfig.Instance.RoomsFinishing.ScheduleName);
 
        return new FilteredElementCollector(Document, schedule.Id)
             .ToElements()

--- a/src/RevitFinishing/Services/FinishingValidationService.cs
+++ b/src/RevitFinishing/Services/FinishingValidationService.cs
@@ -20,46 +20,46 @@ internal class FinishingValidationService {
         _localizationService = localizationService;
     }
 
-    public IList<NoticeElementViewModel> CheckPhaseContainsFinishing(FinishingInProject finishings, 
+    public IList<WarningElementViewModel> CheckPhaseContainsFinishing(FinishingInProject finishings, 
                                                                      Phase phase) {
         return !finishings.AllFinishing.Any()
-            ? [ new NoticeElementViewModel(phase, phase.Name, _localizationService) ]
+            ? [ new WarningElementViewModel(phase, phase.Name, _localizationService) ]
             : [];
     }
 
-    public IList<NoticeElementViewModel> CheckFinishingByRoomBounding(FinishingInProject finishings, 
+    public IList<WarningElementViewModel> CheckFinishingByRoomBounding(FinishingInProject finishings, 
                                                                       Phase phase) {
         return finishings
             .AllFinishing
             .Where(x => x.RevitElement.GetParamValueOrDefault(BuiltInParameter.WALL_ATTR_ROOM_BOUNDING, 0) == 1)
-            .Select(x => new NoticeElementViewModel(x.RevitElement, phase.Name, _localizationService))
+            .Select(x => new WarningElementViewModel(x.RevitElement, phase.Name, _localizationService))
             .ToList();
     }
 
-    public IList<NoticeElementViewModel> CheckRoomsByKeyParameter(IEnumerable<Element> rooms,
+    public IList<WarningElementViewModel> CheckRoomsByKeyParameter(IEnumerable<Element> rooms,
                                                                   ProjectParam projectParam, 
                                                                   Phase phase) {
         return rooms
             .Where(x => !x.IsExistsParamValue(projectParam))
-            .Select(x => new NoticeElementViewModel(x, phase.Name, _localizationService))
+            .Select(x => new WarningElementViewModel(x, phase.Name, _localizationService))
             .ToList();
     }
 
-    public IList<NoticeElementViewModel> CheckRoomsByParameter(IEnumerable<Element> rooms,
+    public IList<WarningElementViewModel> CheckRoomsByParameter(IEnumerable<Element> rooms,
                                                                SystemParam systemParam, 
                                                                Phase phase) {
         return rooms
             .Where(x => !x.IsExistsParamValue(systemParam))
-            .Select(x => new NoticeElementViewModel(x, phase.Name, _localizationService))
+            .Select(x => new WarningElementViewModel(x, phase.Name, _localizationService))
             .ToList();
     }
 
-    public IList<NoticeElementViewModel> CheckFinishingByRoom(IEnumerable<FinishingElement> finishings, 
+    public IList<WarningElementViewModel> CheckFinishingByRoom(IEnumerable<FinishingElement> finishings, 
                                                               Phase phase) {
         return finishings
             .Where(x => !x.CheckFinishingTypes())
             .Select(x => x.RevitElement)
-            .Select(x => new NoticeElementViewModel(x, phase.Name, _localizationService))
+            .Select(x => new WarningElementViewModel(x, phase.Name, _localizationService))
             .ToList();
     }
 }

--- a/src/RevitFinishing/Services/FinishingValidationService.cs
+++ b/src/RevitFinishing/Services/FinishingValidationService.cs
@@ -21,14 +21,14 @@ internal class FinishingValidationService {
     }
 
     public IList<WarningElementViewModel> CheckPhaseContainsFinishing(FinishingInProject finishings, 
-                                                                     Phase phase) {
+                                                                      Phase phase) {
         return !finishings.AllFinishing.Any()
             ? [ new WarningElementViewModel(phase, phase.Name, _localizationService) ]
             : [];
     }
 
     public IList<WarningElementViewModel> CheckFinishingByRoomBounding(FinishingInProject finishings, 
-                                                                      Phase phase) {
+                                                                       Phase phase) {
         return finishings
             .AllFinishing
             .Where(x => x.RevitElement.GetParamValueOrDefault(BuiltInParameter.WALL_ATTR_ROOM_BOUNDING, 0) == 1)
@@ -37,8 +37,8 @@ internal class FinishingValidationService {
     }
 
     public IList<WarningElementViewModel> CheckRoomsByKeyParameter(IEnumerable<Element> rooms,
-                                                                  ProjectParam projectParam, 
-                                                                  Phase phase) {
+                                                                   ProjectParam projectParam, 
+                                                                   Phase phase) {
         return rooms
             .Where(x => !x.IsExistsParamValue(projectParam))
             .Select(x => new WarningElementViewModel(x, phase.Name, _localizationService))
@@ -46,8 +46,8 @@ internal class FinishingValidationService {
     }
 
     public IList<WarningElementViewModel> CheckRoomsByParameter(IEnumerable<Element> rooms,
-                                                               SystemParam systemParam, 
-                                                               Phase phase) {
+                                                                SystemParam systemParam, 
+                                                                Phase phase) {
         return rooms
             .Where(x => !x.IsExistsParamValue(systemParam))
             .Select(x => new WarningElementViewModel(x, phase.Name, _localizationService))
@@ -55,7 +55,7 @@ internal class FinishingValidationService {
     }
 
     public IList<WarningElementViewModel> CheckFinishingByRoom(IEnumerable<FinishingElement> finishings, 
-                                                              Phase phase) {
+                                                               Phase phase) {
         return finishings
             .Where(x => !x.CheckFinishingTypes())
             .Select(x => x.RevitElement)

--- a/src/RevitFinishing/Services/ProjectValidationService.cs
+++ b/src/RevitFinishing/Services/ProjectValidationService.cs
@@ -30,8 +30,8 @@ internal class ProjectValidationService {
     }
 
     public ErrorsViewModel CheckMainErrors(FinishingInProject allFinishing,
-                                            IEnumerable<Room> selectedRooms,
-                                            Phase phase) {
+                                           IEnumerable<Room> selectedRooms,
+                                           Phase phase) {
         var mainErrors = new ErrorsViewModel(_localizationService);
 
         mainErrors.AddElements(new ErrorsListViewModel(_localizationService) {
@@ -65,7 +65,8 @@ internal class ProjectValidationService {
     }
 
     public WarningsListViewModel CheckNumberParam(IEnumerable<Room> selectedRooms, Phase phase) {
-        var numberParam = SystemParamsConfig.Instance.CreateRevitParam(_document, BuiltInParameter.ROOM_NUMBER);
+        var numberParam = SystemParamsConfig.Instance
+            .CreateRevitParam(_document, BuiltInParameter.ROOM_NUMBER);
 
         return new WarningsListViewModel(_localizationService) {
             Description =
@@ -76,7 +77,8 @@ internal class ProjectValidationService {
     }
 
     public WarningsListViewModel CheckNameParam(IEnumerable<Room> selectedRooms, Phase phase) {
-        var nameParam = SystemParamsConfig.Instance.CreateRevitParam(_document, BuiltInParameter.ROOM_NUMBER);
+        var nameParam = SystemParamsConfig.Instance
+            .CreateRevitParam(_document, BuiltInParameter.ROOM_NUMBER);
 
         return new WarningsListViewModel(_localizationService) {
             Description =
@@ -87,7 +89,7 @@ internal class ProjectValidationService {
     }
 
     public WarningsListViewModel CheckCustomFamilies(IEnumerable<FinishingElement> finishingElements,
-                                                             Phase phase) {
+                                                     Phase phase) {
         return new WarningsListViewModel(_localizationService) {
             Description = _localizationService.GetLocalizedString("ErrorsWindow.CustomFamilies"),
             ErrorElements = [.. finishingElements
@@ -133,7 +135,6 @@ internal class ProjectValidationService {
                 }
             }
         }
-
 
         return warningList;
     }

--- a/src/RevitFinishing/Services/ProjectValidationService.cs
+++ b/src/RevitFinishing/Services/ProjectValidationService.cs
@@ -90,12 +90,28 @@ internal class ProjectValidationService {
                 .Select(x => new NoticeElementViewModel(x.RevitElement, phase.Name, _localizationService))]
         });
 
-        IList<KeyFinishingType> keys = _revitRepository.GetKeyFinishingTypes();
 
-        parameterErrors.AddElements(new WarningsListViewModel(_localizationService) {
-            Description = "Unused finishing types!",
-            ErrorElements = []
-        });
+
+
+
+        WarningsListViewModel warningList = new WarningsListViewModel(_localizationService) {
+            Description = "Unused finishing types!"
+        };
+
+        var roomsByFinishingType = calculator.RoomsByFinishingType;
+        IList<KeyFinishingType> keys = _revitRepository.GetKeyFinishingTypes();
+        foreach(var keyFinishingType in keys) {
+            var finishingType = roomsByFinishingType[keyFinishingType.Name];
+
+            if(finishingType.WallTypesNumber != keyFinishingType.NumberOfWalls) {
+                warningList.ErrorElements.Add(new NoticeElementViewModel(keyFinishingType, phase.Name, _localizationService));
+
+                
+            }
+        }
+
+
+        parameterErrors.AddElements(warningList);
 
         return parameterErrors;
     }

--- a/src/RevitFinishing/Services/ProjectValidationService.cs
+++ b/src/RevitFinishing/Services/ProjectValidationService.cs
@@ -92,7 +92,7 @@ internal class ProjectValidationService {
             Description = _localizationService.GetLocalizedString("ErrorsWindow.CustomFamilies"),
             ErrorElements = [.. finishingElements
                 .Where(x => x.IsCustomFamily)
-                .Select(x => new NoticeElementViewModel(x.RevitElement, phase.Name, _localizationService))]
+                .Select(x => new WarningElementViewModel(x.RevitElement, phase.Name, _localizationService))]
         };
     }
 
@@ -108,20 +108,28 @@ internal class ProjectValidationService {
         foreach(var keyFinishingType in keys) {
             if(roomsByFinishingType.TryGetValue(keyFinishingType.Name, out FinishingType finishingType)) {
                 if(finishingType.WallTypesNumber != keyFinishingType.NumberOfWalls) {
+                    string categoryName = _localizationService.GetLocalizedString("ErrorsWindow.Walls");
                     warningList.ErrorElements.Add(
-                        new NoticeElementViewModel(keyFinishingType.Element, phase.Name, _localizationService));                
+                        new WarningScheduleKeyVM(
+                            keyFinishingType.Element, phase.Name, categoryName, _localizationService));                
                 }
                 if(finishingType.FloorTypesNumber != keyFinishingType.NumberOfFloors) {
+                    string categoryName = _localizationService.GetLocalizedString("ErrorsWindow.Floors");
                     warningList.ErrorElements.Add(
-                        new NoticeElementViewModel(keyFinishingType.Element, phase.Name, _localizationService));
+                        new WarningScheduleKeyVM(
+                            keyFinishingType.Element, phase.Name, categoryName, _localizationService));
                 }
                 if(finishingType.BaseboardTypesNumber != keyFinishingType.NumberOfBaseboards) {
+                    string categoryName = _localizationService.GetLocalizedString("ErrorsWindow.Baseboards");
                     warningList.ErrorElements.Add(
-                        new NoticeElementViewModel(keyFinishingType.Element, phase.Name, _localizationService));
+                        new WarningScheduleKeyVM(
+                            keyFinishingType.Element, phase.Name, categoryName, _localizationService));
                 }
                 if(finishingType.CeilingTypesNumber != keyFinishingType.NumberOfCeilings) {
+                    string categoryName = _localizationService.GetLocalizedString("ErrorsWindow.Ceilings");
                     warningList.ErrorElements.Add(
-                        new NoticeElementViewModel(keyFinishingType.Element, phase.Name, _localizationService));
+                        new WarningScheduleKeyVM(
+                            keyFinishingType.Element, phase.Name, categoryName, _localizationService));
                 }
             }
         }

--- a/src/RevitFinishing/ViewModels/MainViewModel.cs
+++ b/src/RevitFinishing/ViewModels/MainViewModel.cs
@@ -158,7 +158,7 @@ internal class MainViewModel : BaseViewModel {
         }
 
         WarningsViewModel parameterErrors = _projectValidationService
-            .CheckWarnings(selectedRooms, finishingElements, _selectedPhase, _revitRepository.Document);
+            .CheckWarnings(selectedRooms, finishingElements, _selectedPhase, _revitRepository);
         _errorWindowService.ShowNoticeWindow(parameterErrors);
 
         SaveConfig();

--- a/src/RevitFinishing/ViewModels/MainViewModel.cs
+++ b/src/RevitFinishing/ViewModels/MainViewModel.cs
@@ -150,6 +150,7 @@ internal class MainViewModel : BaseViewModel {
         string transactionName = _localizationService.GetLocalizedString("MainWindow.TransactionName");
         using(Transaction t = _revitRepository.Document.StartTransaction(transactionName)) {
             foreach(FinishingElement element in finishingElements) {
+                element.ClearFinishingParameters();
                 element.UpdateFinishingParameters(calculator);
                 element.UpdateCategoryParameters(calculator);
             }

--- a/src/RevitFinishing/ViewModels/MainViewModel.cs
+++ b/src/RevitFinishing/ViewModels/MainViewModel.cs
@@ -157,8 +157,13 @@ internal class MainViewModel : BaseViewModel {
             t.Commit();
         }
 
-        WarningsViewModel parameterErrors = _projectValidationService
-            .CheckWarnings(selectedRooms, finishingElements, _selectedPhase, _revitRepository);
+        WarningsViewModel parameterErrors = new WarningsViewModel(_localizationService);
+
+        parameterErrors.AddElements(_projectValidationService.CheckNumberParam(selectedRooms, _selectedPhase));
+        parameterErrors.AddElements(_projectValidationService.CheckNameParam(selectedRooms, _selectedPhase));
+        parameterErrors.AddElements(_projectValidationService.CheckCustomFamilies(finishingElements, _selectedPhase));
+        parameterErrors.AddElements(_projectValidationService.CheckUnusedFinishing(calculator, _selectedPhase));
+
         _errorWindowService.ShowNoticeWindow(parameterErrors);
 
         SaveConfig();

--- a/src/RevitFinishing/ViewModels/Notices/IWarningItemViewModel.cs
+++ b/src/RevitFinishing/ViewModels/Notices/IWarningItemViewModel.cs
@@ -1,11 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Autodesk.Revit.DB;
-
 namespace RevitFinishing.ViewModels.Notices;
 
 internal interface IWarningItemViewModel {

--- a/src/RevitFinishing/ViewModels/Notices/IWarningItemViewModel.cs
+++ b/src/RevitFinishing/ViewModels/Notices/IWarningItemViewModel.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Autodesk.Revit.DB;
+
+namespace RevitFinishing.ViewModels.Notices;
+
+internal interface IWarningItemViewModel {
+    string ElementIdInfo { get; }
+    string ElementName { get; }
+    string CategoryInfo { get; }
+    string PhaseName { get; }
+    string LevelName { get; }
+}

--- a/src/RevitFinishing/ViewModels/Notices/Lists/NoticeListViewModel.cs
+++ b/src/RevitFinishing/ViewModels/Notices/Lists/NoticeListViewModel.cs
@@ -16,5 +16,5 @@ internal class NoticeListViewModel : BaseViewModel {
         set => RaiseAndSetIfChanged(ref _description, value);
     }
 
-    public ObservableCollection<NoticeElementViewModel> ErrorElements { get; set; }
+    public ObservableCollection<IWarningItemViewModel> ErrorElements { get; set; }
 }

--- a/src/RevitFinishing/ViewModels/Notices/WarningElementViewModel.cs
+++ b/src/RevitFinishing/ViewModels/Notices/WarningElementViewModel.cs
@@ -4,13 +4,13 @@ using dosymep.SimpleServices;
 using dosymep.WPF.ViewModels;
 
 namespace RevitFinishing.ViewModels.Notices;
-internal class NoticeElementViewModel : BaseViewModel {
+internal class WarningElementViewModel : BaseViewModel, IWarningItemViewModel {
     private readonly Element _element;
     private readonly string _phaseName;
     private readonly string _levelName;
     private readonly ILocalizationService _localizationService;
 
-    public NoticeElementViewModel(Element element,
+    public WarningElementViewModel(Element element,
                                   string phaseName,
                                   ILocalizationService localizationService) {
         _element = element;
@@ -23,9 +23,9 @@ internal class NoticeElementViewModel : BaseViewModel {
             : _localizationService.GetLocalizedString("ErrorsWindow.WithoutLevel");
     }
 
-    public ElementId ElementId => _element.Id;
+    public string ElementIdInfo => _element.Id.ToString();
     public string ElementName => _element.Name;
-    public string CategoryName => _element.Category.Name;
+    public string CategoryInfo => _element.Category.Name;
     public string PhaseName => _phaseName;
     public string LevelName => _levelName;
 }

--- a/src/RevitFinishing/ViewModels/Notices/WarningScheduleKeyVM.cs
+++ b/src/RevitFinishing/ViewModels/Notices/WarningScheduleKeyVM.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Autodesk.Revit.DB;
+
+using dosymep.SimpleServices;
+using dosymep.WPF.ViewModels;
+
+namespace RevitFinishing.ViewModels.Notices;
+
+internal class WarningScheduleKeyVM : BaseViewModel, IWarningItemViewModel {
+    private readonly Element _element;
+    private readonly string _phaseName;
+    private readonly string _levelName;
+    private readonly string _categoryInfo;
+    private readonly ILocalizationService _localizationService;
+
+    public WarningScheduleKeyVM(Element element,
+                                string phaseName,
+                                string categoryInfo,
+                                ILocalizationService localizationService) {
+        _element = element;
+        _phaseName = phaseName;
+        _localizationService = localizationService;
+        _categoryInfo = categoryInfo;
+
+        _levelName = _localizationService.GetLocalizedString("ErrorsWindow.WithoutLevel");
+    }
+
+    public string ElementIdInfo => _localizationService.GetLocalizedString("ErrorsWindow.WithoutId");
+    public string ElementName => _element.Name;
+    public string CategoryInfo => _categoryInfo;
+    public string PhaseName => _phaseName;
+    public string LevelName => _levelName;
+}

--- a/src/RevitFinishing/Views/ErrorsWindow.xaml
+++ b/src/RevitFinishing/Views/ErrorsWindow.xaml
@@ -21,7 +21,7 @@
     MinHeight="700"
     MinWidth="1200"
     
-    d:DataContext="{d:DesignInstance vms:NoticeElementViewModel, IsDesignTimeCreatable=False}">
+    d:DataContext="{d:DesignInstance vms:WarningElementViewModel, IsDesignTimeCreatable=False}">
 
     <core:WpfUIPlatformWindow.Resources>
         <ResourceDictionary>
@@ -123,11 +123,11 @@
                                 <GridViewColumn
                                     Header="{me:LocalizationSource ErrorsWindow.IdColumn}"
                                     Width="100"
-                                    DisplayMemberBinding="{Binding ElementId}"/>
+                                    DisplayMemberBinding="{Binding ElementIdInfo}"/>
                                 <GridViewColumn
                                     Header="{me:LocalizationSource ErrorsWindow.CategoryColumn}"
                                     Width="100"
-                                    DisplayMemberBinding="{Binding CategoryName}"/>
+                                    DisplayMemberBinding="{Binding CategoryInfo}"/>
                                 <GridViewColumn
                                     Header="{me:LocalizationSource ErrorsWindow.NameColumn}"
                                     Width="200"

--- a/src/RevitFinishing/assets/Localization/Language.en-US.xaml
+++ b/src/RevitFinishing/assets/Localization/Language.en-US.xaml
@@ -9,7 +9,6 @@
     <system:String x:Key="MainWindow.RoomDepartments">Room Departments:</system:String>
     <system:String x:Key="MainWindow.RoomLevels">Room Levels:</system:String>
 
-
     <system:String x:Key="MainWindow.CheckAll">Select all</system:String>
     <system:String x:Key="MainWindow.UnCheckAll">Unselect all</system:String>
     <system:String x:Key="MainWindow.InvertAll">Invert</system:String>
@@ -24,6 +23,11 @@
 
     <system:String x:Key="ErrorsWindow.Title">Calculate finishing</system:String>
 
+    <system:String x:Key="ErrorsWindow.Walls">Walls</system:String>
+    <system:String x:Key="ErrorsWindow.Floors">Floors</system:String>
+    <system:String x:Key="ErrorsWindow.Baseboards">Baseboards</system:String>
+    <system:String x:Key="ErrorsWindow.Ceilings">Ceilings</system:String>
+
     <system:String x:Key="ErrorsWindow.ErrorTypeColumn">Type</system:String>
     <system:String x:Key="ErrorsWindow.ErrorDescriptionColumn">Description</system:String>
     <system:String x:Key="ErrorsWindow.IdColumn">Id</system:String>
@@ -34,6 +38,7 @@
 
     <system:String x:Key="ErrorsWindow.WithoutValue">&lt;No value&gt;</system:String>
     <system:String x:Key="ErrorsWindow.WithoutLevel">&lt;No level&gt;</system:String>
+    <system:String x:Key="ErrorsWindow.WithoutId">&lt;No Id&gt;</system:String>
 
     <system:String x:Key="ErrorsWindow.ListErrorType">Error</system:String>
     <system:String x:Key="ErrorsWindow.ListWarningType">Warning</system:String>
@@ -51,8 +56,10 @@
     <system:String x:Key="ErrorsWindow.ErrorInfoTitle">Calculation not completed!</system:String>
     <system:String x:Key="ErrorsWindow.ErrorInfo">Check these errors:</system:String>
     <system:String x:Key="ErrorsWindow.WarningInfoTitle">Calculation completed!</system:String>
-    <system:String x:Key="ErrorsWindow.WarningInfo">But you have to check these warnings:</system:String>
+    <system:String x:Key="ErrorsWindow.WarningInfo">
+        But you have to check these warnings:
+    </system:String>
     <system:String x:Key="ErrorsWindow.UnusedFinishingTypes">
-        For finishing types some finishing materials were founded
+        For finishing styles some finishing types were not founded
     </system:String>
 </ResourceDictionary>

--- a/src/RevitFinishing/assets/Localization/Language.en-US.xaml
+++ b/src/RevitFinishing/assets/Localization/Language.en-US.xaml
@@ -51,5 +51,8 @@
     <system:String x:Key="ErrorsWindow.ErrorInfoTitle">Calculation not completed!</system:String>
     <system:String x:Key="ErrorsWindow.ErrorInfo">Check these errors:</system:String>
     <system:String x:Key="ErrorsWindow.WarningInfoTitle">Calculation completed!</system:String>
-    <system:String x:Key="ErrorsWindow.WarningInfo">But you have to check these warnings: </system:String>
+    <system:String x:Key="ErrorsWindow.WarningInfo">But you have to check these warnings:</system:String>
+    <system:String x:Key="ErrorsWindow.UnusedFinishingTypes">
+        For finishing types some finishing materials were founded
+    </system:String>
 </ResourceDictionary>

--- a/src/RevitFinishing/assets/Localization/Language.ru-RU.xaml
+++ b/src/RevitFinishing/assets/Localization/Language.ru-RU.xaml
@@ -53,4 +53,7 @@
     <system:String x:Key="ErrorsWindow.WarningInfo">
         При этом были обнаружены следующие предупреждения, которые могли повлиять на корректность расчета:
     </system:String>
+    <system:String x:Key="ErrorsWindow.UnusedFinishingTypes">
+        Для типов отделки найдены неиспользуемые материалы отделки
+    </system:String>
 </ResourceDictionary>

--- a/src/RevitFinishing/assets/Localization/Language.ru-RU.xaml
+++ b/src/RevitFinishing/assets/Localization/Language.ru-RU.xaml
@@ -22,6 +22,11 @@
     <system:String x:Key="MainWindow.TransactionName">Заполнить параметры отделки</system:String>
 
     <system:String x:Key="ErrorsWindow.Title">Рассчитать отделку</system:String>
+    
+    <system:String x:Key="ErrorsWindow.Walls">Стены</system:String>
+    <system:String x:Key="ErrorsWindow.Floors">Полы</system:String>
+    <system:String x:Key="ErrorsWindow.Baseboards">Плинтусы</system:String>
+    <system:String x:Key="ErrorsWindow.Ceilings">Потолки</system:String>
 
     <system:String x:Key="ErrorsWindow.ErrorTypeColumn">Тип</system:String>
     <system:String x:Key="ErrorsWindow.ErrorDescriptionColumn">Описание</system:String>
@@ -33,6 +38,7 @@
     
     <system:String x:Key="ErrorsWindow.WithoutValue">&lt;Без значения&gt;</system:String>
     <system:String x:Key="ErrorsWindow.WithoutLevel">&lt;Без уровня&gt;</system:String>
+    <system:String x:Key="ErrorsWindow.WithoutId">&lt;Без Id&gt;</system:String>
 
     <system:String x:Key="ErrorsWindow.ListErrorType">Ошибка</system:String> 
     <system:String x:Key="ErrorsWindow.ListWarningType">Предупреждение</system:String>
@@ -54,6 +60,6 @@
         При этом были обнаружены следующие предупреждения, которые могли повлиять на корректность расчета:
     </system:String>
     <system:String x:Key="ErrorsWindow.UnusedFinishingTypes">
-        Для типов отделки найдены неиспользуемые материалы отделки
+        Для стилей отделки найдены неиспользуемые типы отделки
     </system:String>
 </ResourceDictionary>


### PR DESCRIPTION
1. Исправлено свойство по которому выводится уровень помещений для выбора (вместо верхнего предела теперь уровень)
2. Добавлена очистка параметров отделки при каждом запуске
3. Добавлена проверка на используемые стили отделки. В ключевой спецификации у одного ключа могут быть заполнены несколько параметров типов отделки, но не все могут использоваться в проекте. Теперь плагин проверяет количество используемых типов отделки и если оно отличается от ключевой спецификации, то выводится предупреждение.