### PR TITLE
RevitClashDetective: Ускорен расчет процента пересечения

### DIFF
--- a/src/RevitClashes/Models/Clashes/ElementModel.cs
+++ b/src/RevitClashes/Models/Clashes/ElementModel.cs
@@ -5,10 +5,10 @@ using System.Linq;
 using Autodesk.Revit.DB;
 
 using dosymep.Revit;
+using dosymep.Revit.Geometry;
 
 using pyRevitLabs.Json;
 
-using RevitClashDetective.Models.Extensions;
 
 namespace RevitClashDetective.Models.Clashes {
     internal class ElementModel : IEquatable<ElementModel> {
@@ -89,7 +89,7 @@ namespace RevitClashDetective.Models.Clashes {
         }
 
         public IList<Solid> GetSolids(IEnumerable<DocInfo> documents) {
-            return GetElement(documents)?.GetSolids()
+            return GetElement(documents)?.GetSolids().ToArray()
                 ?? throw new ArgumentException($"Элемент с Id={Id} не найден в заданных документах");
         }
 


### PR DESCRIPTION
# Обновления

В ходе анализа кода в отладчике было обнаружено, что окно навигатора открывается относительно долго из-за расчета процента пересечения элементов коллизии.

Большую часть времени в этом расчете тормозил метод по получению объединенного солида:

<code>RevitClashDetective.Models.Extensions.GetUnitedSolids(this IEnumerable<Solid> solids)</code> , который вызывается из метода
<code>RevitClashDetective.Models.Extensions.GetSolids(this Element element)</code>.

Т.к. для расчета % пересечения объединенный солид не нужен, то метод <code>RevitClashDetective.Models.Extensions.GetSolids(this Element element)</code> заменен на метод из платформы
<code>dosymep.Revit.Geometry.GetSolids(this Element element)</code>, который сразу возвращает коллекцию солидов элемента и не пытается их объединить.

Замена метода `GetSolids` ускоряет запуск окна навигатора в среднем в 6 раз или примерно до 10 секунд.