### PR TITLE
RevitSleeves: Скорректировано заполнение параметров гильз

### DIFF
--- a/src/RevitSleeves/Services/Core/DocumentChecker.cs
+++ b/src/RevitSleeves/Services/Core/DocumentChecker.cs
@@ -4,7 +4,6 @@ using System.Linq;
 
 using Autodesk.Revit.DB;
 
-using dosymep.Bim4Everyone.SharedParams;
 using dosymep.Revit;
 using dosymep.SimpleServices;
 
@@ -80,7 +79,6 @@ internal class DocumentChecker : IDocumentChecker {
 
     private ICollection<string> GetMissingParameters(Family family) {
         var existingParameters = GetFamilyParameterNames(_revitRepository, family);
-        var paramConfig = SharedParamsConfig.Instance;
         string[] requiredParameters = [
             NamesProvider.ParameterSleeveDiameter,
             NamesProvider.ParameterSleeveLength,
@@ -102,10 +100,9 @@ internal class DocumentChecker : IDocumentChecker {
                 .Any(c => c.Id == category.Id))
             .Select(item => item.Definition.Name)
             .ToArray();
-        var paramConfig = SharedParamsConfig.Instance;
         string[] requiredParameters = [
-            NamesProvider.ParameterSleeveEconomic.Name,
-            NamesProvider.ParameterSleeveSystem.Name
+            NamesProvider.ParameterMepEconomic.Name,
+            NamesProvider.ParameterMepSystem.Name
         ];
         return [.. requiredParameters.Except(existingSharedParameters)];
     }

--- a/src/RevitSleeves/Services/Core/NamesProvider.cs
+++ b/src/RevitSleeves/Services/Core/NamesProvider.cs
@@ -15,6 +15,9 @@ internal static class NamesProvider {
     public const string FamilyNameOpeningArRoundInFloor = "Окн_Отв_Круг_Перекрытие";
     public const string FamilyNameOpeningArRoundInWall = "Окн_Отв_Круг_Стена";
 
+    public static readonly SharedParam ParameterMepSystem = SharedParamsConfig.Instance.VISSystemName;
+    public static readonly SharedParam ParameterMepEconomic = SharedParamsConfig.Instance.VISEconomicFunction;
+
     public static readonly SharedParam ParameterOpeningArDiameter = SharedParamsConfig.Instance.SizeDiameter;
     public static readonly SharedParam ParameterOpeningArWidth = SharedParamsConfig.Instance.SizeOpeningWidth;
     public static readonly SharedParam ParameterOpeningArHeight = SharedParamsConfig.Instance.SizeOpeningHeight;

--- a/src/RevitSleeves/Services/Placing/ParamsSetter/PipeParamsSetter.cs
+++ b/src/RevitSleeves/Services/Placing/ParamsSetter/PipeParamsSetter.cs
@@ -45,9 +45,9 @@ internal abstract class PipeParamsSetter : ParamsSetter {
 
     protected void SetStringParameters(FamilyInstance sleeve, Pipe pipe) {
         sleeve.SetParamValue(NamesProvider.ParameterSleeveSystem,
-            pipe.GetParamValue<string>(NamesProvider.ParameterSleeveSystem));
+            pipe.GetParamValue<string>(NamesProvider.ParameterMepSystem));
         sleeve.SetParamValue(NamesProvider.ParameterSleeveEconomic,
-            pipe.GetParamValue<string>(NamesProvider.ParameterSleeveEconomic));
+            pipe.GetParamValue<string>(NamesProvider.ParameterMepEconomic));
         sleeve.SetParamValue(NamesProvider.ParameterSleeveDescription,
             pipe.Name);
     }

--- a/src/RevitSleeves/Services/Update/SleeveUpdaterService.cs
+++ b/src/RevitSleeves/Services/Update/SleeveUpdaterService.cs
@@ -84,9 +84,9 @@ internal class SleeveUpdaterService : ISleeveUpdaterService {
             _errorsService.AddError([famInst, pipe], "UpdateErrors.SleeveDiameterRangeNotFound");
         }
         famInst.SetParamValue(NamesProvider.ParameterSleeveSystem,
-            pipe.GetParamValue<string>(NamesProvider.ParameterSleeveSystem));
+            pipe.GetParamValue<string>(NamesProvider.ParameterMepSystem));
         famInst.SetParamValue(NamesProvider.ParameterSleeveEconomic,
-            pipe.GetParamValue<string>(NamesProvider.ParameterSleeveEconomic));
+            pipe.GetParamValue<string>(NamesProvider.ParameterMepEconomic));
         famInst.SetParamValue(NamesProvider.ParameterSleeveDescription,
             pipe.Name);
     }


### PR DESCRIPTION
# Обновления

- Параметр трубы "ФОП_ВИС_Имя системы" записывается в параметр гильзы "ФОП_ВИС_Имя системы принудительное"
- Параметр трубы "ФОП_ВИС_Экономическая функция" записывается в параметр гильзы "ФОП_ВИС_ЭФ принудительная"