### PR TITLE
RevitClashDetective: Скорректирован импорт xml

### DIFF
--- a/src/RevitClashes/Models/RevitClashReport/NavisXmlClashesLoader.cs
+++ b/src/RevitClashes/Models/RevitClashReport/NavisXmlClashesLoader.cs
@@ -152,6 +152,8 @@ namespace RevitClashDetective.Models.RevitClashReport {
             if(elements.Length == 2) {
                 clash.MainElement = elements[0];
                 clash.OtherElement = elements[1];
+            } else {
+                throw new InvalidOperationException($"В коллизии \'{name}\' не 2 элемента");
             }
             return clash.SetRevitRepository(_revitRepository);
         }


### PR DESCRIPTION
# Обновления

- При импорте отчета xml добавлен выброс исключения, если какая-то коллизия в отчете содержит не 2 элемента