### PR TITLE
RevitSleeves: Изменены используемые параметры

### DIFF
--- a/src/RevitSleeves/Services/Core/NamesProvider.cs
+++ b/src/RevitSleeves/Services/Core/NamesProvider.cs
@@ -16,7 +16,7 @@ internal static class NamesProvider {
     public const string FamilyNameOpeningArRoundInWall = "Окн_Отв_Круг_Стена";
 
     public static readonly SharedParam ParameterMepSystem = SharedParamsConfig.Instance.VISSystemName;
-    public static readonly SharedParam ParameterMepEconomic = SharedParamsConfig.Instance.VISEconomicFunction;
+    public static readonly SharedParam ParameterMepEconomic = SharedParamsConfig.Instance.EconomicFunction;
 
     public static readonly SharedParam ParameterOpeningArDiameter = SharedParamsConfig.Instance.SizeDiameter;
     public static readonly SharedParam ParameterOpeningArWidth = SharedParamsConfig.Instance.SizeOpeningWidth;


### PR DESCRIPTION
 # Обновления
 
 - При получении значений для параметров гильз теперь берется параметр трубы "ФОП_Экономическая функция"