### PR TITLE
RevitAxonometryViewUpdate: Сортировка по "ФОП_ВИС_Имя системы", сворачивание дубликатов

### DIFF
--- a/src/RevitAxonometryViews/ViewModels/HvacSystemViewModel.cs
+++ b/src/RevitAxonometryViews/ViewModels/HvacSystemViewModel.cs
@@ -5,14 +5,29 @@ using dosymep.WPF.ViewModels;
 namespace RevitAxonometryViews.ViewModels {
     internal class HvacSystemViewModel : BaseViewModel {
         private bool _isSelected;
+        private string _displaySystemName;
+        private string _displaySharedName;
 
         public HvacSystemViewModel(string systemName, string sharedName) {
             SystemName = systemName;
             SharedName = sharedName;
+
+            _displaySystemName = systemName;
+            _displaySharedName = sharedName;
         }
 
         public string SystemName { get; }
         public string SharedName { get; }
+
+        public string DisplaySystemName {
+            get => _displaySystemName;
+            set => RaiseAndSetIfChanged(ref _displaySystemName, value);
+        }
+
+        public string DisplaySharedName {
+            get => _displaySharedName;
+            set => RaiseAndSetIfChanged(ref _displaySharedName, value);
+        }
 
         public bool IsSelected {
             get => _isSelected;

--- a/src/RevitAxonometryViews/Views/MainWindow.xaml
+++ b/src/RevitAxonometryViews/Views/MainWindow.xaml
@@ -103,12 +103,12 @@
                     x:Name="col1"
                     Header="Имя системы"
                     Width="*"
-                    Binding="{Binding Path=SystemName}"/>
+                    Binding="{Binding Path=DisplaySystemName}"/>
 
                 <DataGridTextColumn
                     Header="_ФОП_ВИС_Имя системы"
                     Width="*"
-                    Binding="{Binding Path=SharedName}"/>
+                    Binding="{Binding Path=DisplaySharedName}"/>
             </DataGrid.Columns>
         </DataGrid>
         


### PR DESCRIPTION
Апдейт для упрощения жизни проектировщиков:

1) Для упрощения работы первичный критерий сортировки заменен на ФОП_ВИС_Имя системы, вместо системного. При детальном рассмотрении оказалось, что системное мы очень редко берем в работу.

2) При этом, дублирующиеся системы с разным ФОП_ВИС_Имя системы должны схлопываться в одну позицию <Варианты>, чтобы избежать ситуаций где человек нащелкивает 50 идентичных чекбоксов из-за непонимания принципа работы.

