### PR TITLE
RevitClashDetective: Добавлено выделение элементов коллизии

### DIFF
--- a/src/RevitClashDetective/Resources/CustomGridControl.cs
+++ b/src/RevitClashDetective/Resources/CustomGridControl.cs
@@ -13,6 +13,7 @@ namespace RevitClashDetective.Resources;
 internal class CustomGridControl : GridControl {
     public bool PreventSelectedItemsResetByCellButton { get; set; }
 
+    // https://supportcenter.devexpress.com/ticket/details/t410340/disable-select-unselect-row-when-clicking-on-button-in-a-column
     protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e) {
         if(PreventSelectedItemsResetByCellButton
             && SelectedItems.Count > 1

--- a/src/RevitClashDetective/Resources/CustomGridControl.cs
+++ b/src/RevitClashDetective/Resources/CustomGridControl.cs
@@ -11,8 +11,11 @@ namespace RevitClashDetective.Resources;
 /// Кастомный грид, в котором можно делать кнопки в ячейках, которые не будут менять SelectedItems, когда их больше 1
 /// </summary>
 internal class CustomGridControl : GridControl {
+    public bool PreventSelectedItemsResetByCellButton { get; set; }
+
     protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e) {
-        if(SelectedItems.Count > 1
+        if(PreventSelectedItemsResetByCellButton
+            && SelectedItems.Count > 1
             && LayoutTreeHelper.GetVisualParents((DependencyObject) e.OriginalSource)
             .OfType<Button>()
             .FirstOrDefault() != null) {

--- a/src/RevitClashDetective/Resources/CustomGridControl.cs
+++ b/src/RevitClashDetective/Resources/CustomGridControl.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+using DevExpress.Mvvm.UI;
+using DevExpress.Xpf.Grid;
+
+namespace RevitClashDetective.Resources;
+/// <summary>
+/// Кастомный грид, в котором можно делать кнопки в ячейках, которые не будут менять SelectedItems, когда их больше 1
+/// </summary>
+internal class CustomGridControl : GridControl {
+    protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e) {
+        if(SelectedItems.Count > 1
+            && LayoutTreeHelper.GetVisualParents((DependencyObject) e.OriginalSource)
+            .OfType<Button>()
+            .FirstOrDefault() != null) {
+            return;
+        }
+        base.OnPreviewMouseLeftButtonDown(e);
+    }
+}

--- a/src/RevitClashDetective/ViewModels/Navigator/ClashViewModel.cs
+++ b/src/RevitClashDetective/ViewModels/Navigator/ClashViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 using Autodesk.Revit.DB;
 
+using dosymep.Revit;
 using dosymep.WPF.ViewModels;
 
 using RevitClashDetective.Models;
@@ -19,12 +20,14 @@ namespace RevitClashDetective.ViewModels.Navigator {
 
             ClashName = clash.Name;
 
+            FirstId = clash.MainElement.Id.GetIdValue();
             FirstCategory = clash.MainElement.Category;
             FirstTypeName = clash.MainElement.Name;
             FirstFamilyName = clash.MainElement.FamilyName;
             FirstDocumentName = clash.MainElement.DocumentName;
             FirstLevel = clash.MainElement.Level;
 
+            SecondId = clash.OtherElement.Id.GetIdValue();
             SecondCategory = clash.OtherElement.Category;
             SecondTypeName = clash.OtherElement.Name;
             SecondFamilyName = clash.OtherElement.FamilyName;
@@ -53,6 +56,12 @@ namespace RevitClashDetective.ViewModels.Navigator {
             set => RaiseAndSetIfChanged(ref _clashName, value);
         }
 
+#if REVIT_2023_OR_LESS
+        public int FirstId { get; }
+#else
+        public long FirstId { get; }
+#endif
+
         public string FirstTypeName { get; }
 
         public string FirstFamilyName { get; }
@@ -62,6 +71,12 @@ namespace RevitClashDetective.ViewModels.Navigator {
         public string FirstLevel { get; }
 
         public string FirstCategory { get; }
+
+#if REVIT_2023_OR_LESS
+        public int SecondId { get; }
+#else
+        public long SecondId { get; }
+#endif
 
         public string SecondTypeName { get; }
 

--- a/src/RevitClashDetective/ViewModels/Navigator/IClashViewModel.cs
+++ b/src/RevitClashDetective/ViewModels/Navigator/IClashViewModel.cs
@@ -1,12 +1,19 @@
 using System.Collections.Generic;
+using System.ComponentModel;
 
 using RevitClashDetective.Models.Clashes;
 
 namespace RevitClashDetective.ViewModels.Navigator;
-internal interface IClashViewModel {
+internal interface IClashViewModel : INotifyPropertyChanged {
     ClashStatus ClashStatus { get; set; }
 
     string ClashName { get; set; }
+
+#if REVIT_2023_OR_LESS
+    int FirstId { get; }
+#else
+    long FirstId { get; }
+#endif
 
     string FirstTypeName { get; }
 
@@ -17,6 +24,12 @@ internal interface IClashViewModel {
     string FirstLevel { get; }
 
     string FirstCategory { get; }
+
+#if REVIT_2023_OR_LESS
+    int SecondId { get; }
+#else
+    long SecondId { get; }
+#endif
 
     string SecondTypeName { get; }
 

--- a/src/RevitClashDetective/ViewModels/Navigator/ImaginaryFirstClashViewModel.cs
+++ b/src/RevitClashDetective/ViewModels/Navigator/ImaginaryFirstClashViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 
+using dosymep.Revit;
 using dosymep.WPF.ViewModels;
 
 using RevitClashDetective.Models.Clashes;
@@ -18,6 +19,7 @@ internal class ImaginaryFirstClashViewModel
         _firstElement = firstElement ?? throw new ArgumentNullException(nameof(firstElement));
         FirstElementVolume = firstElement.ElementVolume;
 
+        FirstId = _firstElement.Element.Id.GetIdValue();
         FirstCategory = _firstElement.Element.Category;
         FirstTypeName = _firstElement.Element.Name;
         FirstFamilyName = _firstElement.Element.FamilyName;
@@ -30,6 +32,12 @@ internal class ImaginaryFirstClashViewModel
 
     public string ClashName { get => string.Empty; set { return; } }
 
+#if REVIT_2023_OR_LESS
+    public int FirstId { get; }
+#else
+    public long FirstId { get; }
+#endif
+
     public string FirstTypeName { get; }
 
     public string FirstFamilyName { get; }
@@ -39,6 +47,12 @@ internal class ImaginaryFirstClashViewModel
     public string FirstLevel { get; }
 
     public string FirstCategory { get; }
+
+#if REVIT_2023_OR_LESS
+    public int SecondId => -1;
+#else
+    public long SecondId => -1;
+#endif
 
     public string SecondTypeName => string.Empty;
 

--- a/src/RevitClashDetective/ViewModels/Navigator/ImaginarySecondClashViewModel.cs
+++ b/src/RevitClashDetective/ViewModels/Navigator/ImaginarySecondClashViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 
+using dosymep.Revit;
 using dosymep.WPF.ViewModels;
 
 using RevitClashDetective.Models.Clashes;
@@ -18,6 +19,7 @@ internal class ImaginarySecondClashViewModel
         _secondElement = secondElement ?? throw new ArgumentNullException(nameof(secondElement));
         SecondElementVolume = secondElement.ElementVolume;
 
+        SecondId = _secondElement.Element.Id.GetIdValue();
         SecondCategory = _secondElement.Element.Category;
         SecondTypeName = _secondElement.Element.Name;
         SecondFamilyName = _secondElement.Element.FamilyName;
@@ -30,6 +32,12 @@ internal class ImaginarySecondClashViewModel
 
     public string ClashName { get => string.Empty; set { return; } }
 
+#if REVIT_2023_OR_LESS
+    public int FirstId => -1;
+#else
+    public long FirstId => -1;
+#endif
+
     public string FirstTypeName => string.Empty;
 
     public string FirstFamilyName => string.Empty;
@@ -39,6 +47,12 @@ internal class ImaginarySecondClashViewModel
     public string FirstLevel => string.Empty;
 
     public string FirstCategory => string.Empty;
+
+#if REVIT_2023_OR_LESS
+    public int SecondId { get; }
+#else
+    public long SecondId { get; }
+#endif
 
     public string SecondTypeName { get; }
 

--- a/src/RevitClashDetective/ViewModels/Navigator/ReportsViewModel.cs
+++ b/src/RevitClashDetective/ViewModels/Navigator/ReportsViewModel.cs
@@ -148,7 +148,6 @@ namespace RevitClashDetective.ViewModels.Navigator {
         private bool CanDelete() => SelectedReport != null;
 
         private void SelectClash(IClashViewModel clash) {
-            // TODO добавить обработку мнимых коллизий
             IView3DSetting settings;
             var config = SettingsConfig.GetSettingsConfig(GetPlatformService<IConfigSerializer>());
             if(ElementsIsolationEnabled) {

--- a/src/RevitClashDetective/Views/MainWindow.xaml
+++ b/src/RevitClashDetective/Views/MainWindow.xaml
@@ -104,7 +104,7 @@
 
             <dxg:GridColumn Header="Наименование" FieldName="Name" Width="Auto" SortOrder="Ascending" SortIndex="0"/>
 
-            <dxg:GridColumn Header="Выбор А" Width="*">
+            <dxg:GridColumn Header="Выбор 1" Width="*">
                 <dxg:GridColumn.CellTemplate>
                     <DataTemplate>
                         <local:ProviderComboBox
@@ -113,7 +113,7 @@
                 </dxg:GridColumn.CellTemplate>
             </dxg:GridColumn>
 
-            <dxg:GridColumn Header="Выбор В" Width="*">
+            <dxg:GridColumn Header="Выбор 2" Width="*">
                 <dxg:GridColumn.CellTemplate>
                     <DataTemplate DataType="{x:Type clashDetective:CheckViewModel}">
                         <local:ProviderComboBox

--- a/src/RevitClashDetective/Views/NavigatorView.xaml
+++ b/src/RevitClashDetective/Views/NavigatorView.xaml
@@ -137,12 +137,13 @@
         </DockPanel>
 
         <res:CustomGridControl x:Name="_dg"
-                         Grid.Row="2"
-                         AllowCollectionView="False"
-                         SelectionMode="Row"
-                         SelectedItem="{Binding SelectedReport.SelectedGuiClash}"
-                         SelectedItems="{Binding SelectedReport.SelectedGuiClashes}"
-                         ItemsSource="{Binding SelectedReport.GuiClashes}">
+                               Grid.Row="2"
+                               AllowCollectionView="False"
+                               SelectionMode="Row"
+                               PreventSelectedItemsResetByCellButton="True"
+                               SelectedItem="{Binding SelectedReport.SelectedGuiClash}"
+                               SelectedItems="{Binding SelectedReport.SelectedGuiClashes}"
+                               ItemsSource="{Binding SelectedReport.GuiClashes}">
 
             <res:CustomGridControl.GroupSummary>
                 <dxg:GridSummaryItem SummaryType="Count" />

--- a/src/RevitClashDetective/Views/NavigatorView.xaml
+++ b/src/RevitClashDetective/Views/NavigatorView.xaml
@@ -224,7 +224,6 @@
                                     Width="Auto"
                                     MinWidth="20"
                                     HorizontalAlignment="Right"
-                                    MouseDown="PickElementsButtonDown"
                                     Focusable="False"
                                     Glyph="{dx:DXImage 'Images/RichEdit/Select_16x16.png'}"
                                     Command="{Binding ElementName=_dg, Path=DataContext.SelectedReport.PickFirstElementsCommand}" />

--- a/src/RevitClashDetective/Views/NavigatorView.xaml
+++ b/src/RevitClashDetective/Views/NavigatorView.xaml
@@ -13,6 +13,7 @@
                            xmlns:base="clr-namespace:dosymep.WPF.Views"
                            xmlns:converters="clr-namespace:dosymep.WpfCore.Converters;assembly=dosymep.WpfCore"
                            xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
+                           xmlns:res="clr-namespace:RevitClashDetective.Resources"
                            xmlns:c="clr-namespace:RevitClashDetective.Models.Clashes"
                            xmlns:system="clr-namespace:System;assembly=mscorlib"
                            mc:Ignorable="d"
@@ -135,16 +136,19 @@
             </dxe:CheckEdit>
         </DockPanel>
 
-        <dxg:GridControl Name="_dg"
+        <res:CustomGridControl x:Name="_dg"
                          Grid.Row="2"
                          AllowCollectionView="False"
+                         SelectionMode="Row"
+                         SelectedItem="{Binding SelectedReport.SelectedGuiClash}"
+                         SelectedItems="{Binding SelectedReport.SelectedGuiClashes}"
                          ItemsSource="{Binding SelectedReport.GuiClashes}">
 
-            <dxg:GridControl.GroupSummary>
+            <res:CustomGridControl.GroupSummary>
                 <dxg:GridSummaryItem SummaryType="Count" />
-            </dxg:GridControl.GroupSummary>
+            </res:CustomGridControl.GroupSummary>
 
-            <dxg:GridControl.View>
+            <res:CustomGridControl.View>
                 <dxg:TableView Name="_gridView"
                                AutoWidth="True"
                                DataNavigatorButtons="Navigation"
@@ -153,9 +157,9 @@
                                VirtualizingPanel.IsVirtualizingWhenGrouping="True"
                                VirtualizingPanel.VirtualizationMode="Recycling"
                                VirtualizingPanel.IsVirtualizing="True" />
-            </dxg:GridControl.View>
+            </res:CustomGridControl.View>
 
-            <dxg:GridControl.Columns>
+            <res:CustomGridControl.Columns>
 
                 <dxg:GridColumn ReadOnly="True"
                                 Width="70"
@@ -204,6 +208,31 @@
                         </DataTemplate>
                     </dxg:GridColumn.CellTemplate>
                 </dxg:GridColumn>
+                <dxg:GridColumn ReadOnly="True"
+                                MinWidth="30"
+                                AllowResizing="True"
+                                FieldName="FirstId"
+                                Header="Id 1">
+                    <dxg:GridColumn.CellTemplate>
+                        <DataTemplate>
+                            <DockPanel>
+                                <TextBlock VerticalAlignment="Center"
+                                           Margin="4 0 0 0"
+                                           TextTrimming="CharacterEllipsis"
+                                           Text="{Binding Row.FirstId}" />
+                                <dx:SimpleButton
+                                    Width="Auto"
+                                    MinWidth="20"
+                                    HorizontalAlignment="Right"
+                                    MouseDown="PickElementsButtonDown"
+                                    Focusable="False"
+                                    Glyph="{dx:DXImage 'Images/RichEdit/Select_16x16.png'}"
+                                    Command="{Binding ElementName=_dg, Path=DataContext.SelectedReport.PickFirstElementsCommand}" />
+
+                            </DockPanel>
+                        </DataTemplate>
+                    </dxg:GridColumn.CellTemplate>
+                </dxg:GridColumn>
                 <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
                                 Header="Уровень 1"
                                 FieldName="FirstLevel" />
@@ -219,6 +248,31 @@
                 <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
                                 Header="Имя файла 1"
                                 FieldName="FirstDocumentName" />
+                <dxg:GridColumn ReadOnly="True"
+                                MinWidth="30"
+                                AllowResizing="True"
+                                FieldName="SecondId"
+                                Header="Id 2">
+                    <dxg:GridColumn.CellTemplate>
+                        <DataTemplate>
+                            <DockPanel>
+                                <TextBlock VerticalAlignment="Center"
+                                           TextAlignment="Left"
+                                           Margin="4 0 0 0"
+                                           TextTrimming="CharacterEllipsis"
+                                           Text="{Binding Row.SecondId}" />
+                                <dx:SimpleButton
+                                    Width="Auto"
+                                    MinWidth="20"
+                                    HorizontalAlignment="Right"
+                                    Focusable="False"
+                                    Glyph="{dx:DXImage 'Images/RichEdit/Select_16x16.png'}"
+                                    Command="{Binding ElementName=_dg, Path=DataContext.SelectedReport.PickSecondElementsCommand}" />
+
+                            </DockPanel>
+                        </DataTemplate>
+                    </dxg:GridColumn.CellTemplate>
+                </dxg:GridColumn>
                 <dxg:GridColumn Style="{StaticResource ReadOnlyColumn}"
                                 Header="Уровень 2"
                                 FieldName="SecondLevel" />
@@ -255,8 +309,8 @@
                         <dxe:TextEditSettings HorizontalContentAlignment="Left" />
                     </dxg:GridColumn.EditSettings>
                 </dxg:GridColumn>
-            </dxg:GridControl.Columns>
-        </dxg:GridControl>
+            </res:CustomGridControl.Columns>
+        </res:CustomGridControl>
 
         <DockPanel Grid.Row="3"
                    Margin="0 10 0 0">

--- a/src/RevitClashes/Models/RevitRepository.cs
+++ b/src/RevitClashes/Models/RevitRepository.cs
@@ -307,6 +307,9 @@ namespace RevitClashDetective.Models {
                     }
                 }
             }
+            if(references.Count == 0) {
+                return;
+            }
             _uiDocument.Selection.SetReferences(references);
         }
 #endif

--- a/src/RevitClashes/Models/RevitRepository.cs
+++ b/src/RevitClashes/Models/RevitRepository.cs
@@ -273,6 +273,25 @@ namespace RevitClashDetective.Models {
             SelectAndShowElement(elements.Select(item => item.GetElement(DocInfos)), bbox, additionalSize, view);
         }
 
+        public void SelectElements(ICollection<ElementModel> elementModels) {
+            var elements = elementModels.Select(e => e.GetElement(DocInfos))
+                .Where(e => e != null)
+                .ToArray();
+            if(elements.Length == 0) {
+                return;
+            }
+#if REVIT_2023_OR_LESS
+            var elementsFromActiveDoc = elements.Where(item => item.IsFromDocument(_document))
+                .Select(item => item.Id)
+                .ToArray();
+            if(elementsFromActiveDoc.Length > 0) {
+                _uiDocument.Selection.SetElementIds(elementsFromActiveDoc);
+            }
+#else
+            _uiDocument.Selection.SetReferences(elements.Select(e => new Reference(e)).ToArray());
+#endif
+        }
+
         public void SelectAndShowElement(ICollection<ElementModel> elements, IView3DSetting viewSettings) {
             if(elements is null) {
                 throw new ArgumentNullException(nameof(elements));


### PR DESCRIPTION
# Обновления навигатора

- Добавлены столбцы с id элементами коллизии
- Добавлены кнопки для выделения элементов коллизии в модели без 3D подрезки (в 2024 ревите работает и со связями)
- Добавлено мультиредактирование столбца со статусом коллизии и выбор всех элементов (1 или 2) всех выделенных коллизий в навигаторе

<img width="1000" src="https://github.com/user-attachments/assets/266a227c-0848-4abf-aa59-282ba5a4e0be" />
