### PR TITLE
RevitMechanicalSpecification: Обработка мультипортов, идентификация узлов 

### DIFF
--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamFiller.cs
@@ -65,8 +65,7 @@ namespace RevitMechanicalSpecification.Models.Fillers {
                 // Получаем значение оригинального параметра
                 OriginalParamValue = specificationElement.GetTypeOrInstanceParamStringValue(OriginalParamName);
             }
-
-            // Если целевой параметр ридонли - можно сразу идти дальше
+            
             PrepareValue(specificationElement);
 
             if(TargetParam.IsReadOnly) {

--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamFiller.cs
@@ -44,6 +44,9 @@ namespace RevitMechanicalSpecification.Models.Fillers {
 
         protected Document Document => _document;
 
+        protected virtual void PrepareValue(SpecificationElement specificationElement) {
+        }
+
         public abstract void SetParamValue(SpecificationElement specificationElement);
 
         public void Fill(SpecificationElement specificationElement) {
@@ -64,6 +67,8 @@ namespace RevitMechanicalSpecification.Models.Fillers {
             }
 
             // Если целевой параметр ридонли - можно сразу идти дальше
+            PrepareValue(specificationElement);
+
             if(TargetParam.IsReadOnly) {
                 return;
             }

--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamNameFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamNameFiller.cs
@@ -17,6 +17,14 @@ using RevitMechanicalSpecification.Service;
 namespace RevitMechanicalSpecification.Models.Fillers {
     internal class ElementParamNameFiller : ElementParamFiller {
         private readonly VisElementsCalculator _calculator;
+        private const string ManifoldAddon = ", в составе:";
+        private static readonly IReadOnlyList<string> _manifoldNameEndings = new List<string> {
+            "В составе:",
+            "в составе:",
+            "В составе",
+            "в составе",
+            ":"
+        };
         private string _name;
         private string _nameAddon;
 
@@ -30,8 +38,12 @@ namespace RevitMechanicalSpecification.Models.Fillers {
             _calculator = visElementsCalculator;
         }
 
+        protected override void PrepareValue(SpecificationElement specificationElement) {
+            specificationElement.ElementName = GetName(specificationElement);
+        }
+
         public override void SetParamValue(SpecificationElement specificationElement) {
-            string name = GetName(specificationElement);
+            string name = specificationElement.ElementName ?? GetName(specificationElement);
 
             TargetParam.Set(specificationElement.ManifoldInstance != null
                 ? $"‎    •  {name}"
@@ -49,6 +61,7 @@ namespace RevitMechanicalSpecification.Models.Fillers {
         private string GetName(SpecificationElement specificationElement) {
             _name = specificationElement.GetTypeOrInstanceParamStringValue(Config.OriginalParamNameName);
             _nameAddon = specificationElement.GetTypeOrInstanceParamStringValue(Config.NameAddition);
+
 
             if(string.IsNullOrEmpty(_name)) {
                 _name = "ЗАПОЛНИТЕ НАИМЕНОВАНИЕ";
@@ -72,7 +85,35 @@ namespace RevitMechanicalSpecification.Models.Fillers {
                     return GetFlexElementName(specificationElement);
             }
 
+            string baseName = GetBaseName();
+            if(specificationElement.ElementType.GetSharedParamValueOrDefault<int>(Config.IsManiFoldParamName) == 1) {
+                // Данный пункт необходим для обработки нейросетевым помощником сметчиков, 
+                // необходима подстрока однозначно диктующая что это материнский элемент узла, т.к. его стоимость зануляется
+                return ReplaceOrAppendManifoldAddon(baseName);
+            }
+
+            return baseName;
+        }
+
+        private string GetBaseName() {
             return string.IsNullOrEmpty(_nameAddon) ? _name : $"{_name} {_nameAddon}";
+        }
+
+        private string ReplaceOrAppendManifoldAddon(string name) {
+            string normalizedName = name.TrimEnd();
+
+            foreach(string ending in _manifoldNameEndings.OrderByDescending(item => item.Length)) {
+                if(normalizedName.EndsWith(ending, StringComparison.OrdinalIgnoreCase)) {
+                    string trimmedName = normalizedName
+                        .Substring(0, normalizedName.Length - ending.Length)
+                        .TrimEnd(' ', ',', '.', ':');
+                    return string.IsNullOrEmpty(trimmedName)
+                        ? ManifoldAddon.TrimStart(',', ' ')
+                        : $"{trimmedName}{ManifoldAddon}";
+                }
+            }
+
+            return $"{normalizedName}{ManifoldAddon}";
         }
 
         /// <summary>

--- a/src/RevitMechanicalSpecification/Service/VisElementsCalculator.cs
+++ b/src/RevitMechanicalSpecification/Service/VisElementsCalculator.cs
@@ -61,19 +61,25 @@ namespace RevitMechanicalSpecification.Service {
         /// <returns></returns>
         public string GetDuctFittingName(Element element) {
             string thikness = GetDuctFittingThikness(element);
-            if(thikness is null) {
+            string startName = "Не удалось определить тип фитинга";
+            FamilyInstance instanse = element as FamilyInstance;
+            MechanicalFitting fitting = instanse.MEPModel as MechanicalFitting;
+            
+            if(thikness is null && fitting.PartType != PartType.MultiPort) {
                 return "!Не учитывать";
             }
 
             if(!_specConfiguration.IsSpecifyDuctFittings) {
                 return "Металл для фасонных деталей воздуховодов с толщиной стенки " + thikness + " мм";
             }
-
-            string startName = "Не удалось определить тип фитинга";
-            FamilyInstance instanse = element as FamilyInstance;
-            MechanicalFitting fitting = instanse.MEPModel as MechanicalFitting;
-
+            
             switch(fitting.PartType) {
+                case PartType.MultiPort:
+                    Element elementType = element.GetElementType();
+                    startName = element.GetTypeOrInstanceParamStringValue(
+                        elementType, 
+                        _specConfiguration.OriginalParamNameName);
+                    return startName;
                 case PartType.Transition:
                     startName = "Переход между сечениями воздуховода";
                     break;


### PR DESCRIPTION
1) Исправлена недоработка в формировании группирований - ранее если параметр ФОП_ВИС_Наименование был ридонли, он не попадал в группирование
2) Добавлена отдельная логика работы с мультипортами воздуховодов - ранее не применялись в работе, теперь должно браться их наименование
3) Учтено обязательное добавление подстроки ", в составе:" на конец материнских элементов узлов для их однозначной идентификации в пост-обработке