### PR TITLE
RevitDeclarations: Исправлена кодировка при экспорте в csv

### DIFF
--- a/src/RevitDeclarations/Models/Export/Exporters/CsvExporter.cs
+++ b/src/RevitDeclarations/Models/Export/Exporters/CsvExporter.cs
@@ -15,7 +15,7 @@ internal class CsvExporter : ITableExporter {
 
         string strData = ConvertDataTableToString(table);
 
-        using(var writer = new StreamWriter(fullPath, false, new UTF8Encoding(true))) {
+        using(var writer = new StreamWriter(fullPath, false, Encoding.UTF8)) {
             writer.Write(strData);
         }
 

--- a/src/RevitDeclarations/Models/Export/Exporters/CsvExporter.cs
+++ b/src/RevitDeclarations/Models/Export/Exporters/CsvExporter.cs
@@ -15,8 +15,8 @@ internal class CsvExporter : ITableExporter {
 
         string strData = ConvertDataTableToString(table);
 
-        using(var file = File.CreateText(fullPath)) {
-            file.Write(strData);
+        using(var writer = new StreamWriter(fullPath, false, new UTF8Encoding(true))) {
+            writer.Write(strData);
         }
 
         if(table.SubTables.Any()) {


### PR DESCRIPTION
При экспорте в csv слетала кодировка в некоторых программах, теперь явно указана кодировка UTF8 со спецификацией