### PR TITLE
RevitBuildCoordVolumes: Прокидывание прогресс-бара в тяжелые классы/методы

### DIFF
--- a/src/RevitBuildCoordVolumes/Models/BuildCoordVolumesProcessor.cs
+++ b/src/RevitBuildCoordVolumes/Models/BuildCoordVolumesProcessor.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Threading;
-
 using dosymep.Revit;
-using dosymep.SimpleServices;
 
 using RevitBuildCoordVolumes.Models.Interfaces;
 using RevitBuildCoordVolumes.Models.Services;
@@ -14,7 +10,6 @@ internal class BuildCoordVolumesProcessor {
     private readonly RevitRepository _revitRepository;
     private readonly BuildCoordVolumeSettings _settings;
     private readonly BuildCoordVolumeServices _services;
-    private readonly ILocalizationService _localizationService;
     private readonly ICoordVolumeBuilder _builder;
     private readonly BuilderFactory _builderFactory;
 
@@ -25,7 +20,6 @@ internal class BuildCoordVolumesProcessor {
         _revitRepository = revitRepository;
         _settings = settings;
         _services = services;
-        _localizationService = _services.LocalizationService;
         _builderFactory = new BuilderFactory(_revitRepository, _settings, _services);
         _builder = _builderFactory.Create(_settings.AlgorithmType);
     }
@@ -35,27 +29,24 @@ internal class BuildCoordVolumesProcessor {
     /// <remarks>
     /// В данном методе происходит транзакция, экструзия объемных элементов и назначения им параметров по исходным зонам.
     /// </remarks>
-    /// <param name="progress">Прогресс.</param>
-    /// <param name="ct">Токен отмены.</param>
+    /// <param name="progressService">Прогресс сервис.</param>
     /// <returns>
     /// Void.
     /// </returns>
-    public void Run(IProgress<int> progress = null, CancellationToken ct = default) {
-
-        string transactionName = _localizationService.GetLocalizedString("BuildCoordVolumesProcessor.TransactionName");
+    public void Run(ProgressService progressService = null) {
+        string transactionName = _services.LocalizationService.GetLocalizedString("BuildCoordVolumesProcessor.TransactionName");
         using var t = _revitRepository.Document.StartTransaction(transactionName);
+        var spatialObjects = _settings.SpatialObjects;
 
-        int pro = 0;
-        foreach(var spatialObject in _settings.SpatialObjects) {
-            ct.ThrowIfCancellationRequested();
+        for(int i = 0; i < spatialObjects.Count; i++) {
+            progressService?.CancellationToken.ThrowIfCancellationRequested();
+            progressService.ZoneNumber = (i + 1).ToString();
 
-            var geomElements = _builder.Build(spatialObject);
+            var geomElements = _builder.Build(spatialObjects[i], progressService);
 
             var directShapeElements = _services.DirectShapeObjectFactory.GetDirectShapeObjects(geomElements, _revitRepository);
 
-            _services.ParamSetter.SetParams(spatialObject.SpatialElement, directShapeElements, _settings);
-
-            progress?.Report(++pro);
+            _services.ParamSetter.SetParams(spatialObjects[i].SpatialElement, directShapeElements, _settings);
         }
         t.Commit();
     }

--- a/src/RevitBuildCoordVolumes/Models/BuilderFactory.cs
+++ b/src/RevitBuildCoordVolumes/Models/BuilderFactory.cs
@@ -30,21 +30,9 @@ internal sealed class BuilderFactory {
     /// </returns>
     public ICoordVolumeBuilder Create(AlgorithmType algorithmType) {
         return algorithmType == AlgorithmType.SlabBasedAlgorithm
-            ? new SlabBasedCoordVolumeBuilder(
-                _services.SpatialDivider,
-                _services.SlabNormalizer,
-                _services.ColumnFactory,
-                _services.GeomObjectFactory,
-                _revitRepository,
-                _settings)
+            ? new SlabBasedCoordVolumeBuilder(_revitRepository, _services, _settings)
             : algorithmType == AlgorithmType.ParamBasedAlgorithm
-            ? new ParamBasedCoordVolumeBuilder(
-                _services.GeomObjectFactory,
-                _revitRepository,
-                _settings)
-            : new ParamBasedCoordVolumeBuilder(
-                _services.GeomObjectFactory,
-                _revitRepository,
-                _settings);
+            ? new ParamBasedCoordVolumeBuilder(_revitRepository, _services, _settings)
+            : new ParamBasedCoordVolumeBuilder(_revitRepository, _services, _settings);
     }
 }

--- a/src/RevitBuildCoordVolumes/Models/ColumnFactory.cs
+++ b/src/RevitBuildCoordVolumes/Models/ColumnFactory.cs
@@ -3,8 +3,10 @@ using System.Linq;
 
 using Autodesk.Revit.DB;
 
+using RevitBuildCoordVolumes.Models.Enums;
 using RevitBuildCoordVolumes.Models.Geometry;
 using RevitBuildCoordVolumes.Models.Interfaces;
+using RevitBuildCoordVolumes.Models.Services;
 
 namespace RevitBuildCoordVolumes.Models;
 
@@ -12,8 +14,9 @@ internal class ColumnFactory : IColumnFactory {
     // Длина линии для пресечения, примерно 100 этажей
     private const double _rayHeight = 1000;
 
-    public IEnumerable<IGrouping<string, ColumnObject>> GenerateColumnGroups(List<PolygonObject> polygons, List<SlabElement> slabs) {
-        var columns = GetColumns(polygons, slabs);
+    public IEnumerable<IGrouping<string, ColumnObject>> GenerateColumnGroups(
+        List<PolygonObject> polygons, List<SlabElement> slabs, ProgressService progressService) {
+        var columns = GetColumns(polygons, slabs, progressService);
 
         // Группируем по GUID плит - низ + верх      
         return columns
@@ -21,16 +24,33 @@ internal class ColumnFactory : IColumnFactory {
     }
 
     // Метод генерации колонн
-    private List<ColumnObject> GetColumns(List<PolygonObject> polygons, List<SlabElement> slabs) {
+    private List<ColumnObject> GetColumns(
+        List<PolygonObject> polygons, List<SlabElement> slabs, ProgressService progressService) {
         if(polygons.Count == 0 || slabs.Count < 2) {
             return [];
         }
         var columns = new List<ColumnObject>();
 
+        progressService?.BeginStage(ProgressType.BuildVolumes);
+        int total = polygons.Count;
+        int processed = 0;
+        int reported = 0;
+
         foreach(var polygon in polygons) {
+            progressService?.CancellationToken.ThrowIfCancellationRequested();
             var center = polygon.Center;
             var points = new List<SlabObject>(slabs.Count);
             var line = Line.CreateBound(center + XYZ.BasisZ * _rayHeight, center - XYZ.BasisZ * _rayHeight);
+
+            processed++;
+            int current = processed * 100 / total;
+            if(current > 100) {
+                current = 100;
+            }
+            if(current > reported) {
+                reported = current;
+                progressService?.ProgressCount?.Report(reported);
+            }
 
             foreach(var slab in slabs) {
                 double z = double.NaN;

--- a/src/RevitBuildCoordVolumes/Models/Enums/ProgressType.cs
+++ b/src/RevitBuildCoordVolumes/Models/Enums/ProgressType.cs
@@ -1,0 +1,7 @@
+namespace RevitBuildCoordVolumes.Models.Enums;
+internal enum ProgressType {
+    DivideSpatial,
+    BuildContour,
+    SlabNormalize,
+    BuildVolumes
+}

--- a/src/RevitBuildCoordVolumes/Models/GeomObjectFactory.cs
+++ b/src/RevitBuildCoordVolumes/Models/GeomObjectFactory.cs
@@ -3,8 +3,10 @@ using System.Linq;
 
 using Autodesk.Revit.DB;
 
+using RevitBuildCoordVolumes.Models.Enums;
 using RevitBuildCoordVolumes.Models.Geometry;
 using RevitBuildCoordVolumes.Models.Interfaces;
+using RevitBuildCoordVolumes.Models.Services;
 using RevitBuildCoordVolumes.Models.Utilites;
 
 namespace RevitBuildCoordVolumes.Models;
@@ -20,10 +22,15 @@ internal class GeomObjectFactory : IGeomObjectFactory {
         SpatialElement spatialElement,
         double startExtrudePosition,
         double finishExtrudePosition,
-        double basePointOffset) {
+        double basePointOffset,
+        ProgressService progressService) {
+
+        progressService?.BeginStage(ProgressType.BuildVolumes);
 
         var listCurveLoops = _contourService.GetSimpleCurveLoops(spatialElement, startExtrudePosition, basePointOffset);
         var solid = SolidUtility.ExtrudeSolid(listCurveLoops, startExtrudePosition, finishExtrudePosition);
+
+        progressService?.ProgressCount?.Report(100);
 
         return solid == null
             ? []
@@ -31,14 +38,17 @@ internal class GeomObjectFactory : IGeomObjectFactory {
                 GeometryObjects = [solid],
                 Volume = solid.Volume
             }];
+
     }
 
-    public List<GeomObject> GetUnitedGeomObjects(List<ColumnObject> columns, double spatialElementPosition) {
+    public List<GeomObject> GetUnitedGeomObjects(
+        List<ColumnObject> columns, double spatialElementPosition, ProgressService progressService) {
         var firstElement = columns[0];
         double startExtrudePosition = firstElement.StartPosition;
         double finishExtrudePosition = firstElement.FinishPosition;
 
-        var listCurveLoops = _contourService.GetColumnsCurveLoops(columns, spatialElementPosition, startExtrudePosition);
+        var listCurveLoops = _contourService.GetColumnsCurveLoops(
+            columns, spatialElementPosition, startExtrudePosition, progressService);
         var solid = SolidUtility.ExtrudeSolid(listCurveLoops, startExtrudePosition, finishExtrudePosition);
 
         if(solid == null) {
@@ -55,11 +65,17 @@ internal class GeomObjectFactory : IGeomObjectFactory {
             })];
     }
 
-    public List<GeomObject> GetSeparatedGeomObjects(List<ColumnObject> columns, double spatialElementPosition) {
+    public List<GeomObject> GetSeparatedGeomObjects(
+        List<ColumnObject> columns, double spatialElementPosition, ProgressService progressService) {
         var solids = new List<GeometryObject>();
         var volumes = new List<double>();
         var firstElement = columns[0];
+        progressService?.BeginStage(ProgressType.BuildContour);
+        int total = columns.Count;
+        int processed = 0;
+        int reported = 0;
         foreach(var column in columns) {
+            progressService?.CancellationToken.ThrowIfCancellationRequested();
             double startExtrudePosition = column.StartPosition;
             double finishExtrudePosition = column.FinishPosition;
 
@@ -68,6 +84,15 @@ internal class GeomObjectFactory : IGeomObjectFactory {
             if(solid != null) {
                 solids.Add(solid);
                 volumes.Add(solid.Volume);
+            }
+            processed++;
+            int current = processed * 100 / total;
+            if(current > 100) {
+                current = 100;
+            }
+            if(current > reported) {
+                reported = current;
+                progressService?.ProgressCount?.Report(reported);
             }
         }
 

--- a/src/RevitBuildCoordVolumes/Models/Interfaces/IColumnFactory.cs
+++ b/src/RevitBuildCoordVolumes/Models/Interfaces/IColumnFactory.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using RevitBuildCoordVolumes.Models.Geometry;
+using RevitBuildCoordVolumes.Models.Services;
 
 namespace RevitBuildCoordVolumes.Models.Interfaces;
 
@@ -14,8 +15,9 @@ internal interface IColumnFactory {
     /// </remarks>
     /// <param name="polygons">Список полигонов, на которые была разбита зона.</param>    
     /// <param name="slabs">Список плит перекрытий, служащих для определения точек пересечения.</param>
+    /// <param name="progressService">ProgressService.</param>
     /// <returns>
     /// Коллекция групп ColumnObject, где ключ параметр группировки (GUID низа и верха плиты).
     /// </returns>
-    IEnumerable<IGrouping<string, ColumnObject>> GenerateColumnGroups(List<PolygonObject> polygons, List<SlabElement> slabs);
+    IEnumerable<IGrouping<string, ColumnObject>> GenerateColumnGroups(List<PolygonObject> polygons, List<SlabElement> slabs, ProgressService progressService);
 }

--- a/src/RevitBuildCoordVolumes/Models/Interfaces/IContourService.cs
+++ b/src/RevitBuildCoordVolumes/Models/Interfaces/IContourService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Autodesk.Revit.DB;
 
 using RevitBuildCoordVolumes.Models.Geometry;
+using RevitBuildCoordVolumes.Models.Services;
 
 namespace RevitBuildCoordVolumes.Models.Interfaces;
 
@@ -16,10 +17,15 @@ internal interface IContourService {
     /// <param name="columns">Список колонн, которые были сформированы ColumnFactory.</param>    
     /// <param name="spatialElementPosition">Реальная позиция кривой исходной зоны.</param>
     /// <param name="startExtrudePosition">Позиция для старта экструзии.</param>
+    /// <param name="progressService">ProgressService.</param>
     /// <returns>
     /// Список CurveLoop для построения Solid.
     /// </returns>
-    List<CurveLoop> GetColumnsCurveLoops(List<ColumnObject> columns, double spatialElementPosition, double startExtrudePosition);
+    List<CurveLoop> GetColumnsCurveLoops(
+        List<ColumnObject> columns,
+        double spatialElementPosition,
+        double startExtrudePosition,
+        ProgressService progressService);
     /// <summary>
     /// Метод получения контура по ColumnObject.
     /// </summary>
@@ -28,7 +34,7 @@ internal interface IContourService {
     /// </remarks>
     /// <param name="column">Колонна, которые были сформирована ColumnFactory.</param>    
     /// <param name="spatialElementPosition">Реальная позиция кривой исходной зоны.</param>
-    /// <param name="startExtrudePosition">Позиция для старта экструзии.</param>
+    /// <param name="startExtrudePosition">Позиция для старта экструзии.</param>    
     /// <returns>
     /// Список CurveLoop для построения Solid.
     /// </returns>

--- a/src/RevitBuildCoordVolumes/Models/Interfaces/ICoordVolumeBuilder.cs
+++ b/src/RevitBuildCoordVolumes/Models/Interfaces/ICoordVolumeBuilder.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 
 using RevitBuildCoordVolumes.Models.Geometry;
+using RevitBuildCoordVolumes.Models.Services;
 
 namespace RevitBuildCoordVolumes.Models.Interfaces;
 
@@ -15,5 +16,5 @@ internal interface ICoordVolumeBuilder {
     /// <returns>
     /// Список GeomObject дальнейшего присвоение параметров.
     /// </returns>
-    List<GeomObject> Build(SpatialObject spatialElement);
+    List<GeomObject> Build(SpatialObject spatialElement, ProgressService pro);
 }

--- a/src/RevitBuildCoordVolumes/Models/Interfaces/IGeomObjectFactory.cs
+++ b/src/RevitBuildCoordVolumes/Models/Interfaces/IGeomObjectFactory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Autodesk.Revit.DB;
 
 using RevitBuildCoordVolumes.Models.Geometry;
+using RevitBuildCoordVolumes.Models.Services;
 
 namespace RevitBuildCoordVolumes.Models.Interfaces;
 internal interface IGeomObjectFactory {
@@ -16,11 +17,16 @@ internal interface IGeomObjectFactory {
     /// <param name="startExtrudePosition">Позиция для старта экструзии.</param>   
     /// <param name="finishExtrudePosition">Позиция для конца экструзии.</param>   
     /// <param name="basePointOffset">Смещение базовой точки проекта относительно внутреннего начала.</param>   
+    /// <param name="progressService">Прогресс сервис.</param>   
     /// <returns>
     /// Список геометрических элементов GeomObject.
     /// </returns>
     List<GeomObject> GetSimpleGeomObjects(
-        SpatialElement spatialElement, double startExtrudePosition, double finishExtrudePosition, double basePointOffset);
+        SpatialElement spatialElement,
+        double startExtrudePosition,
+        double finishExtrudePosition,
+        double basePointOffset,
+        ProgressService progressService);
     /// <summary>
     /// Метод получения списка геометрических объектов по списку колонн.
     /// </summary>
@@ -29,10 +35,14 @@ internal interface IGeomObjectFactory {
     /// </remarks>
     /// <param name="columns">Колонны, построенные ColumnFactory.</param>   
     /// <param name="spatialElementPosition">Реальная позиция кривой исходной зоны.</param> 
+    /// <param name="progressService">Прогресс сервис.</param>  
     /// <returns>
     /// Список геометрических элементов GeomObject.
     /// </returns>
-    List<GeomObject> GetUnitedGeomObjects(List<ColumnObject> columns, double spatialElementPosition);
+    List<GeomObject> GetUnitedGeomObjects(
+        List<ColumnObject> columns,
+        double spatialElementPosition,
+        ProgressService progressService);
     /// <summary>
     /// Метод получения списка геометрических объектов по списку колонн.
     /// </summary>
@@ -41,8 +51,12 @@ internal interface IGeomObjectFactory {
     /// </remarks>
     /// <param name="columns">Колонны, построенные ColumnFactory.</param>   
     /// <param name="spatialElementPosition">Реальная позиция кривой исходной зоны.</param> 
+    /// <param name="progressService">Прогресс сервис.</param>  
     /// <returns>
     /// Список геометрических элементов GeomObject.
     /// </returns>
-    List<GeomObject> GetSeparatedGeomObjects(List<ColumnObject> columns, double spatialElementPosition);
+    List<GeomObject> GetSeparatedGeomObjects(
+        List<ColumnObject> columns,
+        double spatialElementPosition,
+        ProgressService progressService);
 }

--- a/src/RevitBuildCoordVolumes/Models/Interfaces/ISpatialElementDividerService.cs
+++ b/src/RevitBuildCoordVolumes/Models/Interfaces/ISpatialElementDividerService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Autodesk.Revit.DB;
 
 using RevitBuildCoordVolumes.Models.Geometry;
+using RevitBuildCoordVolumes.Models.Services;
 
 namespace RevitBuildCoordVolumes.Models.Interfaces;
 
@@ -20,5 +21,5 @@ internal interface ISpatialElementDividerService {
     /// <returns>
     /// Коллекция полигонов, представляющих фрагменты исходной зоны после разбиения.
     /// </returns>
-    List<PolygonObject> DivideSpatialElement(SpatialElement spatialElement, double side, double angleDeg);
+    List<PolygonObject> DivideSpatialElement(SpatialElement spatialElement, double side, double angleDeg, ProgressService pro);
 }

--- a/src/RevitBuildCoordVolumes/Models/ParamBasedCoordVolumeBuilder.cs
+++ b/src/RevitBuildCoordVolumes/Models/ParamBasedCoordVolumeBuilder.cs
@@ -4,25 +4,26 @@ using System.Linq;
 using RevitBuildCoordVolumes.Models.Enums;
 using RevitBuildCoordVolumes.Models.Geometry;
 using RevitBuildCoordVolumes.Models.Interfaces;
+using RevitBuildCoordVolumes.Models.Services;
 using RevitBuildCoordVolumes.Models.Settings;
 
 namespace RevitBuildCoordVolumes.Models;
 
 internal class ParamBasedCoordVolumeBuilder : ICoordVolumeBuilder {
-    private readonly IGeomObjectFactory _geomElementFactory;
+    private readonly IGeomObjectFactory _geomObjectFactory;
     private readonly RevitRepository _revitRepository;
     private readonly BuildCoordVolumeSettings _settings;
 
     public ParamBasedCoordVolumeBuilder(
-        IGeomObjectFactory geomElementFactory,
         RevitRepository revitRepository,
+        BuildCoordVolumeServices services,
         BuildCoordVolumeSettings settings) {
-        _geomElementFactory = geomElementFactory;
         _revitRepository = revitRepository;
+        _geomObjectFactory = services.GeomObjectFactory;
         _settings = settings;
     }
 
-    public List<GeomObject> Build(SpatialObject spatialObject) {
+    public List<GeomObject> Build(SpatialObject spatialObject, ProgressService progressService) {
         var spatialElement = spatialObject.SpatialElement;
 
         var topZoneParam = _settings.ParamMaps
@@ -38,11 +39,12 @@ internal class ParamBasedCoordVolumeBuilder : ICoordVolumeBuilder {
 
         double basePointOffset = _revitRepository.GetBasePointOffset();
 
-        var listGeomObjects = _geomElementFactory.GetSimpleGeomObjects(
+        var listGeomObjects = _geomObjectFactory.GetSimpleGeomObjects(
             spatialElement,
             bottomPosition,
             topPosition,
-            basePointOffset);
+            basePointOffset,
+            progressService);
 
         return listGeomObjects.Count > 0
             ? listGeomObjects

--- a/src/RevitBuildCoordVolumes/Models/Services/BuildCoordVolumeServices.cs
+++ b/src/RevitBuildCoordVolumes/Models/Services/BuildCoordVolumeServices.cs
@@ -15,6 +15,7 @@ internal sealed class BuildCoordVolumeServices {
         IWindowService windowService) {
         LocalizationService = localizationService;
         RevitParamFactory = revitParamFactory;
+        ContourService = new ContourService();
         GeomObjectFactory = new GeomObjectFactory(ContourService);
         CategoryAvailabilityService = new CategoryAvailabilityService(revitRepository.Document);
         DirectShapeObjectFactory = new DirectShapeObjectFactory(systemPluginConfig);
@@ -23,12 +24,13 @@ internal sealed class BuildCoordVolumeServices {
         SpatialElementCheckService = new SpatialElementCheckService(ContourService);
         SpatialDivider = new SpatialElementDividerService(ContourService);
         SlabNormalizer = new SlabNormalizeService(systemPluginConfig);
+        ColumnFactory = new ColumnFactory();
     }
 
     public ISpatialElementDividerService SpatialDivider { get; }
     public ISlabNormalizeService SlabNormalizer { get; }
-    public IColumnFactory ColumnFactory { get; } = new ColumnFactory();
-    public IContourService ContourService { get; } = new ContourService();
+    public IColumnFactory ColumnFactory { get; }
+    public IContourService ContourService { get; }
     public IGeomObjectFactory GeomObjectFactory { get; }
     public IParamSetter ParamSetter { get; }
     public IDirectShapeObjectFactory DirectShapeObjectFactory { get; }

--- a/src/RevitBuildCoordVolumes/Models/Services/ContourService.cs
+++ b/src/RevitBuildCoordVolumes/Models/Services/ContourService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 using Autodesk.Revit.DB;
 
+using RevitBuildCoordVolumes.Models.Enums;
 using RevitBuildCoordVolumes.Models.Geometry;
 using RevitBuildCoordVolumes.Models.Interfaces;
 using RevitBuildCoordVolumes.Models.Utilites;
@@ -11,14 +12,15 @@ using RevitBuildCoordVolumes.Models.Utilites;
 namespace RevitBuildCoordVolumes.Models.Services;
 
 internal class ContourService : IContourService {
-    public List<CurveLoop> GetColumnsCurveLoops(List<ColumnObject> columns, double spatialElementPosition, double startExtrudePosition) {
+    public List<CurveLoop> GetColumnsCurveLoops(
+        List<ColumnObject> columns, double spatialElementPosition, double startExtrudePosition, ProgressService progressService) {
         // Получаем все линии полигонов
         var allLines = columns
             .SelectMany(column => column.PolygonObject.Sides)
             .ToList();
 
         // Удаляем дубликаты
-        var uniqueLines = GetUniqueLines(allLines)
+        var uniqueLines = GetUniqueLines(allLines, progressService)
             .Cast<Curve>()
             .ToList();
 
@@ -93,9 +95,8 @@ internal class ContourService : IContourService {
     }
 
     // Метод получения списка уникальных линий (удаление дубликатов квадратов)
-    private List<Line> GetUniqueLines(List<Line> lines) {
+    private List<Line> GetUniqueLines(List<Line> lines, ProgressService progressService) {
         var map = new Dictionary<string, Line>(lines.Count);
-
         static string GetKey(Line line) {
             // сортируем концы по координатам
             double x1 = line.GetEndPoint(0).X, y1 = line.GetEndPoint(0).Y;
@@ -114,17 +115,29 @@ internal class ContourService : IContourService {
 
             return $"{qx1}_{qy1}_{qx2}_{qy2}";
         }
-
+        progressService?.BeginStage(ProgressType.BuildContour);
+        int total = lines.Count;
+        int processed = 0;
+        int reported = 0;
         foreach(var line in lines) {
+            progressService?.CancellationToken.ThrowIfCancellationRequested();
             string key = GetKey(line);
 
             if(map.TryGetValue(key, out var existing)) {
                 if(line.Intersect(existing) == SetComparisonResult.Equal) {
-                    // удаляем обе линии
                     map.Remove(key);
                 }
             } else {
                 map.Add(key, line);
+            }
+            processed++;
+            int current = processed * 100 / total;
+            if(current > 100) {
+                current = 100;
+            }
+            if(current > reported) {
+                reported = current;
+                progressService?.ProgressCount?.Report(reported);
             }
         }
 

--- a/src/RevitBuildCoordVolumes/Models/Services/ProgressService.cs
+++ b/src/RevitBuildCoordVolumes/Models/Services/ProgressService.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+
+using dosymep.SimpleServices;
+
+using RevitBuildCoordVolumes.Models.Enums;
+
+namespace RevitBuildCoordVolumes.Models.Services;
+internal class ProgressService {
+    private readonly ILocalizationService _localizationService;
+
+    public ProgressService(ILocalizationService localizationService) {
+        _localizationService = localizationService;
+    }
+
+    public CancellationToken CancellationToken { get; set; }
+    public IProgress<int> ProgressCount { get; set; }
+    public string ZoneNumber { get; set; } = string.Empty;
+    public Action<string, int, int> SetupStage { get; set; }
+
+    public void BeginStage(ProgressType progressType, int max = 100, int step = 5) {
+        SetupStage?.Invoke(GetProgressName(progressType), max, step);
+        ProgressCount?.Report(0);
+    }
+
+    public string GetProgressName(ProgressType progressType) {
+        string progressTitle = _localizationService.GetLocalizedString($"{progressType}.ProgressTitle");
+        string zoneName = _localizationService.GetLocalizedString("BuildCoordVolumesProcessor.ZoneName", ZoneNumber);
+        return string.Join(" ", zoneName, progressTitle);
+    }
+}

--- a/src/RevitBuildCoordVolumes/Models/Services/SpatialElementCheckService.cs
+++ b/src/RevitBuildCoordVolumes/Models/Services/SpatialElementCheckService.cs
@@ -42,7 +42,6 @@ internal class SpatialElementCheckService : ISpatialElementCheckService {
                     });
                 } else {
                     var contourCurves = _contourService.GetOuterContour(spatialElement);
-                    //var loop = _contourService.GetCurveLoop(contourCurves, null);
                     var l = _contourService.GetCurveLoopsContour(contourCurves, null);
                     var testSolid = SolidUtility.ExtrudeSolid(l);
                     if(testSolid == null) {

--- a/src/RevitBuildCoordVolumes/Models/Services/SpatialElementDividerService.cs
+++ b/src/RevitBuildCoordVolumes/Models/Services/SpatialElementDividerService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 using Autodesk.Revit.DB;
 
+using RevitBuildCoordVolumes.Models.Enums;
 using RevitBuildCoordVolumes.Models.Geometry;
 using RevitBuildCoordVolumes.Models.Interfaces;
 using RevitBuildCoordVolumes.Models.Utilites;
@@ -17,9 +18,12 @@ internal class SpatialElementDividerService : ISpatialElementDividerService {
         _contourService = contourService;
     }
 
-    public List<PolygonObject> DivideSpatialElement(SpatialElement spatialElement, double side, double angleDeg) {
+    public List<PolygonObject> DivideSpatialElement(
+        SpatialElement spatialElement,
+        double side,
+        double angleDeg,
+        ProgressService progressService) {
         var contour = _contourService.GetOuterContour(spatialElement);
-
         if(contour.Count == 0) {
             return [];
         }
@@ -44,10 +48,14 @@ internal class SpatialElementDividerService : ISpatialElementDividerService {
         int nx = (int) (halfWidth / side) + 1;
         int ny = (int) (halfHeight / side) + 1;
 
+        progressService?.BeginStage(ProgressType.DivideSpatial);
+        int total = (2 * nx + 1) * (2 * ny + 1);
+        int processed = 0;
+        int reported = 0;
         var polygons = new List<PolygonObject>();
-
         for(int ix = -nx; ix <= nx; ix++) {
             for(int iy = -ny; iy <= ny; iy++) {
+                progressService?.CancellationToken.ThrowIfCancellationRequested();
 
                 var basePoint = origin + ux * (ix * side) + uy * (iy * side);
 
@@ -78,6 +86,15 @@ internal class SpatialElementDividerService : ISpatialElementDividerService {
                         Line.CreateBound(p4, p1)
                     ]
                 });
+                processed++;
+                int current = processed * 100 / total;
+                if(current > 100) {
+                    current = 100;
+                }
+                if(current > reported) {
+                    reported = current;
+                    progressService?.ProgressCount?.Report(reported);
+                }
             }
         }
         return polygons;

--- a/src/RevitBuildCoordVolumes/Models/SlabBasedCoordVolumeBuilder.cs
+++ b/src/RevitBuildCoordVolumes/Models/SlabBasedCoordVolumeBuilder.cs
@@ -6,6 +6,7 @@ using Autodesk.Revit.DB;
 using RevitBuildCoordVolumes.Models.Enums;
 using RevitBuildCoordVolumes.Models.Geometry;
 using RevitBuildCoordVolumes.Models.Interfaces;
+using RevitBuildCoordVolumes.Models.Services;
 using RevitBuildCoordVolumes.Models.Settings;
 
 namespace RevitBuildCoordVolumes.Models;
@@ -16,38 +17,39 @@ internal class SlabBasedCoordVolumeBuilder : ICoordVolumeBuilder {
     private readonly IColumnFactory _columnFactory;
     private readonly IGeomObjectFactory _geomObjectFactory;
     private readonly RevitRepository _revitRepository;
+    private readonly BuildCoordVolumeServices _services;
     private readonly BuildCoordVolumeSettings _settings;
 
     public SlabBasedCoordVolumeBuilder(
-        ISpatialElementDividerService spatialElementDividerService,
-        ISlabNormalizeService slabNormalizeService,
-        IColumnFactory columnFactory,
-        IGeomObjectFactory geomObjectFactory,
         RevitRepository revitRepository,
+        BuildCoordVolumeServices services,
         BuildCoordVolumeSettings settings) {
-        _spatialElementDividerService = spatialElementDividerService;
-        _slabNormalizeService = slabNormalizeService;
-        _columnFactory = columnFactory;
-        _geomObjectFactory = geomObjectFactory;
         _revitRepository = revitRepository;
+        _services = services;
+        _spatialElementDividerService = _services.SpatialDivider;
+        _slabNormalizeService = _services.SlabNormalizer;
+        _columnFactory = _services.ColumnFactory;
+        _geomObjectFactory = _services.GeomObjectFactory;
         _settings = settings;
     }
 
-    public List<GeomObject> Build(SpatialObject spatialObject) {
+    public List<GeomObject> Build(SpatialObject spatialObject, ProgressService progressService) {
         // Разделение зоны на полигоны
         double squareSidePolygon = UnitUtils.ConvertToInternalUnits(_settings.SquareSideMm, UnitTypeId.Millimeters);
         double squareAngle = UnitUtils.ConvertToInternalUnits(_settings.SquareAngleDeg, UnitTypeId.Degrees);
-        var polygons = _spatialElementDividerService.DivideSpatialElement(spatialObject.SpatialElement, squareSidePolygon, squareAngle);
+
+        var polygons = _spatialElementDividerService.DivideSpatialElement(
+            spatialObject.SpatialElement, squareSidePolygon, squareAngle, progressService);
 
         // Получение всех плит перекрытия из настроек
         var allSlabs = _revitRepository.GetSlabsByTypesDocsAndLevels(
             _settings.TypeSlabs, _settings.Documents, _settings.Levels).ToList();
 
         // Получение всех плит без отверстий (для плоских)
-        var normalizedSlabs = GetNormalizeSlabs(allSlabs);
+        var normalizedSlabs = GetNormalizeSlabs(allSlabs, progressService);
 
         // Построение групп колонн  
-        var columnGroups = _columnFactory.GenerateColumnGroups(polygons, normalizedSlabs);
+        var columnGroups = _columnFactory.GenerateColumnGroups(polygons, normalizedSlabs, progressService);
 
         // Получение ориентации полигона для Transform
         double spatialElementPosition = polygons[0].Sides[0].GetEndPoint(0).Z;
@@ -55,7 +57,7 @@ internal class SlabBasedCoordVolumeBuilder : ICoordVolumeBuilder {
         // Получение режима работы билдера 
         var builderMode = _settings.BuilderMode;
 
-        // Получение списка GeomObject в зависимости от настроек
+        // Получение списка GeomObject в зависимости от настроек        
         var geomObjects = new List<GeomObject>();
         foreach(var columnGroup in columnGroups) {
             var listColumns = columnGroup.ToList();
@@ -63,16 +65,15 @@ internal class SlabBasedCoordVolumeBuilder : ICoordVolumeBuilder {
 
             var newObjects = builderMode switch {
                 BuilderMode.AutomaticBuilder when firstColumn.IsSloped || listColumns.Count == 1
-                    => _geomObjectFactory.GetSeparatedGeomObjects(listColumns, spatialElementPosition),
+                    => _geomObjectFactory.GetSeparatedGeomObjects(listColumns, spatialElementPosition, progressService),
                 BuilderMode.AutomaticBuilder
-                    => _geomObjectFactory.GetUnitedGeomObjects(listColumns, spatialElementPosition),
+                    => _geomObjectFactory.GetUnitedGeomObjects(listColumns, spatialElementPosition, progressService),
                 BuilderMode.ContourBuilder
-                    => _geomObjectFactory.GetUnitedGeomObjects(listColumns, spatialElementPosition),
+                    => _geomObjectFactory.GetUnitedGeomObjects(listColumns, spatialElementPosition, progressService),
                 BuilderMode.ColumnBuilder
-                    => _geomObjectFactory.GetSeparatedGeomObjects(listColumns, spatialElementPosition),
+                    => _geomObjectFactory.GetSeparatedGeomObjects(listColumns, spatialElementPosition, progressService),
                 _ => []
             };
-
             geomObjects.AddRange(newObjects);
         }
 
@@ -80,14 +81,29 @@ internal class SlabBasedCoordVolumeBuilder : ICoordVolumeBuilder {
     }
 
     // Метод получения всех перекрытий без отверстий и вырезов (для плоских)
-    private List<SlabElement> GetNormalizeSlabs(List<SlabElement> slabElements) {
+    private List<SlabElement> GetNormalizeSlabs(List<SlabElement> slabElements, ProgressService progressService
+        ) {
+        progressService?.BeginStage(ProgressType.SlabNormalize);
+        int total = slabElements.Count;
+        int processed = 0;
+        int reported = 0;
         foreach(var slab in slabElements) {
+            progressService?.CancellationToken.ThrowIfCancellationRequested();
             bool isSloped = _slabNormalizeService.IsSloped(slab);
             var topFaces = _slabNormalizeService.GetTopFaces(slab);
             slab.IsSloped = isSloped;
             slab.TopFaces = slab.IsSloped
                 ? topFaces
                 : _slabNormalizeService.GetTopFacesClean(slab, topFaces);
+            processed++;
+            int current = processed * 100 / total;
+            if(current > 100) {
+                current = 100;
+            }
+            if(current > reported) {
+                reported = current;
+                progressService?.ProgressCount?.Report(reported);
+            }
         }
         return slabElements;
     }

--- a/src/RevitBuildCoordVolumes/ViewModels/MainViewModel.cs
+++ b/src/RevitBuildCoordVolumes/ViewModels/MainViewModel.cs
@@ -178,19 +178,24 @@ internal class MainViewModel : BaseViewModel {
 
         var processor = new BuildCoordVolumesProcessor(_revitRepository, _settings, _services);
 
-        int count = _settings.SpatialObjects.Count;
         using var progressDialogService = ProgressDialogFactory.CreateDialog();
         var progress = progressDialogService.CreateProgress();
         var ct = progressDialogService.CreateCancellationToken();
 
-        progressDialogService.MaxValue = count;
-        progressDialogService.StepValue = count / 10;
-        progressDialogService.DisplayTitleFormat = _services.LocalizationService.GetLocalizedString("MainViewModel.ProgressTitle");
+        var progressService = new ProgressService(_services.LocalizationService) {
+            CancellationToken = ct,
+            ProgressCount = progress,
+            SetupStage = (text, max, step) => {
+                progressDialogService.DisplayTitleFormat = text;
+                progressDialogService.MaxValue = max;
+                progressDialogService.StepValue = step;
+            }
+        };
 
         progressDialogService.Show();
 
         // Основной метод построения объемов
-        processor.Run(progress, ct);
+        processor.Run(progressService);
     }
 
     // Метод проверки возможности выполнения основного метода

--- a/src/RevitBuildCoordVolumes/assets/Localization/Language.en-US.xaml
+++ b/src/RevitBuildCoordVolumes/assets/Localization/Language.en-US.xaml
@@ -88,7 +88,6 @@
     <system:String x:Key="MainViewModel.SquareSideNoNegate">Input must be positive</system:String>
     <system:String x:Key="MainViewModel.SquareSideBig">Input must not exceed 1000 mm</system:String>
     <system:String x:Key="MainViewModel.SquareSideSmall">Input must not be less than 10 mm</system:String>
-    <system:String x:Key="MainViewModel.ProgressTitle">Building volumes... [{0}]\[{1}]</system:String>
     <system:String x:Key="MainViewModel.MessageBoxTitle">Checking zones</system:String>
     <system:String x:Key="MainViewModel.MessageBoxText">Zones checked. No issues found.</system:String>
 
@@ -118,4 +117,9 @@
     <system:String x:Key="WarningsViewModel.NotFilledParamDescription">Zones missing parameters required for building</system:String>
     <system:String x:Key="WarningsViewModel.WrongFilledParam">Zones with incorrectly filled parameters</system:String>
     <system:String x:Key="WarningsViewModel.WrongFilledParamDescription">Bottom elevation is higher than or equal to top elevation</system:String>
+
+    <system:String x:Key="DivideSpatial.ProgressTitle">Divide zone {0}%</system:String>
+    <system:String x:Key="SlabNormalize.ProgressTitle">Processing slabs {0}%</system:String>
+    <system:String x:Key="BuildContour.ProgressTitle">Generate contours {0}%</system:String>
+    <system:String x:Key="BuildVolumes.ProgressTitle">Generate Volumes {0}%</system:String>
 </ResourceDictionary>

--- a/src/RevitBuildCoordVolumes/assets/Localization/Language.ru-RU.xaml
+++ b/src/RevitBuildCoordVolumes/assets/Localization/Language.ru-RU.xaml
@@ -87,7 +87,6 @@
     <system:String x:Key="MainViewModel.SquareSideNoNegate">Вводимые данные должны быть положительными</system:String>
     <system:String x:Key="MainViewModel.SquareSideBig">Вводимые данные не должны превышать 1000 мм</system:String>
     <system:String x:Key="MainViewModel.SquareSideSmall">Вводимые данные не должны быть меньше 10 мм</system:String>    
-    <system:String x:Key="MainViewModel.ProgressTitle">Построение объёмов... [{0}]\[{1}]</system:String>
     <system:String x:Key="MainViewModel.MessageBoxTitle">Проверка зон</system:String>
     <system:String x:Key="MainViewModel.MessageBoxText">Зоны проверены. Проблем не обнаружено</system:String>
 
@@ -95,6 +94,7 @@
     <system:String x:Key="DocumentViewModel.CurrentFile">Текущий файл (открытый)</system:String>
 
     <system:String x:Key="BuildCoordVolumesProcessor.TransactionName">Построение объемов СМР</system:String>
+    <system:String x:Key="BuildCoordVolumesProcessor.ZoneName">Зона {0}: </system:String>
 
     <system:String x:Key="Common.ParamErrorMessageBody">Ошибка загрузки параметров</system:String>
     <system:String x:Key="Common.ConfigErrorMessageTitle">Ошибка настройки плагина</system:String>
@@ -117,4 +117,10 @@
     <system:String x:Key="WarningsViewModel.NotFilledParamDescription">Зоны с не заполненными параметрами, необходимыми для построения</system:String>
     <system:String x:Key="WarningsViewModel.WrongFilledParam">Зоны с неверно заполненными параметрами</system:String>
     <system:String x:Key="WarningsViewModel.WrongFilledParamDescription">Отметка низа находится выше или равна отметке верха</system:String>
+
+    <system:String x:Key="DivideSpatial.ProgressTitle">Деление зоны {0}%</system:String>
+    <system:String x:Key="SlabNormalize.ProgressTitle">Обработка плит {0}%</system:String>
+    <system:String x:Key="BuildContour.ProgressTitle">Генерация контуров {0}%</system:String>
+    <system:String x:Key="BuildVolumes.ProgressTitle">Генерация объемов {0}%</system:String>   
+    
 </ResourceDictionary>


### PR DESCRIPTION
Прокидывание прогресса в тяжелые классы и методы, для возможности отмены тяжелых операций и понимания какой тяжелый очередной этап сейчас происходит. Одна тяжелая операция, длившаяся продолжительное время и приводившая к "зависанию" UI:

<img width="407" height="72" alt="image" src="https://github.com/user-attachments/assets/6d18af3f-1730-4605-8380-9e8c8fc1c688" />

Теперь разбита на несколько последовательных операций:

Разделение зоны на полигоны:
<img width="433" height="80" alt="image" src="https://github.com/user-attachments/assets/22e56fe6-49fb-486a-8680-3b8fc4d396cf" />

Обработка плит перекрытий:
<img width="430" height="80" alt="image" src="https://github.com/user-attachments/assets/04dabbe0-f229-4636-86e9-049f733838ac" />

Генерация объемов:
<img width="428" height="78" alt="image" src="https://github.com/user-attachments/assets/b89b23fc-1541-4bc0-951a-6b13e0ccb4b6" />

Генерация контуров:
<img width="425" height="72" alt="image" src="https://github.com/user-attachments/assets/e582af25-3725-47cf-b05f-ca06972330dc" />


