### PR TITLE
RevitParamsChecker: Обновлен layout страницы анализа

### DIFF
--- a/src/RevitParamsChecker/Resources/CustomStyles.xaml
+++ b/src/RevitParamsChecker/Resources/CustomStyles.xaml
@@ -151,6 +151,22 @@
             Value="Stretch" />
     </Style>
     <Style
+        TargetType="GridSplitter"
+        x:Key="CustomHorizontalGridSplitter">
+        <Setter
+            Property="Height"
+            Value="4" />
+        <Setter
+            Property="Background"
+            Value="Transparent" />
+        <Setter
+            Property="HorizontalAlignment"
+            Value="Stretch" />
+        <Setter
+            Property="VerticalAlignment"
+            Value="Center" />
+    </Style>
+    <Style
         TargetType="ui:ToggleSwitch"
         x:Key="LabeledToggleSwitch"
         BasedOn="{StaticResource DefaultUiToggleSwitchStyle}">

--- a/src/RevitParamsChecker/Views/Results/ResultsPage.xaml
+++ b/src/RevitParamsChecker/Views/Results/ResultsPage.xaml
@@ -32,30 +32,40 @@
             <ColumnDefinition
                 Width="Auto" />
             <ColumnDefinition
-                Width="5*"
-                MinWidth="200" />
-            <ColumnDefinition
-                Width="Auto" />
-            <ColumnDefinition
-                Width="3*"
-                MinWidth="200" />
+                Width="*" />
         </Grid.ColumnDefinitions>
+
+        <Grid.RowDefinitions>
+            <RowDefinition
+                Height="2*"
+                MinHeight="200" />
+            <RowDefinition
+                Height="Auto" />
+            <RowDefinition
+                Height="1*"
+                MinHeight="200" />
+        </Grid.RowDefinitions>
 
         <local:CheckResultsListControl
             Grid.Column="0"
+            Grid.RowSpan="3"
             DataContext="{Binding}" />
 
         <local:CheckResultControl
             Grid.Column="1"
+            Grid.Row="0"
             Margin="4 0 0 0"
             DataContext="{Binding SelectedCheckResult}" />
 
         <GridSplitter
-            Grid.Column="2"
-            Style="{StaticResource CustomGridSplitter}" />
+            Grid.Column="1"
+            Grid.Row="1"
+            Style="{StaticResource CustomHorizontalGridSplitter}" />
 
         <Border
-            Grid.Column="3"
+            Grid.Column="1"
+            Grid.Row="2"
+            Margin="4 0 0 0"
             Style="{StaticResource CustomBorder}">
             <DockPanel
                 LastChildFill="True">


### PR DESCRIPTION
## Обновления

- В странице анализа раздел правил перемещен под список элементов. Так лучше читается таблица элементов.

<img width="1500" alt="image" src="https://github.com/user-attachments/assets/d9e3dfdf-6746-4622-b115-b05ca039dc3f" />
