### PR TITLE
RevitMechanicalSpecification: Обновление масок, принудительных параметров, корректировка работы по выбранным

### DIFF
--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamFunctionFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamFunctionFiller.cs
@@ -32,7 +32,7 @@ namespace RevitMechanicalSpecification.Models.Fillers {
         public override void SetParamValue(SpecificationElement specificationElement) {
             string calculatedFunction = GetFunction(specificationElement);
             if(!(string.IsNullOrWhiteSpace(calculatedFunction))) {
-                TargetParam.Set(GetFunction(specificationElement));
+                TargetParam.Set(calculatedFunction);
                 return;
             }
             TargetParam.Set(Config.GlobalFunction);
@@ -60,7 +60,7 @@ namespace RevitMechanicalSpecification.Models.Fillers {
                 }
             }
 
-            return _nameFactory.GetFunctionNameValue(specificationElement.Element);
+            return _nameFactory.GetFunctionNameValue(specificationElement);
         }
     }
 }

--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamSystemFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamSystemFiller.cs
@@ -65,6 +65,10 @@ namespace RevitMechanicalSpecification.Models.Fillers {
         /// <returns></returns>
         private string GetSystemName(SpecificationElement specificationElement) {
             string forcedSystem = _nameFactory.GetForcedParamValue(specificationElement, Config.ForcedSystemName);
+            if(_nameFactory.IsForcedSystemPattern(forcedSystem)) {
+                return _nameFactory.GetSystemNameValue(specificationElement);
+            }
+
             if(!string.IsNullOrEmpty(forcedSystem)) {
                 return forcedSystem;
             }
@@ -74,12 +78,13 @@ namespace RevitMechanicalSpecification.Models.Fillers {
             if(specificationElement.InsulationSpHost != null) {
                 string forcedHostSystem = _nameFactory.GetForcedParamValue(specificationElement.InsulationSpHost,
                     Config.ForcedSystemName);
-                if(!string.IsNullOrEmpty(forcedHostSystem)) {
+                if(!string.IsNullOrEmpty(forcedHostSystem)
+                    && !_nameFactory.IsForcedSystemPattern(forcedHostSystem)) {
                     return forcedHostSystem;
                 }
             }
 
-            return _nameFactory.GetSystemNameValue(specificationElement.Element);
+            return _nameFactory.GetSystemNameValue(specificationElement);
         }
     }
 }

--- a/src/RevitMechanicalSpecification/Service/DataOperator.cs
+++ b/src/RevitMechanicalSpecification/Service/DataOperator.cs
@@ -11,6 +11,12 @@ using RevitMechanicalSpecification.Entities;
 
 namespace RevitMechanicalSpecification.Service {
     public static class DataOperator {
+        private static readonly ElementFilter _insulationFilter = new ElementMulticategoryFilter(
+            new List<BuiltInCategory> {
+                BuiltInCategory.OST_PipeInsulations,
+                BuiltInCategory.OST_DuctInsulations
+            });
+
         /// <summary>
         /// возвращает значение параметра по типу или экземпляру, если существует, иначе null
         /// </summary>
@@ -140,6 +146,24 @@ namespace RevitMechanicalSpecification.Service {
                     subs.AddRange(GetSub(subInst, document));
                 }
             }
+            // Для категории арматуры изоляция не является субкомпонентом, требуется сбор через зависимые, иначе
+            // при работе полного обновления выбранного изоляция не обновится на части элементов
+            if(element.InAnyCategory(new List<BuiltInCategory> {
+                BuiltInCategory.OST_PipeAccessory,
+                BuiltInCategory.OST_DuctAccessory
+            })) {
+                foreach(ElementId dependentElementId in element.GetDependentElements(_insulationFilter)) {
+                    Element dependentElement = document.GetElement(dependentElementId);
+                    if(dependentElement == null) {
+                        continue;
+                    }
+
+                    if(subs.All(item => item.Id != dependentElement.Id)) {
+                        subs.Add(dependentElement);
+                    }
+                }
+            }
+
             return subs;
         }
     }

--- a/src/RevitMechanicalSpecification/Service/MaskReplacer.cs
+++ b/src/RevitMechanicalSpecification/Service/MaskReplacer.cs
@@ -67,11 +67,16 @@ namespace RevitMechanicalSpecification.Service {
                 if(string.IsNullOrWhiteSpace(paramName)) {
                     return match.Value;
                 }
+                
+                Parameter parameter = element.GetTypeOrInstanceParam(elemType, paramName);
+                if(parameter == null) {
+                    return match.Value;
+                }
 
                 string value = GetStringValue(element, elemType, paramName);
 
                 if(value == null) {
-                    return match.Value;
+                    return string.Empty;
                 }
 
                 return value;

--- a/src/RevitMechanicalSpecification/Service/SystemFunctionNameFactory.cs
+++ b/src/RevitMechanicalSpecification/Service/SystemFunctionNameFactory.cs
@@ -56,18 +56,24 @@ namespace RevitMechanicalSpecification.Service {
             return result;
         }
 
+        public bool IsForcedSystemPattern(string forcedSystemValue) {
+            return TryGetForcedSystemSelector(forcedSystemValue, out _);
+        }
+
         /// <summary>
         /// Возвращает функцию системы
         /// </summary>
         /// <param name="element"></param>
         /// <returns></returns>
+        public string GetFunctionNameValue(SpecificationElement specificationElement) {
+            return GetFunctionNameValue(GetVisSystem(specificationElement));
+        }
+
         public string GetFunctionNameValue(Element element) {
-            if(element is FamilyInstance instance) {
-                element = GetSuperComponentIfExist(instance);
-            }
+            return GetFunctionNameValue(GetVisSystem(element, null));
+        }
 
-            VisSystem visSystem = GetVisSystem(element);
-
+        private string GetFunctionNameValue(VisSystem visSystem) {
             if(visSystem == null) {
                 return string.Empty;
             }
@@ -88,12 +94,15 @@ namespace RevitMechanicalSpecification.Service {
         /// </summary>
         /// <param name="element"></param>
         /// <returns></returns>
-        public string GetSystemNameValue(Element element) {
-            if(element is FamilyInstance instance) {
-                element = GetSuperComponentIfExist(instance);
-            }
+        public string GetSystemNameValue(SpecificationElement specificationElement) {
+            return GetSystemNameValue(GetVisSystem(specificationElement));
+        }
 
-            VisSystem visSystem = GetVisSystem(element);
+        public string GetSystemNameValue(Element element) {
+            return GetSystemNameValue(GetVisSystem(element, null));
+        }
+
+        private string GetSystemNameValue(VisSystem visSystem) {
             if(visSystem is null) {
                 return string.Empty;
             }
@@ -153,22 +162,86 @@ namespace RevitMechanicalSpecification.Service {
         /// </summary>
         /// <param name="element"></param>
         /// <returns></returns>
-        private VisSystem GetVisSystem(Element element) {
+        private VisSystem GetVisSystem(SpecificationElement specificationElement) {
+            if(specificationElement == null) {
+                return null;
+            }
+
+            string forcedSystemSelector = GetForcedSystemSelector(specificationElement)
+                ?? GetForcedSystemSelector(specificationElement.InsulationSpHost);
+
+            return GetVisSystem(specificationElement.Element, forcedSystemSelector);
+        }
+
+        private VisSystem GetVisSystem(Element element, string forcedSystemSelector) {
+            if(element == null) {
+                return null;
+            }
+
             if(element is FamilyInstance instance) {
                 element = instance.GetSuperComponentIfExist();
             }
 
-            string systemName = element.GetParamValueOrDefault(BuiltInParameter.RBS_SYSTEM_NAME_PARAM, _noneSystemValue);
-
-            systemName = systemName.Split(',').FirstOrDefault();
-
-            if(element.InAnyCategory(new HashSet<BuiltInCategory>() {
-                BuiltInCategory.OST_DuctInsulations,
-                BuiltInCategory.OST_PipeInsulations})) {
-                systemName = GetInsulationSystem(element as InsulationLiningBase);
+            List<string> systemNames = GetSystemNames(element);
+            if(!string.IsNullOrEmpty(forcedSystemSelector)) {
+                string selectedSystemName = systemNames.FirstOrDefault(systemName =>
+                    systemName.IndexOf(forcedSystemSelector, StringComparison.OrdinalIgnoreCase) >= 0);
+                VisSystem selectedSystem = GetVisSystemByName(selectedSystemName);
+                if(selectedSystem != null) {
+                    return selectedSystem;
+                }
             }
 
-            return _systems.Where(s => s.SystemSystemName == systemName).FirstOrDefault();
+            return systemNames.Select(GetVisSystemByName).FirstOrDefault(visSystem => visSystem != null);
+        }
+
+        private List<string> GetSystemNames(Element element) {
+            string systemNames = element.InAnyCategory(new HashSet<BuiltInCategory>() {
+                BuiltInCategory.OST_DuctInsulations,
+                BuiltInCategory.OST_PipeInsulations})
+                ? GetInsulationSystem(element as InsulationLiningBase)
+                : GetParamSystemValue(element);
+
+            return systemNames
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(item => item.Trim())
+                .Where(item => !string.IsNullOrEmpty(item))
+                .ToList();
+        }
+
+        private VisSystem GetVisSystemByName(string systemName) {
+            if(string.IsNullOrWhiteSpace(systemName)) {
+                return null;
+            }
+
+            return _systems.FirstOrDefault(s => string.Equals(s.SystemSystemName, systemName, StringComparison.Ordinal));
+        }
+
+        private string GetForcedSystemSelector(SpecificationElement specificationElement) {
+            if(specificationElement == null) {
+                return null;
+            }
+
+            string forcedSystemValue = GetForcedParamValue(specificationElement, _specConfiguration.ForcedSystemName);
+            return TryGetForcedSystemSelector(forcedSystemValue, out string forcedSystemSelector)
+                ? forcedSystemSelector
+                : null;
+        }
+
+        private bool TryGetForcedSystemSelector(string forcedSystemValue, out string forcedSystemSelector) {
+            forcedSystemSelector = null;
+
+            if(string.IsNullOrWhiteSpace(forcedSystemValue)) {
+                return false;
+            }
+
+            string trimmedValue = forcedSystemValue.Trim();
+            if(trimmedValue.Length < 3 || trimmedValue[0] != '{' || trimmedValue[trimmedValue.Length - 1] != '}') {
+                return false;
+            }
+
+            forcedSystemSelector = trimmedValue.Substring(1, trimmedValue.Length - 2).Trim();
+            return !string.IsNullOrEmpty(forcedSystemSelector);
 
         }
     }


### PR DESCRIPTION
1) Обновлена логика работы с масками, имя параметра возвращаем если такого параметра нет, если значение параметра пустое - возвращаем пустую строку

2) Для категории арматуры изоляция не является субкомпонентом требуется сбор через зависимые, иначе при работе полного обновления выбранного изоляция не обновится на части элементов

3) Переработка логики получения имени системы-функции из принудителньных параметров. Требуется добавление паттерна по которому будут выбираться корректные системы из многосистемных элементов, типа раковин или сплит/VRV систем. Теперь если в принудительном параметре указана {Подстрока} то будет возвращаться система содержащая эту подстроку в своем имени, или первая встреченная если подстрока не найдена.