### PR TITLE
RevitBuildCoordVolumes: Замена выпадающего списка на множественный выбор

### DIFF
--- a/src/RevitBuildCoordVolumes/Models/ColumnFactory.cs
+++ b/src/RevitBuildCoordVolumes/Models/ColumnFactory.cs
@@ -31,7 +31,7 @@ internal class ColumnFactory : IColumnFactory {
         }
         var columns = new List<ColumnObject>();
 
-        progressService?.BeginStage(ProgressType.BuildVolumes);
+        progressService?.BeginStage(ProgressType.BuildContour);
         int total = polygons.Count;
         int processed = 0;
         int reported = 0;

--- a/src/RevitBuildCoordVolumes/Models/GeomObjectFactory.cs
+++ b/src/RevitBuildCoordVolumes/Models/GeomObjectFactory.cs
@@ -70,7 +70,7 @@ internal class GeomObjectFactory : IGeomObjectFactory {
         var solids = new List<GeometryObject>();
         var volumes = new List<double>();
         var firstElement = columns[0];
-        progressService?.BeginStage(ProgressType.BuildContour);
+        progressService?.BeginStage(ProgressType.BuildVolumes);
         int total = columns.Count;
         int processed = 0;
         int reported = 0;

--- a/src/RevitBuildCoordVolumes/Models/RevitRepository.cs
+++ b/src/RevitBuildCoordVolumes/Models/RevitRepository.cs
@@ -87,6 +87,7 @@ internal class RevitRepository {
     /// Метод получения зон RevitArea по заданному типу и параметру
     /// </summary>
     public IEnumerable<SpatialObject> GetSpatialObjects(List<string> areaTypes, RevitParam revitParam) {
+        var areaTypesSet = new HashSet<string>(areaTypes);
         return GetSpatialElements()
             .Select(spatialElement => {
                 string levelName = GetLevelName(spatialElement);
@@ -98,8 +99,9 @@ internal class RevitRepository {
                 };
             })
             .Where(spatialObject => {
-                string value = spatialObject.SpatialElement.GetParamValueOrDefault<string>(revitParam.Name);
-                return value != null && areaTypes.Contains(value);
+                string value = spatialObject.SpatialElement
+                    .GetParamValueOrDefault<string>(revitParam.Name);
+                return value != null && areaTypesSet.Contains(value);
             });
     }
 

--- a/src/RevitBuildCoordVolumes/Models/RevitRepository.cs
+++ b/src/RevitBuildCoordVolumes/Models/RevitRepository.cs
@@ -86,7 +86,7 @@ internal class RevitRepository {
     /// <summary>
     /// Метод получения зон RevitArea по заданному типу и параметру
     /// </summary>
-    public IEnumerable<SpatialObject> GetSpatialObjects(string areaType, RevitParam revitParam) {
+    public IEnumerable<SpatialObject> GetSpatialObjects(List<string> areaTypes, RevitParam revitParam) {
         return GetSpatialElements()
             .Select(spatialElement => {
                 string levelName = GetLevelName(spatialElement);
@@ -97,8 +97,10 @@ internal class RevitRepository {
                     Description = description
                 };
             })
-            .Where(spatialObject => areaType
-                .Equals(spatialObject.SpatialElement.GetParamValueOrDefault<string>(revitParam.Name)));
+            .Where(spatialObject => {
+                string value = spatialObject.SpatialElement.GetParamValueOrDefault<string>(revitParam.Name);
+                return value != null && areaTypes.Contains(value);
+            });
     }
 
     /// <summary>

--- a/src/RevitBuildCoordVolumes/Models/Services/ContourService.cs
+++ b/src/RevitBuildCoordVolumes/Models/Services/ContourService.cs
@@ -115,7 +115,7 @@ internal class ContourService : IContourService {
 
             return $"{qx1}_{qy1}_{qx2}_{qy2}";
         }
-        progressService?.BeginStage(ProgressType.BuildContour);
+        progressService?.BeginStage(ProgressType.BuildVolumes);
         int total = lines.Count;
         int processed = 0;
         int reported = 0;

--- a/src/RevitBuildCoordVolumes/Models/Settings/BuildCoordVolumeSettings.cs
+++ b/src/RevitBuildCoordVolumes/Models/Settings/BuildCoordVolumeSettings.cs
@@ -10,7 +10,7 @@ namespace RevitBuildCoordVolumes.Models.Settings;
 internal class BuildCoordVolumeSettings {
     public AlgorithmType AlgorithmType { get; set; }
     public BuilderMode BuilderMode { get; set; }
-    public string TypeZone { get; set; }
+    public List<string> TypeZones { get; set; }
     public List<ParamMap> ParamMaps { get; set; }
     public List<Document> Documents { get; set; }
     public List<string> TypeSlabs { get; set; }

--- a/src/RevitBuildCoordVolumes/Models/Settings/ConfigSettings.cs
+++ b/src/RevitBuildCoordVolumes/Models/Settings/ConfigSettings.cs
@@ -7,7 +7,7 @@ namespace RevitBuildCoordVolumes.Models.Settings;
 internal class ConfigSettings {
     public AlgorithmType AlgorithmType { get; set; }
     public BuilderMode BuilderMode { get; set; }
-    public string TypeZone { get; set; }
+    public List<string> TypeZones { get; set; }
     public List<ParamMap> ParamMaps { get; set; }
     public List<string> Documents { get; set; }
     public List<string> TypeSlabs { get; set; }
@@ -17,7 +17,7 @@ internal class ConfigSettings {
     public void ApplyDefaultValues(SystemPluginConfig systemPluginConfig) {
         AlgorithmType = AlgorithmType.SlabBasedAlgorithm;
         BuilderMode = BuilderMode.AutomaticBuilder;
-        TypeZone = string.Empty;
+        TypeZones = [];
         ParamMaps = systemPluginConfig.GetAdvancedParamMaps();
         Documents = [];
         TypeSlabs = [];

--- a/src/RevitBuildCoordVolumes/ViewModels/CommonSettingViewModel.cs
+++ b/src/RevitBuildCoordVolumes/ViewModels/CommonSettingViewModel.cs
@@ -116,16 +116,19 @@ internal class CommonSettingViewModel : BaseViewModel {
         FilteredTypeZones = new ObservableCollection<TypeZoneViewModel>(TypeZones);
     }
 
-    // Метод получения коллекции TypeModelViewModel для TypeModels
+    // Метод получения коллекции TypeZoneViewModel для TypeModels
     private IEnumerable<TypeZoneViewModel> GetTypeZoneViewModels() {
         var param = Params.FirstOrDefault()?.ParamMap.SourceParam;
-        var typeZones = _revitRepository.GetTypeZones(param);
-        return !typeZones.Any()
+        var allTypeZones = _revitRepository.GetTypeZones(param);
+        var savedTypeModels = _settings.TypeZones ?? [];
+        return !allTypeZones.Any()
             ? []
-            : typeZones
-                .Select(value => new TypeZoneViewModel { Name = value })
-                .OrderByDescending(vm => vm.Name.Equals(_settings.TypeZone))
-                .ThenBy(vm => vm.Name);
+            : allTypeZones
+                .Select(value => new TypeZoneViewModel {
+                    Name = value,
+                    IsChecked = savedTypeModels.Contains(value)
+                })
+                .OrderBy(vm => vm.Name);
     }
 
     // Метод обновления Params

--- a/src/RevitBuildCoordVolumes/ViewModels/CommonSettingViewModel.cs
+++ b/src/RevitBuildCoordVolumes/ViewModels/CommonSettingViewModel.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
+using System.Windows.Input;
 
 using dosymep.Bim4Everyone.SimpleServices;
 using dosymep.Revit;
 using dosymep.SimpleServices;
+using dosymep.WPF.Commands;
 using dosymep.WPF.ViewModels;
 
 using RevitBuildCoordVolumes.Models;
@@ -27,7 +29,8 @@ internal class CommonSettingViewModel : BaseViewModel {
     private ObservableCollection<AlgorithmViewModel> _typeAlgorithms;
     private AlgorithmViewModel _selectedTypeAlgorithm;
     private ObservableCollection<TypeZoneViewModel> _typeZones;
-    private TypeZoneViewModel _selectedTypeZone;
+    private ObservableCollection<TypeZoneViewModel> _filteredTypeZones;
+    private string _searchTextTypeZones;
     private ObservableCollection<ParamViewModel> _params;
     private bool _hasParamWarning;
 
@@ -45,7 +48,15 @@ internal class CommonSettingViewModel : BaseViewModel {
         _revitParamFactory = _services.RevitParamFactory;
 
         LoadView();
+
+        SearchTypeZonesCommand = RelayCommand.Create(ApplySearchTypeZones);
+        CheckAllTypeModelsCommand = RelayCommand.Create(CheckAllTypeZones);
+        UncheckAllTypeModelsCommand = RelayCommand.Create(UncheckAllTypeZones);
     }
+
+    public ICommand SearchTypeZonesCommand { get; }
+    public ICommand CheckAllTypeModelsCommand { get; }
+    public ICommand UncheckAllTypeModelsCommand { get; }
 
     public ObservableCollection<AlgorithmViewModel> TypeAlgorithms {
         get => _typeAlgorithms;
@@ -59,9 +70,13 @@ internal class CommonSettingViewModel : BaseViewModel {
         get => _typeZones;
         set => RaiseAndSetIfChanged(ref _typeZones, value);
     }
-    public TypeZoneViewModel SelectedTypeZone {
-        get => _selectedTypeZone;
-        set => RaiseAndSetIfChanged(ref _selectedTypeZone, value);
+    public ObservableCollection<TypeZoneViewModel> FilteredTypeZones {
+        get => _filteredTypeZones;
+        set => RaiseAndSetIfChanged(ref _filteredTypeZones, value);
+    }
+    public string SearchTextTypeZones {
+        get => _searchTextTypeZones;
+        set => RaiseAndSetIfChanged(ref _searchTextTypeZones, value);
     }
     public ObservableCollection<ParamViewModel> Params {
         get => _params;
@@ -72,10 +87,33 @@ internal class CommonSettingViewModel : BaseViewModel {
         set => RaiseAndSetIfChanged(ref _hasParamWarning, value);
     }
 
+    // Метод для реализации поиска типов зон
+    private void ApplySearchTypeZones() {
+        FilteredTypeZones = string.IsNullOrEmpty(SearchTextTypeZones)
+            ? new ObservableCollection<TypeZoneViewModel>(TypeZones)
+            : new ObservableCollection<TypeZoneViewModel>(TypeZones
+                .Where(item => item.Name
+                .IndexOf(SearchTextTypeZones, StringComparison.OrdinalIgnoreCase) >= 0));
+    }
+
+    // Метод команды на выделение всех типов зон
+    private void CheckAllTypeZones() {
+        foreach(var catVM in FilteredTypeZones) {
+            catVM.IsChecked = true;
+        }
+    }
+
+    // Метод команды на снятие выделения всех типов зон
+    private void UncheckAllTypeZones() {
+        foreach(var catVM in FilteredTypeZones) {
+            catVM.IsChecked = false;
+        }
+    }
+
     // Метод обновления TypeZones
     private void UpdateTypeZones() {
         TypeZones = new ObservableCollection<TypeZoneViewModel>(GetTypeZoneViewModels());
-        SelectedTypeZone = TypeZones.FirstOrDefault();
+        FilteredTypeZones = new ObservableCollection<TypeZoneViewModel>(TypeZones);
     }
 
     // Метод получения коллекции TypeModelViewModel для TypeModels
@@ -204,6 +242,6 @@ internal class CommonSettingViewModel : BaseViewModel {
         UpdateParamWarnings();
 
         TypeZones = new ObservableCollection<TypeZoneViewModel>(GetTypeZoneViewModels());
-        SelectedTypeZone = TypeZones.FirstOrDefault();
+        FilteredTypeZones = new ObservableCollection<TypeZoneViewModel>(TypeZones);
     }
 }

--- a/src/RevitBuildCoordVolumes/ViewModels/CommonSettingViewModel.cs
+++ b/src/RevitBuildCoordVolumes/ViewModels/CommonSettingViewModel.cs
@@ -30,6 +30,7 @@ internal class CommonSettingViewModel : BaseViewModel {
     private AlgorithmViewModel _selectedTypeAlgorithm;
     private ObservableCollection<TypeZoneViewModel> _typeZones;
     private ObservableCollection<TypeZoneViewModel> _filteredTypeZones;
+    private ObservableCollection<TypeZoneViewModel> _selectedTypeZones;
     private string _searchTextTypeZones;
     private ObservableCollection<ParamViewModel> _params;
     private bool _hasParamWarning;
@@ -50,13 +51,13 @@ internal class CommonSettingViewModel : BaseViewModel {
         LoadView();
 
         SearchTypeZonesCommand = RelayCommand.Create(ApplySearchTypeZones);
-        CheckAllTypeModelsCommand = RelayCommand.Create(CheckAllTypeZones);
-        UncheckAllTypeModelsCommand = RelayCommand.Create(UncheckAllTypeZones);
+        CheckAllTypeZonesCommand = RelayCommand.Create(CheckAllTypeZones);
+        UncheckAllTypeZonesCommand = RelayCommand.Create(UncheckAllTypeZones);
     }
 
     public ICommand SearchTypeZonesCommand { get; }
-    public ICommand CheckAllTypeModelsCommand { get; }
-    public ICommand UncheckAllTypeModelsCommand { get; }
+    public ICommand CheckAllTypeZonesCommand { get; }
+    public ICommand UncheckAllTypeZonesCommand { get; }
 
     public ObservableCollection<AlgorithmViewModel> TypeAlgorithms {
         get => _typeAlgorithms;
@@ -73,6 +74,10 @@ internal class CommonSettingViewModel : BaseViewModel {
     public ObservableCollection<TypeZoneViewModel> FilteredTypeZones {
         get => _filteredTypeZones;
         set => RaiseAndSetIfChanged(ref _filteredTypeZones, value);
+    }
+    public ObservableCollection<TypeZoneViewModel> SelectedTypeZones {
+        get => _selectedTypeZones;
+        set => RaiseAndSetIfChanged(ref _selectedTypeZones, value);
     }
     public string SearchTextTypeZones {
         get => _searchTextTypeZones;
@@ -114,6 +119,15 @@ internal class CommonSettingViewModel : BaseViewModel {
     private void UpdateTypeZones() {
         TypeZones = new ObservableCollection<TypeZoneViewModel>(GetTypeZoneViewModels());
         FilteredTypeZones = new ObservableCollection<TypeZoneViewModel>(TypeZones);
+        SelectedTypeZones = new ObservableCollection<TypeZoneViewModel>(FilteredTypeZones.Where(zone => zone.IsChecked));
+    }
+
+    // Метод обновления предупреждений в параметрах
+    private void OnTypeZoneChanged(object sender, PropertyChangedEventArgs e) {
+        if(sender is not TypeZoneViewModel vm) {
+            return;
+        }
+        SelectedTypeZones = new ObservableCollection<TypeZoneViewModel>(FilteredTypeZones.Where(zone => zone.IsChecked));
     }
 
     // Метод получения коллекции TypeZoneViewModel для TypeModels
@@ -245,6 +259,11 @@ internal class CommonSettingViewModel : BaseViewModel {
         UpdateParamWarnings();
 
         TypeZones = new ObservableCollection<TypeZoneViewModel>(GetTypeZoneViewModels());
+        // Подписка на события в ParamViewModel
+        foreach(var typeZone in TypeZones) {
+            typeZone.PropertyChanged += OnTypeZoneChanged;
+        }
         FilteredTypeZones = new ObservableCollection<TypeZoneViewModel>(TypeZones);
+        SelectedTypeZones = new ObservableCollection<TypeZoneViewModel>(FilteredTypeZones.Where(zone => zone.IsChecked));
     }
 }

--- a/src/RevitBuildCoordVolumes/ViewModels/MainViewModel.cs
+++ b/src/RevitBuildCoordVolumes/ViewModels/MainViewModel.cs
@@ -97,7 +97,7 @@ internal class MainViewModel : BaseViewModel {
             case nameof(CommonSettingViewModel.SelectedTypeAlgorithm):
                 UpdateVisibilitySettings();
                 break;
-            case nameof(CommonSettingViewModel.TypeZones):
+            case nameof(CommonSettingViewModel.SelectedTypeZones):
                 UpdateRequiredCheckArea();
                 CanAcceptView();
                 break;
@@ -165,7 +165,7 @@ internal class MainViewModel : BaseViewModel {
     // Метод проверки возможности выполнения метода проверки зон
     private bool CanCheckArea() {
         return CommonSettingViewModel != null
-            && CommonSettingViewModel.FilteredTypeZones.Count == 0
+            && CommonSettingViewModel.FilteredTypeZones.Count != 0
             && RequiredCheckArea;
     }
 
@@ -231,7 +231,7 @@ internal class MainViewModel : BaseViewModel {
                 ErrorText = _services.LocalizationService.GetLocalizedString("MainViewModel.ErrorParams");
                 return false;
             }
-            if(CommonSettingViewModel.FilteredTypeZones.Count == 0) {
+            if(CommonSettingViewModel.SelectedTypeZones.Count == 0) {
                 ErrorText = _services.LocalizationService.GetLocalizedString("MainViewModel.NoTypeZone");
                 return false;
             }

--- a/src/RevitBuildCoordVolumes/ViewModels/MainViewModel.cs
+++ b/src/RevitBuildCoordVolumes/ViewModels/MainViewModel.cs
@@ -323,7 +323,7 @@ internal class MainViewModel : BaseViewModel {
     // Метод сохранения настроек
     private void SaveSettings() {
         var algorithmType = CommonSettingViewModel.SelectedTypeAlgorithm.AlgorithmType;
-        var typeZones = CommonSettingViewModel.FilteredTypeZones.Select(typeZone => typeZone.Name).ToList();
+        var typeZones = CommonSettingViewModel.SelectedTypeZones.Select(typeZone => typeZone.Name).ToList();
         var paramMaps = CommonSettingViewModel.Params.Where(vm => vm.IsChecked).Select(vm => vm.ParamMap).ToList();
         var builderMode = SlabBasedSettingViewModel.SelectedBuilderMode.BuilderMode;
         var documents = SlabBasedSettingViewModel.FilteredDocuments.Where(vm => vm.IsChecked).Select(d => d.Document).ToList();

--- a/src/RevitBuildCoordVolumes/ViewModels/MainViewModel.cs
+++ b/src/RevitBuildCoordVolumes/ViewModels/MainViewModel.cs
@@ -98,7 +98,6 @@ internal class MainViewModel : BaseViewModel {
                 UpdateVisibilitySettings();
                 break;
             case nameof(CommonSettingViewModel.TypeZones):
-            case nameof(CommonSettingViewModel.SelectedTypeZone):
                 UpdateRequiredCheckArea();
                 CanAcceptView();
                 break;
@@ -140,9 +139,9 @@ internal class MainViewModel : BaseViewModel {
 
     // Метод получения всех зон
     private List<SpatialObject> GetSpatialObjects() {
-        string areaType = _settings.TypeZone;
+        var areaTypes = _settings.TypeZones;
         var areaTypeParam = _settings.ParamMaps.First().SourceParam;
-        return _revitRepository.GetSpatialObjects(areaType, areaTypeParam).ToList();
+        return _revitRepository.GetSpatialObjects(areaTypes, areaTypeParam).ToList();
     }
 
     // Метод проверки зон
@@ -166,7 +165,7 @@ internal class MainViewModel : BaseViewModel {
     // Метод проверки возможности выполнения метода проверки зон
     private bool CanCheckArea() {
         return CommonSettingViewModel != null
-            && CommonSettingViewModel.SelectedTypeZone != null
+            && CommonSettingViewModel.FilteredTypeZones.Count == 0
             && RequiredCheckArea;
     }
 
@@ -232,7 +231,7 @@ internal class MainViewModel : BaseViewModel {
                 ErrorText = _services.LocalizationService.GetLocalizedString("MainViewModel.ErrorParams");
                 return false;
             }
-            if(CommonSettingViewModel.SelectedTypeZone == null) {
+            if(CommonSettingViewModel.FilteredTypeZones.Count == 0) {
                 ErrorText = _services.LocalizationService.GetLocalizedString("MainViewModel.NoTypeZone");
                 return false;
             }
@@ -312,7 +311,7 @@ internal class MainViewModel : BaseViewModel {
         _settings = new BuildCoordVolumeSettings {
             AlgorithmType = configSettings.AlgorithmType,
             BuilderMode = configSettings.BuilderMode,
-            TypeZone = configSettings.TypeZone,
+            TypeZones = configSettings.TypeZones,
             ParamMaps = configSettings.ParamMaps,
             Documents = documents,
             TypeSlabs = typeSlabs,
@@ -324,7 +323,7 @@ internal class MainViewModel : BaseViewModel {
     // Метод сохранения настроек
     private void SaveSettings() {
         var algorithmType = CommonSettingViewModel.SelectedTypeAlgorithm.AlgorithmType;
-        string typeZone = CommonSettingViewModel.SelectedTypeZone.Name;
+        var typeZones = CommonSettingViewModel.FilteredTypeZones.Select(typeZone => typeZone.Name).ToList();
         var paramMaps = CommonSettingViewModel.Params.Where(vm => vm.IsChecked).Select(vm => vm.ParamMap).ToList();
         var builderMode = SlabBasedSettingViewModel.SelectedBuilderMode.BuilderMode;
         var documents = SlabBasedSettingViewModel.FilteredDocuments.Where(vm => vm.IsChecked).Select(d => d.Document).ToList();
@@ -337,7 +336,7 @@ internal class MainViewModel : BaseViewModel {
         _settings.BuilderMode = builderMode;
         _settings.Documents = documents;
         _settings.TypeSlabs = typeSlabs;
-        _settings.TypeZone = typeZone;
+        _settings.TypeZones = typeZones;
         _settings.ParamMaps = paramMaps;
         _settings.Levels = levels;
         _settings.SquareSideMm = squareSide;
@@ -350,7 +349,7 @@ internal class MainViewModel : BaseViewModel {
             AlgorithmType = _settings.AlgorithmType,
             BuilderMode = _settings.BuilderMode,
             Documents = _settings.Documents.Select(doc => doc.GetUniqId()).ToList(),
-            TypeZone = _settings.TypeZone,
+            TypeZones = _settings.TypeZones,
             ParamMaps = _settings.ParamMaps,
             TypeSlabs = _settings.TypeSlabs,
             SquareSideMm = _settings.SquareSideMm,

--- a/src/RevitBuildCoordVolumes/ViewModels/TypeZoneViewModel.cs
+++ b/src/RevitBuildCoordVolumes/ViewModels/TypeZoneViewModel.cs
@@ -5,9 +5,14 @@ namespace RevitBuildCoordVolumes.ViewModels;
 internal class TypeZoneViewModel : BaseViewModel {
 
     private string _name;
+    private bool _isChecked;
 
     public string Name {
         get => _name;
         set => RaiseAndSetIfChanged(ref _name, value);
+    }
+    public bool IsChecked {
+        get => _isChecked;
+        set => RaiseAndSetIfChanged(ref _isChecked, value);
     }
 }

--- a/src/RevitBuildCoordVolumes/Views/Edits/CommonSettingsEditControl.xaml
+++ b/src/RevitBuildCoordVolumes/Views/Edits/CommonSettingsEditControl.xaml
@@ -32,18 +32,75 @@
                 ItemsSource="{Binding TypeAlgorithms}"
                 SelectedValue="{Binding SelectedTypeAlgorithm}"
                 DisplayMemberPath="Name" />
-        </edits:CustomEditControl>
+        </edits:CustomEditControl>        
 
-        <edits:CustomEditControl
+        <edits:CustomGroupEditControl
             Icon="{ui:SymbolIcon grid24}"
-            Header="{me:LocalizationSource CommonSettingsEditControl.TypeZones}"
-            Description="{me:LocalizationSource CommonSettingsEditControl.TypeZonesDescription}">
+            Header="{me:LocalizationSource MainWindow.TypeZones}"
+            Description="{me:LocalizationSource MainWindow.TypeZonesDescription}"
+            ExtraIconVisible="False">
+            <edits:CustomGroupEditControl.EditControl>
+                <StackPanel>
+                    <Border
+                        Margin="5"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Stretch"
+                        Background="{DynamicResource CardBackground}"
+                        BorderBrush="{DynamicResource CardBorderBrush}"
+                        CornerRadius="{DynamicResource ControlCornerRadius}"
+                        BorderThickness="{DynamicResource CardControlBorderThemeThickness}">
+                        <StackPanel
+                            Orientation="Horizontal"
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Center">
+                            <RadioButton
+                                Margin="20,0,0,0"
+                                GroupName="Choise"
+                                Content="{me:LocalizationSource MainWindow.CheckedAllTypeZones}"
+                                IsChecked="{Binding IsCheckedAllTypeZones, Mode=TwoWay}"
+                                Command="{Binding CheckAllTypeZonesCommand}" />
+                            <RadioButton
+                                Margin="20,0,0,0"
+                                GroupName="Choise"
+                                Content="{me:LocalizationSource MainWindow.NotCheckedAllTypeZones}"
+                                Command="{Binding UncheckAllTypeZonesCommand}" />
+                        </StackPanel>
+                    </Border>
+                    <ui:AutoSuggestBox
+                        Margin="5,0,5,20"
+                        Icon="{ui:SymbolIcon Search24}"
+                        Text="{Binding SearchTextTypeZones, Mode=TwoWay}"
+                        PlaceholderText="{me:LocalizationSource MainWindow.SearchTextTypeZones}">
+                        <i:Interaction.Triggers>
+                            <i:EventTrigger
+                                EventName="TextChanged">
+                                <i:InvokeCommandAction
+                                    Command="{Binding SearchTypeZonesCommand}" />
+                            </i:EventTrigger>
+                        </i:Interaction.Triggers>
+                    </ui:AutoSuggestBox>
+                    <ItemsControl
+                        ItemsSource="{Binding FilteredTypeZones}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate
+                                DataType="{x:Type vms:TypeZoneViewModel}">
+                                <edits:ItemControl
+                                    ItemName="{Binding Name}"
+                                    IsChecked="{Binding IsChecked, Mode=TwoWay}"
+                                    HasWarning="False" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
 
-            <ComboBox
-                ItemsSource="{Binding TypeZones}"
-                SelectedValue="{Binding SelectedTypeZone}"
-                DisplayMemberPath="Name" />
-        </edits:CustomEditControl>
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <UniformGrid
+                                    Columns="3" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                    </ItemsControl>
+                </StackPanel>
+            </edits:CustomGroupEditControl.EditControl>
+        </edits:CustomGroupEditControl>
 
         <edits:CustomGroupEditControl
             Icon="{ui:SymbolIcon clipboardTaskListLtr24}"

--- a/src/RevitBuildCoordVolumes/Views/Edits/CommonSettingsEditControl.xaml
+++ b/src/RevitBuildCoordVolumes/Views/Edits/CommonSettingsEditControl.xaml
@@ -36,8 +36,8 @@
 
         <edits:CustomGroupEditControl
             Icon="{ui:SymbolIcon grid24}"
-            Header="{me:LocalizationSource MainWindow.TypeZones}"
-            Description="{me:LocalizationSource MainWindow.TypeZonesDescription}"
+            Header="{me:LocalizationSource CommonSettingsEditControl.TypeZones}"
+            Description="{me:LocalizationSource CommonSettingsEditControl.TypeZonesDescription}"
             ExtraIconVisible="False">
             <edits:CustomGroupEditControl.EditControl>
                 <StackPanel>
@@ -56,13 +56,12 @@
                             <RadioButton
                                 Margin="20,0,0,0"
                                 GroupName="Choise"
-                                Content="{me:LocalizationSource MainWindow.CheckedAllTypeZones}"
-                                IsChecked="{Binding IsCheckedAllTypeZones, Mode=TwoWay}"
+                                Content="{me:LocalizationSource CommonSettingsEditControl.CheckedAllTypeZones}"
                                 Command="{Binding CheckAllTypeZonesCommand}" />
                             <RadioButton
                                 Margin="20,0,0,0"
                                 GroupName="Choise"
-                                Content="{me:LocalizationSource MainWindow.NotCheckedAllTypeZones}"
+                                Content="{me:LocalizationSource CommonSettingsEditControl.NotCheckedAllTypeZones}"
                                 Command="{Binding UncheckAllTypeZonesCommand}" />
                         </StackPanel>
                     </Border>
@@ -70,7 +69,7 @@
                         Margin="5,0,5,20"
                         Icon="{ui:SymbolIcon Search24}"
                         Text="{Binding SearchTextTypeZones, Mode=TwoWay}"
-                        PlaceholderText="{me:LocalizationSource MainWindow.SearchTextTypeZones}">
+                        PlaceholderText="{me:LocalizationSource CommonSettingsEditControl.SearchTextTypeZones}">
                         <i:Interaction.Triggers>
                             <i:EventTrigger
                                 EventName="TextChanged">

--- a/src/RevitBuildCoordVolumes/Views/Edits/ItemControl.xaml
+++ b/src/RevitBuildCoordVolumes/Views/Edits/ItemControl.xaml
@@ -1,5 +1,5 @@
 ﻿<UserControl
-    x:Class="RevitBuildCoordVolumes.Views.Edits.SlabControl"
+    x:Class="RevitBuildCoordVolumes.Views.Edits.ItemControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -48,7 +48,7 @@
                 VerticalAlignment="Center"
                 FontTypography="BodyStrong"
                 Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                Text="{Binding SlabName, ElementName=_this}"
+                Text="{Binding ItemName, ElementName=_this}"
                 TextWrapping="WrapWithOverflow" />
 
             <ui:SymbolIcon

--- a/src/RevitBuildCoordVolumes/Views/Edits/ItemControl.xaml.cs
+++ b/src/RevitBuildCoordVolumes/Views/Edits/ItemControl.xaml.cs
@@ -2,26 +2,26 @@ using System.Windows;
 
 namespace RevitBuildCoordVolumes.Views.Edits;
 
-public partial class SlabControl {
+public partial class ItemControl {
 
     public static readonly DependencyProperty SlabNameProperty = DependencyProperty.Register(
-        nameof(SlabName), typeof(string), typeof(SlabControl), new PropertyMetadata(default(string)));
+        nameof(ItemName), typeof(string), typeof(ItemControl), new PropertyMetadata(default(string)));
 
     public static readonly DependencyProperty WarningDescriptionProperty = DependencyProperty.Register(
-        nameof(WarningDescription), typeof(string), typeof(SlabControl), new PropertyMetadata(default(string)));
+        nameof(WarningDescription), typeof(string), typeof(ItemControl), new PropertyMetadata(default(string)));
 
     public static readonly DependencyProperty IsCheckedProperty = DependencyProperty.Register(
-        nameof(IsChecked), typeof(bool), typeof(SlabControl), new PropertyMetadata(true));
+        nameof(IsChecked), typeof(bool), typeof(ItemControl), new PropertyMetadata(true));
 
     public static readonly DependencyProperty HasWarningProperty = DependencyProperty.Register(
-        nameof(HasWarning), typeof(bool), typeof(SlabControl), new PropertyMetadata(true));
+        nameof(HasWarning), typeof(bool), typeof(ItemControl), new PropertyMetadata(true));
 
 
-    public SlabControl() {
+    public ItemControl() {
         InitializeComponent();
     }
 
-    public string SlabName {
+    public string ItemName {
         get => (string) GetValue(SlabNameProperty);
         set => SetValue(SlabNameProperty, value);
     }

--- a/src/RevitBuildCoordVolumes/Views/Edits/SlabBasedSettingEditControl.xaml
+++ b/src/RevitBuildCoordVolumes/Views/Edits/SlabBasedSettingEditControl.xaml
@@ -54,8 +54,8 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate
                                 DataType="{x:Type vms:DocumentViewModel}">
-                                <edits:SlabControl
-                                    SlabName="{Binding Name}"
+                                <edits:ItemControl
+                                    ItemName="{Binding Name}"
                                     IsChecked="{Binding IsChecked, Mode=TwoWay}"
                                     HasWarning="False" />
                             </DataTemplate>
@@ -98,8 +98,8 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate
                                 DataType="{x:Type vms:SlabViewModel}">
-                                <edits:SlabControl
-                                    SlabName="{Binding Name}"
+                                <edits:ItemControl
+                                    ItemName="{Binding Name}"
                                     IsChecked="{Binding IsChecked, Mode=TwoWay}"
                                     HasWarning="False" />
                             </DataTemplate>
@@ -166,8 +166,8 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate
                                 DataType="{x:Type vms:LevelViewModel}">
-                                <edits:SlabControl
-                                    SlabName="{Binding Name}"
+                                <edits:ItemControl
+                                    ItemName="{Binding Name}"
                                     IsChecked="{Binding IsChecked, Mode=TwoWay}"
                                     HasWarning="False" />
                             </DataTemplate>

--- a/src/RevitBuildCoordVolumes/assets/Localization/Language.en-US.xaml
+++ b/src/RevitBuildCoordVolumes/assets/Localization/Language.en-US.xaml
@@ -16,7 +16,10 @@
     <system:String x:Key="CommonSettingsEditControl.Params">CMR parameters</system:String>
     <system:String x:Key="CommonSettingsEditControl.ParamsDescription">Select CMR parameters for reading and writing</system:String>
     <system:String x:Key="CommonSettingsEditControl.ParamWarningTooltip">Some parameters contain errors</system:String>
-
+    <system:String x:Key="CommonSettingsEditControl.CheckedAllTypeZones">Check all type zones</system:String>
+    <system:String x:Key="CommonSettingsEditControl.NotCheckedAllTypeZones">Uncheck all type zones</system:String>
+    <system:String x:Key="CommonSettingsEditControl.SearchTextTypeZones">Search type zone by name</system:String>
+    
     <system:String x:Key="ParamControl.ParamsToggleSwitchOn">Use parameter</system:String>
     <system:String x:Key="ParamControl.ParamsToggleSwitchOff">Do not use parameter</system:String>
     <system:String x:Key="ParamControl.SourceParamHeader">Zone parameter</system:String>
@@ -35,10 +38,9 @@
 
     <system:String x:Key="SlabBasedSettingEditControl.Levels">Slab levels</system:String>
     <system:String x:Key="SlabBasedSettingEditControl.LevelsDescription">Slab levels used to define the base</system:String>
-    <system:String x:Key="SlabBasedSettingEditControl.CheckedAllLevels">Select all levels</system:String>
-    <system:String x:Key="SlabBasedSettingEditControl.NotCheckedAllLevels">Clear level selection</system:String>
+    <system:String x:Key="SlabBasedSettingEditControl.CheckedAllLevels">Select all levels</system:String>    
     <system:String x:Key="SlabBasedSettingEditControl.SearchTextLevels">Search by level name</system:String>
-    
+    <system:String x:Key="SlabBasedSettingEditControl.NotCheckedAllLevels">Clear level selection</system:String>
 
     <system:String x:Key="SlabBasedSettingEditControl.SquareSide">Square side length (mm)</system:String>
     <system:String x:Key="SlabBasedSettingEditControl.SquareSideDescription">The zone is divided into a grid of squares with the specified side length</system:String>
@@ -95,6 +97,7 @@
     <system:String x:Key="DocumentViewModel.CurrentFile">Current file (open)</system:String>
 
     <system:String x:Key="BuildCoordVolumesProcessor.TransactionName">Build CMR volumes</system:String>
+    <system:String x:Key="BuildCoordVolumesProcessor.ZoneName">Zone {0}:</system:String>
 
     <system:String x:Key="Common.ParamErrorMessageBody">Parameter loading error</system:String>
     <system:String x:Key="Common.ConfigErrorMessageTitle">Plugin configuration error</system:String>
@@ -122,4 +125,5 @@
     <system:String x:Key="SlabNormalize.ProgressTitle">Processing slabs {0}%</system:String>
     <system:String x:Key="BuildContour.ProgressTitle">Generate contours {0}%</system:String>
     <system:String x:Key="BuildVolumes.ProgressTitle">Generate Volumes {0}%</system:String>
+    
 </ResourceDictionary>

--- a/src/RevitBuildCoordVolumes/assets/Localization/Language.ru-RU.xaml
+++ b/src/RevitBuildCoordVolumes/assets/Localization/Language.ru-RU.xaml
@@ -16,6 +16,9 @@
     <system:String x:Key="CommonSettingsEditControl.Params">Параметры СМР</system:String>
     <system:String x:Key="CommonSettingsEditControl.ParamsDescription">Выбор параметров СМР для чтения и записи</system:String>
     <system:String x:Key="CommonSettingsEditControl.ParamWarningTooltip">В некоторых параметрах есть ошибки</system:String>
+    <system:String x:Key="CommonSettingsEditControl.CheckedAllTypeZones">Выбрать все типы зон</system:String>
+    <system:String x:Key="CommonSettingsEditControl.NotCheckedAllTypeZones">Сбросить выбор типов зон</system:String>
+    <system:String x:Key="CommonSettingsEditControl.SearchTextTypeZones">Поиск типа зоны по имени</system:String>
     
     <system:String x:Key="ParamControl.ParamsToggleSwitchOn">Использовать параметр</system:String>
     <system:String x:Key="ParamControl.ParamsToggleSwitchOff">Не использовать параметр</system:String>


### PR DESCRIPTION
В старой версии плагина можно было отработать только 1 тип зоны за 1 раз:

<img width="500" height="952" alt="image" src="https://github.com/user-attachments/assets/0868db3e-7d12-4b22-b28a-00a8318508e0" />

В новой версии можно выбрать несколько зон сразу:

<img width="500" height="951" alt="image" src="https://github.com/user-attachments/assets/2a0c1b72-1f18-4047-9c3b-ca84c577e3a8" />

