### PR TITLE
RevitParamsChecker: Исправлена загрузка конфигов в пустые списки наборов, правил, проверок

### DIFF
--- a/src/RevitParamsChecker/ViewModels/Checks/ChecksPageViewModel.cs
+++ b/src/RevitParamsChecker/ViewModels/Checks/ChecksPageViewModel.cs
@@ -261,7 +261,7 @@ internal class ChecksPageViewModel : BaseViewModel {
                         })
                         .ToArray())
                 .OfType<CheckViewModel>();
-            string selectedName = SelectedCheck.Name;
+            string selectedName = SelectedCheck?.Name;
             Checks.Clear();
             foreach(var vm in vms) {
                 Checks.Add(vm);

--- a/src/RevitParamsChecker/ViewModels/Filtration/FiltrationPageViewModel.cs
+++ b/src/RevitParamsChecker/ViewModels/Filtration/FiltrationPageViewModel.cs
@@ -223,7 +223,7 @@ internal class FiltrationPageViewModel : BaseViewModel {
                         })
                         .ToArray())
                 .OfType<FilterViewModel>();
-            string selectedName = SelectedFilter.Name;
+            string selectedName = SelectedFilter?.Name;
             Filters.Clear();
             foreach(var vm in vms) {
                 Filters.Add(vm);

--- a/src/RevitParamsChecker/ViewModels/Rules/RulesPageViewModel.cs
+++ b/src/RevitParamsChecker/ViewModels/Rules/RulesPageViewModel.cs
@@ -170,7 +170,7 @@ internal class RulesPageViewModel : BaseViewModel {
                         })
                         .ToArray())
                 .OfType<RuleViewModel>();
-            string selectedName = SelectedRule.Name;
+            string selectedName = SelectedRule?.Name;
             Rules.Clear();
             foreach(var vm in vms) {
                 Rules.Add(vm);


### PR DESCRIPTION
## Описание

- Исправлена ошибка, когда в пустой список поисковых наборов/правил/проверок не загружались настройки