### PR TITLE
RevitClashDetective: Ifc связи исключены из обработки плагином

### DIFF
--- a/src/RevitClashes/Models/FilterableValueProviders/ParameterValueProvider.cs
+++ b/src/RevitClashes/Models/FilterableValueProviders/ParameterValueProvider.cs
@@ -70,11 +70,15 @@ internal class ParameterValueProvider : IFilterableValueProvider, IEquatable<Par
     }
 
     public ParamValue GetElementParamValue(Element item) {
+        if(item is null) {
+            return null;
+        }
+
         if(item.IsExistsParam(RevitParam)) {
             return ParamValue.GetParamValue(RevitParam, item);
         } else {
             var typeId = item.GetTypeId();
-            if(typeId != null) {
+            if(typeId.IsNotNull()) {
                 var type = item.Document.GetElement(typeId);
                 if(type.IsExistsParam(RevitParam)) {
                     return ParamValue.GetParamValue(RevitParam, type);

--- a/src/RevitClashes/Models/RevitRepository.cs
+++ b/src/RevitClashes/Models/RevitRepository.cs
@@ -94,7 +94,7 @@ internal class RevitRepository {
 
     public UIApplication UiApplication { get; }
 
-    public List<DocInfo> DocInfos { get; set; }
+    public List<DocInfo> DocInfos { get; private set; }
 
     public View3D GetClashView() {
         var view = new FilteredElementCollector(Doc)
@@ -185,7 +185,10 @@ internal class RevitRepository {
         return new FilteredElementCollector(Doc)
             .OfClass(typeof(RevitLinkInstance))
             .Cast<RevitLinkInstance>()
-            .Where(item => item.GetLinkDocument() != null)
+            .Where(item => {
+                var doc = item.GetLinkDocument();
+                return doc != null && doc.Title.EndsWith(".rvt");
+            })
             .ToList();
     }
 


### PR DESCRIPTION
## Обновления

- Список связей для обработки теперь формируется исключительно из **rvt** связей