### PR TITLE
RevitClashDetective: Исправлены биндинги для чекбоксов в окнах наборы и проверки

### DIFF
--- a/src/RevitClashDetective/Views/Checks/MainWindow.xaml
+++ b/src/RevitClashDetective/Views/Checks/MainWindow.xaml
@@ -172,7 +172,7 @@
                                         <CheckBox
                                             Padding="0"
                                             Margin="4 0 0 0"
-                                            IsChecked="{Binding ItemIsSelected, UpdateSourceTrigger=PropertyChanged}" />
+                                            IsChecked="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" />
                                     </DockPanel>
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>

--- a/src/RevitClashDetective/Views/Filters/CategoryView.xaml
+++ b/src/RevitClashDetective/Views/Filters/CategoryView.xaml
@@ -66,7 +66,7 @@
                         <DataGridCheckBoxColumn
                             Width="47"
                             CanUserSort="False"
-                            Binding="{Binding ItemIsSelected, UpdateSourceTrigger=PropertyChanged}">
+                            Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}">
                             <DataGridCheckBoxColumn.Header>
                                 <CheckBox
                                     IsChecked="{Binding DataContext.AllCategoriesSelected, RelativeSource={RelativeSource AncestorType=ui:DataGrid}, UpdateSourceTrigger=PropertyChanged}" />


### PR DESCRIPTION
## Описание

- В предыдущем PR #427 во время рефакторинга по ошибке были изменены свойства для привязки чекбоксов в xaml, из-за чего эти чекбоксы перестали работать.