### PR TITLE
RevitParamsChecker: Добавлен функционал по проверке параметров материалов элементов

### DIFF
--- a/src/RevitParamsChecker/Models/Checks/Check.cs
+++ b/src/RevitParamsChecker/Models/Checks/Check.cs
@@ -8,6 +8,8 @@ internal class Check {
 
     public string Name { get; set; }
 
+    public CheckTargetType TargetType { get; set; } = CheckTargetType.Element;
+
     public HashSet<string> Filters { get; set; } = [];
 
     public HashSet<string> Files { get; set; } = [];
@@ -17,6 +19,7 @@ internal class Check {
     public Check Copy() {
         return new Check() {
             Name = Name,
+            TargetType = TargetType,
             Filters = [..Filters],
             Files = [..Files],
             Rules = [..Rules]

--- a/src/RevitParamsChecker/Models/Checks/CheckTargetType.cs
+++ b/src/RevitParamsChecker/Models/Checks/CheckTargetType.cs
@@ -1,0 +1,6 @@
+namespace RevitParamsChecker.Models.Checks;
+
+internal enum CheckTargetType {
+    Element = 0,
+    Material = 1
+}

--- a/src/RevitParamsChecker/Models/Revit/RevitRepository.cs
+++ b/src/RevitParamsChecker/Models/Revit/RevitRepository.cs
@@ -67,6 +67,31 @@ internal class RevitRepository {
             .ToArray();
     }
 
+    public ICollection<Material> GetElementMaterials(Element element) {
+        if(element is null) {
+            throw new ArgumentNullException(nameof(element));
+        }
+
+        var doc = element.Document;
+        var ids = new HashSet<ElementId>();
+        foreach(var id in element.GetMaterialIds(false)) {
+            ids.Add(id);
+        }
+
+        foreach(var id in element.GetMaterialIds(true)) {
+            ids.Add(id);
+        }
+
+        List<Material> materials = [];
+        foreach(var id in ids) {
+            if(doc.GetElement(id) is Material m) {
+                materials.Add(m);
+            }
+        }
+
+        return materials;
+    }
+
     public void SelectElements(ICollection<ElementModel> elements) {
 #if REVIT_2023_OR_GREATER
         ActiveUIDocument.Selection.SetReferences(elements.Select(e => e.Reference).ToArray());

--- a/src/RevitParamsChecker/RevitParamsCheckerCommand.cs
+++ b/src/RevitParamsChecker/RevitParamsCheckerCommand.cs
@@ -197,5 +197,12 @@ public class RevitParamsCheckerCommand : BasePluginCommand {
         kernel.Bind<NamesService>()
             .ToSelf()
             .InSingletonScope();
+
+        kernel.Bind<ChecksEngine>()
+            .To<ElementChecksEngine>()
+            .InSingletonScope();
+        kernel.Bind<ChecksEngine>()
+            .To<MaterialChecksEngine>()
+            .InSingletonScope();
     }
 }

--- a/src/RevitParamsChecker/Services/ChecksEngine.cs
+++ b/src/RevitParamsChecker/Services/ChecksEngine.cs
@@ -5,7 +5,6 @@ using System.Threading;
 
 using dosymep.SimpleServices;
 
-using RevitParamsChecker.Exceptions;
 using RevitParamsChecker.Models.Checks;
 using RevitParamsChecker.Models.Filtration;
 using RevitParamsChecker.Models.Results;
@@ -14,14 +13,14 @@ using RevitParamsChecker.Models.Rules;
 
 namespace RevitParamsChecker.Services;
 
-internal class ChecksEngine {
-    private readonly RevitRepository _revitRepo;
-    private readonly FiltersRepository _filtersRepo;
-    private readonly RulesRepository _rulesRepo;
-    private readonly CheckResultsRepository _checkResultsRepo;
-    private readonly ILocalizationService _localization;
+internal abstract class ChecksEngine {
+    protected readonly RevitRepository _revitRepo;
+    protected readonly FiltersRepository _filtersRepo;
+    protected readonly RulesRepository _rulesRepo;
+    protected readonly CheckResultsRepository _checkResultsRepo;
+    protected readonly ILocalizationService _localization;
 
-    public ChecksEngine(
+    protected ChecksEngine(
         RevitRepository revitRepo,
         FiltersRepository filtersRepo,
         RulesRepository rulesRepo,
@@ -33,6 +32,8 @@ internal class ChecksEngine {
         _checkResultsRepo = checkResultsRepo ?? throw new ArgumentNullException(nameof(checkResultsRepo));
         _localization = localization ?? throw new ArgumentNullException(nameof(localization));
     }
+
+    public abstract CheckTargetType TargetType { get; }
 
     public void Run(Check check, CancellationToken ct = default) {
         if(check == null) {
@@ -46,20 +47,7 @@ internal class ChecksEngine {
             List<ElementResult> elementResults = [];
             foreach(var element in elements) {
                 ct.ThrowIfCancellationRequested();
-                try {
-                    bool success = rule.RootRule.Evaluate(element.Element);
-                    var status = success ? StatusCode.Valid : StatusCode.Invalid;
-                    elementResults.Add(new ElementResult(element, status, rule.Name));
-                } catch(ParamNotFoundException exParam) {
-                    elementResults.Add(
-                        new ElementResult(
-                            element,
-                            StatusCode.ParamNotFound,
-                            rule.Name,
-                            _localization.GetLocalizedString("Exceptions.ParamNotFound", exParam.Message)));
-                } catch(Autodesk.Revit.Exceptions.ApplicationException exRevit) {
-                    elementResults.Add(new ElementResult(element, StatusCode.Error, rule.Name, exRevit.Message));
-                }
+                elementResults.Add(EvaluateElement(element, rule));
             }
 
             ruleResults.Add(new RuleResult(elementResults, rule.Copy()));
@@ -68,6 +56,8 @@ internal class ChecksEngine {
         var result = new CheckResult(ruleResults, check.Copy());
         _checkResultsRepo.AddCheckResult(result);
     }
+
+    protected abstract ElementResult EvaluateElement(ElementModel element, Rule rule);
 
     private ICollection<ElementModel> GetElements(Check check) {
         var filters = check.Filters.Select(f => _filtersRepo.GetFilter(f)).ToArray();

--- a/src/RevitParamsChecker/Services/ElementChecksEngine.cs
+++ b/src/RevitParamsChecker/Services/ElementChecksEngine.cs
@@ -1,0 +1,39 @@
+using dosymep.SimpleServices;
+
+using RevitParamsChecker.Exceptions;
+using RevitParamsChecker.Models.Checks;
+using RevitParamsChecker.Models.Filtration;
+using RevitParamsChecker.Models.Results;
+using RevitParamsChecker.Models.Revit;
+using RevitParamsChecker.Models.Rules;
+
+namespace RevitParamsChecker.Services;
+
+internal class ElementChecksEngine : ChecksEngine {
+    public ElementChecksEngine(
+        RevitRepository revitRepo,
+        FiltersRepository filtersRepo,
+        RulesRepository rulesRepo,
+        CheckResultsRepository checkResultsRepo,
+        ILocalizationService localization)
+        : base(revitRepo, filtersRepo, rulesRepo, checkResultsRepo, localization) {
+    }
+
+    public override CheckTargetType TargetType => CheckTargetType.Element;
+
+    protected override ElementResult EvaluateElement(ElementModel element, Rule rule) {
+        try {
+            bool success = rule.RootRule.Evaluate(element.Element);
+            var status = success ? StatusCode.Valid : StatusCode.Invalid;
+            return new ElementResult(element, status, rule.Name);
+        } catch(ParamNotFoundException exParam) {
+            return new ElementResult(
+                element,
+                StatusCode.ParamNotFound,
+                rule.Name,
+                _localization.GetLocalizedString("Exceptions.ParamNotFound", exParam.Message));
+        } catch(Autodesk.Revit.Exceptions.ApplicationException exRevit) {
+            return new ElementResult(element, StatusCode.Error, rule.Name, exRevit.Message);
+        }
+    }
+}

--- a/src/RevitParamsChecker/Services/MaterialChecksEngine.cs
+++ b/src/RevitParamsChecker/Services/MaterialChecksEngine.cs
@@ -34,31 +34,26 @@ internal class MaterialChecksEngine : ChecksEngine {
                 _localization.GetLocalizedString("Exceptions.NoMaterials"));
         }
 
-        StatusCode worst = StatusCode.Valid;
-        var errors = new HashSet<string>(StringComparer.Ordinal);
-
+        StatusCode status = StatusCode.Valid;
+        string error = string.Empty;
         foreach(var material in materials) {
             try {
                 bool success = rule.RootRule.Evaluate(material);
-                var status = success ? StatusCode.Valid : StatusCode.Invalid;
-                if((int) status < (int) worst) {
-                    worst = status;
+                if(!success) {
+                    status = StatusCode.Invalid;
+                    break;
                 }
             } catch(ParamNotFoundException exParam) {
-                if((int) StatusCode.ParamNotFound < (int) worst) {
-                    worst = StatusCode.ParamNotFound;
-                }
-
-                errors.Add(_localization.GetLocalizedString("Exceptions.ParamNotFound", exParam.Message));
+                status = StatusCode.ParamNotFound;
+                error = _localization.GetLocalizedString("Exceptions.MaterialParamNotFound", exParam.Message);
+                break;
             } catch(Autodesk.Revit.Exceptions.ApplicationException exRevit) {
-                worst = StatusCode.Error;
-                if(!string.IsNullOrEmpty(exRevit.Message)) {
-                    errors.Add(exRevit.Message);
-                }
+                status = StatusCode.Error;
+                error = exRevit.Message;
+                break;
             }
         }
 
-        string error = errors.Count > 0 ? string.Join("; ", errors) : string.Empty;
-        return new ElementResult(element, worst, rule.Name, error);
+        return new ElementResult(element, status, rule.Name, error);
     }
 }

--- a/src/RevitParamsChecker/Services/MaterialChecksEngine.cs
+++ b/src/RevitParamsChecker/Services/MaterialChecksEngine.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+
+using dosymep.SimpleServices;
+
+using RevitParamsChecker.Exceptions;
+using RevitParamsChecker.Models.Checks;
+using RevitParamsChecker.Models.Filtration;
+using RevitParamsChecker.Models.Results;
+using RevitParamsChecker.Models.Revit;
+using RevitParamsChecker.Models.Rules;
+
+namespace RevitParamsChecker.Services;
+
+internal class MaterialChecksEngine : ChecksEngine {
+    public MaterialChecksEngine(
+        RevitRepository revitRepo,
+        FiltersRepository filtersRepo,
+        RulesRepository rulesRepo,
+        CheckResultsRepository checkResultsRepo,
+        ILocalizationService localization)
+        : base(revitRepo, filtersRepo, rulesRepo, checkResultsRepo, localization) {
+    }
+
+    public override CheckTargetType TargetType => CheckTargetType.Material;
+
+    protected override ElementResult EvaluateElement(ElementModel element, Rule rule) {
+        var materials = _revitRepo.GetElementMaterials(element.Element);
+        if(materials.Count == 0) {
+            return new ElementResult(
+                element,
+                StatusCode.ParamNotFound,
+                rule.Name,
+                _localization.GetLocalizedString("Exceptions.NoMaterials"));
+        }
+
+        StatusCode worst = StatusCode.Valid;
+        var errors = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach(var material in materials) {
+            try {
+                bool success = rule.RootRule.Evaluate(material);
+                var status = success ? StatusCode.Valid : StatusCode.Invalid;
+                if((int) status < (int) worst) {
+                    worst = status;
+                }
+            } catch(ParamNotFoundException exParam) {
+                if((int) StatusCode.ParamNotFound < (int) worst) {
+                    worst = StatusCode.ParamNotFound;
+                }
+
+                errors.Add(_localization.GetLocalizedString("Exceptions.ParamNotFound", exParam.Message));
+            } catch(Autodesk.Revit.Exceptions.ApplicationException exRevit) {
+                worst = StatusCode.Error;
+                if(!string.IsNullOrEmpty(exRevit.Message)) {
+                    errors.Add(exRevit.Message);
+                }
+            }
+        }
+
+        string error = errors.Count > 0 ? string.Join("; ", errors) : string.Empty;
+        return new ElementResult(element, worst, rule.Name, error);
+    }
+}

--- a/src/RevitParamsChecker/ViewModels/Checks/CheckViewModel.cs
+++ b/src/RevitParamsChecker/ViewModels/Checks/CheckViewModel.cs
@@ -1,11 +1,15 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Linq;
 
 using dosymep.WPF.ViewModels;
 
 using RevitParamsChecker.Models;
 using RevitParamsChecker.Models.Checks;
+
+using ArgumentOutOfRangeException = Autodesk.Revit.Exceptions.ArgumentOutOfRangeException;
 
 namespace RevitParamsChecker.ViewModels.Checks;
 
@@ -21,10 +25,21 @@ internal class CheckViewModel : BaseViewModel, IEquatable<CheckViewModel>, IName
     private ObservableCollection<string> _selectedFilters;
     private ObservableCollection<string> _selectedRules;
     private bool _modified;
+    private EngineViewModel _selectedEngine;
 
-    public CheckViewModel(Check check) {
+    public CheckViewModel(Check check, IReadOnlyCollection<EngineViewModel> availableEngines) {
         _check = check ?? throw new ArgumentNullException(nameof(check));
+        if(availableEngines is null) {
+            throw new ArgumentNullException(nameof(availableEngines));
+        }
+
+        if(availableEngines.Count == 0) {
+            throw new System.ArgumentOutOfRangeException(nameof(availableEngines));
+        }
+
         Name = _check.Name;
+        SelectedEngine = availableEngines.FirstOrDefault(e => e.TargetType == _check.TargetType)
+            ?? availableEngines.First();
         Modified = true;
         SelectedFiles = [.._check.Files];
         SelectedFilters = [.._check.Filters];
@@ -36,6 +51,11 @@ internal class CheckViewModel : BaseViewModel, IEquatable<CheckViewModel>, IName
     public string Name {
         get => _name;
         set => RaiseAndSetIfChanged(ref _name, value);
+    }
+
+    public EngineViewModel SelectedEngine {
+        get => _selectedEngine;
+        set => RaiseAndSetIfChanged(ref _selectedEngine, value);
     }
 
     public string WarningFiles {
@@ -100,6 +120,7 @@ internal class CheckViewModel : BaseViewModel, IEquatable<CheckViewModel>, IName
 
     public Check GetCheck() {
         _check.Name = Name;
+        _check.TargetType = SelectedEngine.TargetType;
         _check.Files = [..SelectedFiles];
         _check.Filters = [..SelectedFilters];
         _check.Rules = [..SelectedRules];
@@ -110,7 +131,8 @@ internal class CheckViewModel : BaseViewModel, IEquatable<CheckViewModel>, IName
         if(e.PropertyName == nameof(Name)
            || e.PropertyName == nameof(SelectedFilters)
            || e.PropertyName == nameof(SelectedFiles)
-           || e.PropertyName == nameof(SelectedRules)) {
+           || e.PropertyName == nameof(SelectedRules)
+           || e.PropertyName == nameof(SelectedEngine)) {
             Modified = true;
         }
     }

--- a/src/RevitParamsChecker/ViewModels/Checks/CheckViewModel.cs
+++ b/src/RevitParamsChecker/ViewModels/Checks/CheckViewModel.cs
@@ -9,8 +9,6 @@ using dosymep.WPF.ViewModels;
 using RevitParamsChecker.Models;
 using RevitParamsChecker.Models.Checks;
 
-using ArgumentOutOfRangeException = Autodesk.Revit.Exceptions.ArgumentOutOfRangeException;
-
 namespace RevitParamsChecker.ViewModels.Checks;
 
 internal class CheckViewModel : BaseViewModel, IEquatable<CheckViewModel>, IName {

--- a/src/RevitParamsChecker/ViewModels/Checks/ChecksPageViewModel.cs
+++ b/src/RevitParamsChecker/ViewModels/Checks/ChecksPageViewModel.cs
@@ -28,7 +28,7 @@ internal class ChecksPageViewModel : BaseViewModel {
     private readonly RevitRepository _revitRepo;
     private readonly ChecksConverter _checksConverter;
     private readonly NamesService _namesService;
-    private readonly ChecksEngine _checksEngine;
+    private readonly EngineViewModel[] _availableEngines;
     private string _errorText;
     private string _dirPath;
     private bool _allSelected;
@@ -50,7 +50,7 @@ internal class ChecksPageViewModel : BaseViewModel {
         RevitRepository revitRepo,
         ChecksConverter checksConverter,
         NamesService namesService,
-        ChecksEngine checksEngine) {
+        IEnumerable<ChecksEngine> checksEngines) {
         OpenFileDialogService = openFileDialogService ?? throw new ArgumentNullException(nameof(openFileDialogService));
         SaveFileDialogService = saveFileDialogService ?? throw new ArgumentNullException(nameof(saveFileDialogService));
         MessageBoxService = messageBoxService ?? throw new ArgumentNullException(nameof(messageBoxService));
@@ -62,14 +62,22 @@ internal class ChecksPageViewModel : BaseViewModel {
         _revitRepo = revitRepo ?? throw new ArgumentNullException(nameof(revitRepo));
         _checksConverter = checksConverter ?? throw new ArgumentNullException(nameof(checksConverter));
         _namesService = namesService ?? throw new ArgumentNullException(nameof(namesService));
-        _checksEngine = checksEngine ?? throw new ArgumentNullException(nameof(checksEngine));
+        if(checksEngines is null) {
+            throw new ArgumentNullException(nameof(checksEngines));
+        }
+
+        _availableEngines = [..checksEngines.Select(e => new EngineViewModel(e, _localization))];
+        if(_availableEngines.Length == 0) {
+            throw new ArgumentOutOfRangeException(nameof(checksEngines));
+        }
+
         _dirPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
 
         _availableFiles = [.._revitRepo.GetDocuments().Select(d => d.Name)];
         _availableFilters = [.._filtersRepo.GetFilters().Select(f => f.Name)];
         _availableRules = [.._rulesRepo.GetRules().Select(r => r.Name)];
 
-        Checks = [.._checksRepo.GetChecks().Select(c => new CheckViewModel(c) { Modified = false })];
+        Checks = [.._checksRepo.GetChecks().Select(c => new CheckViewModel(c, _availableEngines) { Modified = false })];
         SelectedCheck = Checks.FirstOrDefault();
         AddCheckCommand = RelayCommand.Create(AddCheck);
         RenameCheckCommand = RelayCommand.Create<CheckViewModel>(RenameCheck, CanRenameCheck);
@@ -109,6 +117,8 @@ internal class ChecksPageViewModel : BaseViewModel {
 
     public ObservableCollection<CheckViewModel> Checks { get; }
 
+    public IReadOnlyList<EngineViewModel> AvailableEngines => _availableEngines;
+
     public CheckViewModel SelectedCheck {
         get => _selectedCheck;
         set => RaiseAndSetIfChanged(ref _selectedCheck, value);
@@ -142,7 +152,7 @@ internal class ChecksPageViewModel : BaseViewModel {
             newCheck.Name = _namesService.CreateNewName(
                 _localization.GetLocalizedString("ChecksPage.NewCheckPrompt"),
                 Checks.Select(f => f.Name).ToArray());
-            var vm = new CheckViewModel(newCheck);
+            var vm = new CheckViewModel(newCheck, _availableEngines);
             vm.PropertyChanged += OnCheckChanged;
             Checks.Add(vm);
             SelectedCheck = vm;
@@ -168,7 +178,7 @@ internal class ChecksPageViewModel : BaseViewModel {
                 _localization.GetLocalizedString("ChecksPage.NewCheckPrompt"),
                 Checks.Select(f => f.Name).ToArray(),
                 check.Name);
-            var vm = new CheckViewModel(copyCheck);
+            var vm = new CheckViewModel(copyCheck, _availableEngines);
             vm.PropertyChanged += OnCheckChanged;
             Checks.Add(vm);
             SelectedCheck = vm;
@@ -207,9 +217,9 @@ internal class ChecksPageViewModel : BaseViewModel {
         var ct = progressDialogService.CreateCancellationToken();
         progressDialogService.Show();
 
-        var checks = Checks.Where(f => f.IsSelected).Select(c => c.GetCheck()).ToArray();
-        foreach(var check in checks) {
-            _checksEngine.Run(check, ct);
+        var checkVms = Checks.Where(f => f.IsSelected).ToArray();
+        foreach(var checkVm in checkVms) {
+            checkVm.SelectedEngine.Engine.Run(checkVm.GetCheck(), ct);
         }
 
         progressDialogService?.Close();
@@ -255,7 +265,7 @@ internal class ChecksPageViewModel : BaseViewModel {
             var vms = _namesService.GetResolvedCollection(
                     Checks.ToArray(),
                     checks.Select(c => {
-                            var check = new CheckViewModel(c);
+                            var check = new CheckViewModel(c, _availableEngines);
                             check.PropertyChanged += OnCheckChanged;
                             return check;
                         })

--- a/src/RevitParamsChecker/ViewModels/Checks/EngineViewModel.cs
+++ b/src/RevitParamsChecker/ViewModels/Checks/EngineViewModel.cs
@@ -1,0 +1,26 @@
+using System;
+
+using dosymep.SimpleServices;
+using dosymep.WPF.ViewModels;
+
+using RevitParamsChecker.Models.Checks;
+using RevitParamsChecker.Services;
+
+namespace RevitParamsChecker.ViewModels.Checks;
+
+internal class EngineViewModel : BaseViewModel {
+    public EngineViewModel(ChecksEngine engine, ILocalizationService localization) {
+        Engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        if(localization is null) {
+            throw new ArgumentNullException(nameof(localization));
+        }
+
+        Name = localization.GetLocalizedString($"{nameof(CheckTargetType)}.{engine.TargetType}");
+    }
+
+    public ChecksEngine Engine { get; }
+
+    public string Name { get; }
+
+    public CheckTargetType TargetType => Engine.TargetType;
+}

--- a/src/RevitParamsChecker/Views/Checks/ChecksControl.xaml
+++ b/src/RevitParamsChecker/Views/Checks/ChecksControl.xaml
@@ -135,6 +135,24 @@
                     </DataGridTextColumn>
 
                     <DataGridTemplateColumn
+                        MinWidth="120"
+                        Width="Auto">
+                        <DataGridTemplateColumn.Header>
+                            <ui:TextBlock
+                                Text="{DynamicResource ChecksPage.TargetTypeHeader}" />
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <ComboBox
+                                    VerticalAlignment="Center"
+                                    ItemsSource="{Binding DataContext.AvailableEngines, RelativeSource={RelativeSource AncestorType=UserControl, Mode=FindAncestor}}"
+                                    SelectedItem="{Binding SelectedEngine, UpdateSourceTrigger=PropertyChanged}"
+                                    DisplayMemberPath="Name" />
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+
+                    <DataGridTemplateColumn
                         MinWidth="100"
                         Width="*">
                         <DataGridTemplateColumn.CellTemplate>

--- a/src/RevitParamsChecker/assets/Localization/Language.en-US.xaml
+++ b/src/RevitParamsChecker/assets/Localization/Language.en-US.xaml
@@ -19,6 +19,8 @@
     <system:String
         x:Key="Exceptions.ParamNotFound">Parameter missing: {0}</system:String>
     <system:String
+        x:Key="Exceptions.MaterialParamNotFound">Material parameter missing: {0}</system:String>
+    <system:String
         x:Key="Exceptions.NoMaterials">Element has no materials</system:String>
 
     <system:String

--- a/src/RevitParamsChecker/assets/Localization/Language.en-US.xaml
+++ b/src/RevitParamsChecker/assets/Localization/Language.en-US.xaml
@@ -18,6 +18,8 @@
         x:Key="ResultsPage.Title">Analysis</system:String>
     <system:String
         x:Key="Exceptions.ParamNotFound">Parameter missing: {0}</system:String>
+    <system:String
+        x:Key="Exceptions.NoMaterials">Element has no materials</system:String>
 
     <system:String
         x:Key="NamesSelectionDialog.NamesHeader">Name</system:String>
@@ -49,6 +51,8 @@
         x:Key="ChecksPage.ExecuteChecksButton">Run Selected</system:String>
     <system:String
         x:Key="ChecksPage.NameHeader">Name</system:String>
+    <system:String
+        x:Key="ChecksPage.TargetTypeHeader">Check Type</system:String>
     <system:String
         x:Key="ChecksPage.NothingSelectPrompt">Nothing Selected</system:String>
     <system:String
@@ -202,6 +206,11 @@ Previously selected checks are missing:
         x:Key="AndOperator">And</system:String>
     <system:String
         x:Key="OrOperator">Or</system:String>
+
+    <system:String
+        x:Key="CheckTargetType.Element">Elements</system:String>
+    <system:String
+        x:Key="CheckTargetType.Material">Materials</system:String>
 
     <system:String
         x:Key="StatusCode.Valid">Valid</system:String>

--- a/src/RevitParamsChecker/assets/Localization/Language.ru-RU.xaml
+++ b/src/RevitParamsChecker/assets/Localization/Language.ru-RU.xaml
@@ -19,6 +19,8 @@
     <system:String
         x:Key="Exceptions.ParamNotFound">Параметр отсутствует: {0}</system:String>
     <system:String
+        x:Key="Exceptions.MaterialParamNotFound">Параметр материала отсутствует: {0}</system:String>
+    <system:String
         x:Key="Exceptions.NoMaterials">У элемента нет материалов</system:String>
 
     <system:String

--- a/src/RevitParamsChecker/assets/Localization/Language.ru-RU.xaml
+++ b/src/RevitParamsChecker/assets/Localization/Language.ru-RU.xaml
@@ -18,6 +18,8 @@
         x:Key="ResultsPage.Title">Анализ</system:String>
     <system:String
         x:Key="Exceptions.ParamNotFound">Параметр отсутствует: {0}</system:String>
+    <system:String
+        x:Key="Exceptions.NoMaterials">У элемента нет материалов</system:String>
 
     <system:String
         x:Key="NamesSelectionDialog.NamesHeader">Название</system:String>
@@ -49,6 +51,8 @@
         x:Key="ChecksPage.ExecuteChecksButton">Запустить выбранные</system:String>
     <system:String
         x:Key="ChecksPage.NameHeader">Название</system:String>
+    <system:String
+        x:Key="ChecksPage.TargetTypeHeader">Тип проверки</system:String>
     <system:String
         x:Key="ChecksPage.NothingSelectPrompt">Ничего не выбрано</system:String>
     <system:String
@@ -202,6 +206,11 @@
         x:Key="AndOperator">И</system:String>
     <system:String
         x:Key="OrOperator">Или</system:String>
+
+    <system:String
+        x:Key="CheckTargetType.Element">Элементы</system:String>
+    <system:String
+        x:Key="CheckTargetType.Material">Материалы</system:String>
 
     <system:String
         x:Key="StatusCode.Valid">Соответствует</system:String>


### PR DESCRIPTION
## Обновление

- Добавлен режим для проверки параметров материалов элементов из выборки. Если хотя бы один из материалов элемента не соответствует правилу, будет присвоен статус "не соответствует". Статус назначается на элемент, у которого брались материалы.

<img width="500" src="https://github.com/user-attachments/assets/4a9d7df5-4792-4fce-8e21-93e61bc2aeb7" />
