### PR TITLE
RevitParamsChecker: Обновлен UI

### DIFF
--- a/src/RevitParamsChecker/Resources/CustomDataGrid.xaml
+++ b/src/RevitParamsChecker/Resources/CustomDataGrid.xaml
@@ -110,6 +110,9 @@
         BasedOn="{StaticResource DefaultUiDataGridColumnHeaderStyle}"
         TargetType="DataGridColumnHeader">
         <Setter
+            Property="Foreground"
+            Value="{DynamicResource LabelForeground}" />
+        <Setter
             Property="Template">
             <Setter.Value>
                 <ControlTemplate

--- a/src/RevitParamsChecker/Resources/CustomExpanderStyle.xaml
+++ b/src/RevitParamsChecker/Resources/CustomExpanderStyle.xaml
@@ -55,24 +55,24 @@
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition
-                                                        Width="*" />
-                                                    <ColumnDefinition
                                                         Width="Auto" />
+                                                    <ColumnDefinition
+                                                        Width="*" />
                                                 </Grid.ColumnDefinitions>
-                                                <ContentPresenter
-                                                    x:Name="ContentPresenter"
-                                                    Grid.Column="0"
-                                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                    Content="{TemplateBinding Content}" />
                                                 <ui:SymbolIcon
                                                     x:Name="ControlChevronIcon"
-                                                    Grid.Column="1"
-                                                    Margin="0"
+                                                    Grid.Column="0"
+                                                    Margin="0 0 8 0"
                                                     VerticalAlignment="Center"
                                                     FontSize="16"
                                                     Foreground="{TemplateBinding Foreground}"
                                                     Symbol="ChevronDown24" />
+                                                <ContentPresenter
+                                                    x:Name="ContentPresenter"
+                                                    Grid.Column="1"
+                                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                    Content="{TemplateBinding Content}" />
                                             </Grid>
                                         </Border>
                                     </ControlTemplate>

--- a/src/RevitParamsChecker/ViewModels/Results/CheckResultViewModel.cs
+++ b/src/RevitParamsChecker/ViewModels/Results/CheckResultViewModel.cs
@@ -121,7 +121,6 @@ internal class CheckResultViewModel : BaseViewModel {
                          || result.RuleName?.IndexOf(filter, StringComparison.CurrentCultureIgnoreCase) >= 0
                          || result.Status?.IndexOf(filter, StringComparison.CurrentCultureIgnoreCase) >= 0
                          || result.Error?.IndexOf(filter, StringComparison.CurrentCultureIgnoreCase) >= 0
-                         || result.UserMark?.IndexOf(filter, StringComparison.CurrentCultureIgnoreCase) >= 0
                          || result.CategoryName?.IndexOf(filter, StringComparison.CurrentCultureIgnoreCase) >= 0;
         }
     }

--- a/src/RevitParamsChecker/ViewModels/Results/CheckResultViewModel.cs
+++ b/src/RevitParamsChecker/ViewModels/Results/CheckResultViewModel.cs
@@ -28,7 +28,7 @@ internal class CheckResultViewModel : BaseViewModel {
     private readonly DelayAction _refreshViewDelay;
     private readonly RevitRepository _revitRepo;
     private readonly ObservableCollection<ElementResultViewModel> _allElementResults;
-    private readonly PropertyGroupDescription _defaultGroupDescription;
+    private readonly PropertyGroupDescription _chunkGroupDescription;
     private string _elementsFilter;
     private ElementResultViewModel _selectedElementResult;
     private RuleViewModel _selectedRuleStamp;
@@ -47,13 +47,13 @@ internal class CheckResultViewModel : BaseViewModel {
         _refreshViewDelay = new DelayAction(300, () => ElementResults.View.Refresh());
         var availableProperties = GetEditableGroupProperties(_localization);
         GroupingProperties = new GroupDescriptionsViewModel(availableProperties, [availableProperties.First()]);
-        _defaultGroupDescription = new PropertyGroupDescription(nameof(ElementResultViewModel.ChunkName));
+        _chunkGroupDescription = new PropertyGroupDescription(nameof(ElementResultViewModel.ChunkName));
         if(_allElementResults.Count <= _chunkSize) {
             ResetGrouping(ElementResults, [availableProperties.First().PropertyGroupDescription]);
         } else {
             ResetGrouping(
                 ElementResults,
-                [_defaultGroupDescription, availableProperties.First().PropertyGroupDescription]);
+                [availableProperties.First().PropertyGroupDescription, _chunkGroupDescription]);
         }
 
         PropertyChanged += ElementsFilterPropertyChanged;
@@ -196,7 +196,7 @@ internal class CheckResultViewModel : BaseViewModel {
         if(_allElementResults.Count <= _chunkSize) {
             ResetGrouping(ElementResults, groups);
         } else {
-            ResetGrouping(ElementResults, [_defaultGroupDescription, .. groups]);
+            ResetGrouping(ElementResults, [.. groups, _chunkGroupDescription]);
         }
     }
 }

--- a/src/RevitParamsChecker/ViewModels/Results/ElementResultViewModel.cs
+++ b/src/RevitParamsChecker/ViewModels/Results/ElementResultViewModel.cs
@@ -13,7 +13,6 @@ internal class ElementResultViewModel : BaseViewModel {
     private readonly ILocalizationService _localization;
     private string _chunkName;
     private int _itemNumber;
-    private string _userMark;
 
     public ElementResultViewModel(ILocalizationService localization, ElementResult elementResult) {
         _localization = localization ?? throw new ArgumentNullException(nameof(localization));
@@ -37,11 +36,6 @@ internal class ElementResultViewModel : BaseViewModel {
     public int ItemNumber {
         get => _itemNumber;
         set => RaiseAndSetIfChanged(ref _itemNumber, value);
-    }
-
-    public string UserMark {
-        get => _userMark;
-        set => RaiseAndSetIfChanged(ref _userMark, value);
     }
 
     public string CategoryName { get; }

--- a/src/RevitParamsChecker/Views/Controls/EditableListControl.xaml
+++ b/src/RevitParamsChecker/Views/Controls/EditableListControl.xaml
@@ -56,7 +56,7 @@
                     <DataTemplate>
                         <DockPanel
                             Height="20"
-                            Margin="10 4"
+                            Margin="8 4"
                             VerticalAlignment="Center">
                             <ui:TextBlock
                                 VerticalAlignment="Center"

--- a/src/RevitParamsChecker/Views/Controls/PageMenuControl.xaml
+++ b/src/RevitParamsChecker/Views/Controls/PageMenuControl.xaml
@@ -44,13 +44,14 @@
                 ToolTip="{me:LocalizationSource PageMenu.Tooltip.Export}"
                 Command="{Binding ExportButtonCommand, ElementName=_this}"
                 Content="{ui:SymbolIcon Symbol=ArrowExportUp20}" />
-            <Label
+            <ui:TextBlock
                 Margin="8 0 0 0"
                 VerticalAlignment="Center"
                 Padding="0"
+                FontWeight="Bold"
                 FontSize="{DynamicResource ControlContentThemeFontSize}"
                 Visibility="{Binding ShowSaveChangesPrompt, ElementName=_this, Converter={StaticResource BoolToVisibilityConverter}}"
-                Content="{me:LocalizationSource PageMenu.SaveChangesPrompt}" />
+                Text="{me:LocalizationSource PageMenu.SaveChangesPrompt}" />
             <ui:TextBlock
                 Margin="8 0 0 0"
                 HorizontalAlignment="Left"

--- a/src/RevitParamsChecker/Views/MainWindow.xaml
+++ b/src/RevitParamsChecker/Views/MainWindow.xaml
@@ -62,6 +62,7 @@
             Grid.Row="1"
             x:Name="_rootNavigationView"
             FrameMargin="0"
+            Margin="8 0"
             OpenPaneLength="200"
             IsPaneOpen="True"
             PaneDisplayMode="Top"
@@ -73,9 +74,17 @@
 
             <ui:NavigationView.Header>
                 <StackPanel
-                    Margin="42 20 42 20">
+                    Margin="4 8  0 8">
                     <ui:BreadcrumbBar
-                        x:Name="_breadcrumbBar" />
+                        x:Name="_breadcrumbBar">
+                        <ui:BreadcrumbBar.ItemTemplate>
+                            <DataTemplate>
+                                <ui:TextBlock
+                                    FontTypography="Subtitle"
+                                    Text="{Binding Content}" />
+                            </DataTemplate>
+                        </ui:BreadcrumbBar.ItemTemplate>
+                    </ui:BreadcrumbBar>
                 </StackPanel>
             </ui:NavigationView.Header>
 
@@ -113,13 +122,13 @@
             HorizontalAlignment="Right">
 
             <ui:TextBlock
-                Margin="10"
+                Margin="8"
                 Foreground="Orange"
                 VerticalAlignment="Center"
                 Text="{Binding ErrorText}" />
 
             <ui:Button
-                Margin="10"
+                Margin="8"
                 Width="80"
                 Content="{me:LocalizationSource Close}"
                 IsCancel="True"

--- a/src/RevitParamsChecker/Views/MainWindow.xaml
+++ b/src/RevitParamsChecker/Views/MainWindow.xaml
@@ -46,6 +46,8 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition
+                Height="Auto" />
+            <RowDefinition
                 Height="*" />
             <RowDefinition
                 Height="Auto" />
@@ -57,12 +59,12 @@
             Title="{me:LocalizationSource MainWindow.Title}" />
 
         <ui:NavigationView
-            Grid.Row="0"
+            Grid.Row="1"
             x:Name="_rootNavigationView"
             FrameMargin="0"
             OpenPaneLength="200"
             IsPaneOpen="True"
-            PaneDisplayMode="Left"
+            PaneDisplayMode="Top"
             IsBackButtonVisible="Visible"
             IsPaneVisible="True"
             IsPaneToggleVisible="True"
@@ -106,7 +108,7 @@
             x:Name="_rootContentDialog" />
 
         <StackPanel
-            Grid.Row="1"
+            Grid.Row="2"
             Orientation="Horizontal"
             HorizontalAlignment="Right">
 

--- a/src/RevitParamsChecker/Views/Results/CheckResultControl.xaml
+++ b/src/RevitParamsChecker/Views/Results/CheckResultControl.xaml
@@ -161,16 +161,6 @@
                             MinWidth="50"
                             Width="150"
                             IsReadOnly="True"
-                            Binding="{Binding FileName}">
-                            <DataGridTextColumn.Header>
-                                <ui:TextBlock
-                                    Text="{DynamicResource ResultsPage.FileNameHeader}" />
-                            </DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn
-                            MinWidth="50"
-                            Width="150"
-                            IsReadOnly="True"
                             Binding="{Binding CategoryName}">
                             <DataGridTextColumn.Header>
                                 <ui:TextBlock
@@ -191,17 +181,6 @@
 
                         <DataGridTextColumn
                             MinWidth="50"
-                            Width="150"
-                            IsReadOnly="True"
-                            Binding="{Binding RuleName}">
-                            <DataGridTextColumn.Header>
-                                <ui:TextBlock
-                                    Text="{DynamicResource ResultsPage.RuleNameHeader}" />
-                            </DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-
-                        <DataGridTextColumn
-                            MinWidth="50"
                             Width="Auto"
                             IsReadOnly="True"
                             Binding="{Binding Status}">
@@ -210,14 +189,14 @@
                                     Text="{DynamicResource ResultsPage.StatusHeader}" />
                             </DataGridTextColumn.Header>
                         </DataGridTextColumn>
-
                         <DataGridTextColumn
                             MinWidth="50"
-                            Width="100"
-                            Binding="{Binding UserMark, UpdateSourceTrigger=PropertyChanged}">
+                            Width="150"
+                            IsReadOnly="True"
+                            Binding="{Binding FileName}">
                             <DataGridTextColumn.Header>
                                 <ui:TextBlock
-                                    Text="{DynamicResource ResultsPage.UserMarkHeader}" />
+                                    Text="{DynamicResource ResultsPage.FileNameHeader}" />
                             </DataGridTextColumn.Header>
                         </DataGridTextColumn>
                     </ui:DataGrid.Columns>

--- a/src/RevitParamsChecker/Views/Results/CheckResultsListControl.xaml
+++ b/src/RevitParamsChecker/Views/Results/CheckResultsListControl.xaml
@@ -57,7 +57,7 @@
                     <DataTemplate>
                         <DockPanel
                             Height="20"
-                            Margin="10 4"
+                            Margin="8 4"
                             VerticalAlignment="Center">
                             <ui:TextBlock
                                 VerticalAlignment="Center"

--- a/src/RevitParamsChecker/Views/Utils/NameEditorWindow.xaml
+++ b/src/RevitParamsChecker/Views/Utils/NameEditorWindow.xaml
@@ -44,12 +44,12 @@
 
         <DockPanel
             Grid.Row="1"
-            Margin="10 0"
+            Margin="8 0"
             LastChildFill="True">
             <Label
                 DockPanel.Dock="Left"
                 VerticalAlignment="Center"
-                Margin="10 0"
+                Margin="8 0"
                 FontSize="{DynamicResource ControlContentThemeFontSize}"
                 Content="{me:LocalizationSource NameEditor.Label}" />
             <ui:TextBox
@@ -65,19 +65,19 @@
             Orientation="Horizontal"
             HorizontalAlignment="Right">
             <ui:TextBlock
-                Margin="10"
+                Margin="8"
                 Text="{Binding ErrorText}"
                 Style="{StaticResource CustomErrorText}" />
             <ui:Button
                 Width="80"
-                Margin="10"
+                Margin="8"
                 IsDefault="True"
                 Appearance="Info"
                 Click="ButtonOk_Click"
                 Content="{me:LocalizationSource Ok}"
                 Command="{Binding Create}" />
             <ui:Button
-                Margin="10"
+                Margin="8"
                 Width="80"
                 IsCancel="true"
                 Click="ButtonCancel_Click"


### PR DESCRIPTION
## Обновления

- Меню страниц расположено сверху
- "Сохраните изменения" теперь отображается черным жирным текстом
- Скорректирована группировка на странице анализа
- Скорректированы столбцы на страницеанализа
- Иконки экспандера группы на странице анализа в datagrid отображаются теперь слева
- Цвет заголовков в DataGrid на странице проверок и анализа теперь серый

### Обновленная страница проверок

<img width="1024" alt="image" src="https://github.com/user-attachments/assets/902f287b-7e61-4ee1-bed0-8d5d695734d0" />

### Обновленная страница анализа

<img width="800" alt="image" src="https://github.com/user-attachments/assets/0ff61991-4710-4e22-a42c-9ca2b5b7e2c2" />
