### PR TITLE
RevitParamsChecker: Исправлено получение значений параметров для проверки

### DIFF
--- a/src/RevitParamsChecker/Models/Rules/ParameterRule.cs
+++ b/src/RevitParamsChecker/Models/Rules/ParameterRule.cs
@@ -38,7 +38,7 @@ internal class ParameterRule : ValidationRule {
         }
 
         var parameter = element.GetParam(ParameterName);
-        string actualValue = parameter.AsValueString()?.Split(' ').FirstOrDefault() ?? string.Empty;
+        string actualValue = GetParamActualValue(parameter);
 
         return Operator.Evaluate(actualValue, ExpectedValue);
     }
@@ -49,5 +49,15 @@ internal class ParameterRule : ValidationRule {
             ExpectedValue = ExpectedValue,
             Operator = Operator.Copy()
         };
+    }
+
+    private string GetParamActualValue(Parameter parameter) {
+        if(parameter.StorageType == StorageType.Double) {
+            // у double параметров в конце могут быть единицы измерения, например:
+            // Площадь = "84 м²"
+            return parameter.AsValueString()?.Split(' ').FirstOrDefault() ?? string.Empty;
+        } else {
+            return parameter.AsValueString() ?? string.Empty;
+        }
     }
 }


### PR DESCRIPTION
## Обновления

Раньше алгоритм брал значение параметра через `AsValueString`, разбивал на подстроки по пробелу и брал первую подстроку. Это работало для таких параметров, как например "Площадь":
<img width="500"  src="https://github.com/user-attachments/assets/66ea83e9-71c9-460a-a2b2-023c8bb1ab71" />
Но это совершенно не работает для текстовых параметров, где могут быть пробелы между словами.

Теперь разбиение по пробелу только для `StorageType.Double` параметров.