### PR TITLE
RevitUnmodelingMep: Расширение обработки изоляции воздуховодов

### DIFF
--- a/src/RevitUnmodelingMep/Models/CollectionGenerator.cs
+++ b/src/RevitUnmodelingMep/Models/CollectionGenerator.cs
@@ -92,7 +92,8 @@ internal static class CollectionGenerator {
                     return false;
 
                 return host.Category.IsId(BuiltInCategory.OST_PipeCurves)
-                       || host.Category.IsId(BuiltInCategory.OST_DuctCurves);
+                       || host.Category.IsId(BuiltInCategory.OST_DuctCurves)
+                       || host.Category.IsId(BuiltInCategory.OST_DuctFitting);
             }
 
             elements = elements

--- a/src/RevitUnmodelingMep/Models/Entities/CalculationElementDuctIns.cs
+++ b/src/RevitUnmodelingMep/Models/Entities/CalculationElementDuctIns.cs
@@ -13,7 +13,7 @@ internal sealed class CalculationElementDuctIns : CalculationElementBase {
     public CalculationElementDuctIns(Element element) : base(element) {
     }
 
-    public bool IsRound { get; set; }
+    public bool? IsRound { get; set; }
 
     public double ProjectStock { get; set; }
 

--- a/src/RevitUnmodelingMep/Models/Unmodeling/CalculationElementFactory.cs
+++ b/src/RevitUnmodelingMep/Models/Unmodeling/CalculationElementFactory.cs
@@ -208,10 +208,13 @@ internal sealed class CalculationElementFactory {
     private void SetDuctInsulationFittingGeometry(CalculationElementDuctIns calculationElement, Element fitting) {
         List<Connector> connectors = GetConnectors(fitting);
         if(connectors.Count == 0) {
+            SetEmptyDuctInsulationValues(calculationElement);
             return;
         }
 
-        Connector connector = connectors.First();
+        Connector connector = connectors
+            .OrderByDescending(GetConnectorArea)
+            .First();
         calculationElement.Length_mm = GetMaxConnectorDistance(connectors);
 
         if(connector.Shape == ConnectorProfileType.Round) {
@@ -226,6 +229,17 @@ internal sealed class CalculationElementFactory {
             calculationElement.Height_mm = connector.Height;
             calculationElement.Perimeter_mm = connector.Width * 2 + connector.Height * 2;
         }
+    }
+
+    private static double GetConnectorArea(Connector connector) {
+        if(connector.Shape == ConnectorProfileType.Rectangular) {
+            return connector.Height * connector.Width;
+        }
+        if(connector.Shape == ConnectorProfileType.Round) {
+            return connector.Radius * connector.Radius * 3.14;
+        }
+
+        return 0;
     }
 
     private static double GetMaxConnectorDistance(IReadOnlyList<Connector> connectors) {

--- a/src/RevitUnmodelingMep/Models/Unmodeling/CalculationElementFactory.cs
+++ b/src/RevitUnmodelingMep/Models/Unmodeling/CalculationElementFactory.cs
@@ -9,6 +9,8 @@ using Autodesk.Revit.DB.Plumbing;
 using dosymep.Bim4Everyone;
 using dosymep.Bim4Everyone.SharedParams;
 using dosymep.Revit;
+using dosymep.Revit.Geometry;
+
 
 using RevitUnmodelingMep.Models.Entities;
 
@@ -164,12 +166,67 @@ internal sealed class CalculationElementFactory {
         return calculationElement;
     }
 
+    private double GetFittingArea(Element element) {
+        double area = 0;
+
+        foreach(Solid solid in element.GetSolids())
+        foreach(Face face in solid.Faces) {
+            area += face.Area;
+        }
+
+        if(area <= 0) {
+            return area;
+        }
+
+        double connectorArea = 0;
+        foreach(Connector connector in GetConnectors(element)) {
+            if(connector.Shape == ConnectorProfileType.Rectangular) {
+                connectorArea += connector.Height * connector.Width;
+            }
+            if(connector.Shape == ConnectorProfileType.Round) {
+                connectorArea += Math.PI * Math.Pow(connector.Radius, 2);
+            }
+        }
+
+        return area - connectorArea;
+    }
+
+    private List<Connector> GetConnectors(Element element) {
+        if(element is not FamilyInstance instance || instance.MEPModel?.ConnectorManager == null) {
+            return new List<Connector>();
+        }
+
+        return instance.MEPModel.ConnectorManager.Connectors.Cast<Connector>().ToList();
+    }
+
     private CalculationElementBase CreateDuctInsulation(DuctInsulation ductIns) {
         CalculationElementDuctIns calculationElement = new CalculationElementDuctIns(ductIns) {
             ProjectStock = _projectStockProvider.Get(BuiltInCategory.OST_DuctInsulations)
         };
+        
+        calculationElement.SystemSharedName =
+            ductIns.GetParamValueOrDefault<string>(SharedParamsConfig.Instance.VISSystemName, "");
+        
+        calculationElement.Length_mm = ductIns.GetParamValueOrDefault<double>(BuiltInParameter.CURVE_ELEM_LENGTH);
+        
+        var insulationHost = _doc.GetElement(ductIns.HostElementId);
 
-        MEPCurve duct = (MEPCurve) _doc.GetElement(ductIns.HostElementId);
+        if(insulationHost.Category.IsId(BuiltInCategory.OST_DuctFitting)) {
+            calculationElement.Area_m2 = GetFittingArea(insulationHost);
+            
+            calculationElement.SystemTypeName =
+                insulationHost.get_Parameter(BuiltInParameter.RBS_DUCT_SYSTEM_TYPE_PARAM).AsValueString();
+            
+            return calculationElement;
+        }
+        calculationElement.Area_m2 = ductIns.GetParamValueOrDefault<double>(BuiltInParameter.RBS_CURVE_SURFACE_AREA);
+        MEPCurve duct = insulationHost as MEPCurve;
+        if(duct == null) {
+            return calculationElement;
+        }
+        
+        calculationElement.SystemTypeName = duct.MEPSystem?.GetElementType()?.Name ?? string.Empty;
+        
         DuctType ductType = (DuctType) duct.GetElementType();
 
         if(ductType.Shape == ConnectorProfileType.Round) {
@@ -182,12 +239,6 @@ internal sealed class CalculationElementFactory {
             calculationElement.Height_mm = ductIns.Height;
             calculationElement.Perimeter_mm = ductIns.Width * 2 + ductIns.Height * 2;
         }
-
-        calculationElement.SystemSharedName =
-            ductIns.GetParamValueOrDefault<string>(SharedParamsConfig.Instance.VISSystemName, "");
-        calculationElement.SystemTypeName = duct?.MEPSystem?.GetElementType()?.Name ?? string.Empty;
-        calculationElement.Area_m2 = ductIns.GetParamValueOrDefault<double>(BuiltInParameter.RBS_CURVE_SURFACE_AREA);
-        calculationElement.Length_mm = ductIns.GetParamValueOrDefault<double>(BuiltInParameter.CURVE_ELEM_LENGTH);
 
         return calculationElement;
     }

--- a/src/RevitUnmodelingMep/Models/Unmodeling/CalculationElementFactory.cs
+++ b/src/RevitUnmodelingMep/Models/Unmodeling/CalculationElementFactory.cs
@@ -263,17 +263,38 @@ internal sealed class CalculationElementFactory {
         }
     }
 
+    private static bool IsMultiPortFitting(Element element) {
+        return element is FamilyInstance { MEPModel: MechanicalFitting fitting }
+               && fitting.PartType == PartType.MultiPort;
+    }
+
+    private static void SetEmptyDuctInsulationValues(CalculationElementDuctIns calculationElement) {
+        calculationElement.SystemSharedName = string.Empty;
+        calculationElement.SystemTypeName = string.Empty;
+        calculationElement.IsRound = false;
+        calculationElement.Length_mm = 0;
+        calculationElement.Diameter_mm = 0;
+        calculationElement.Width_mm = 0;
+        calculationElement.Height_mm = 0;
+        calculationElement.Perimeter_mm = 0;
+        calculationElement.Area_m2 = 0;
+    }
+
     private CalculationElementBase CreateDuctInsulation(DuctInsulation ductIns) {
         CalculationElementDuctIns calculationElement = new CalculationElementDuctIns(ductIns) {
             ProjectStock = _projectStockProvider.Get(BuiltInCategory.OST_DuctInsulations)
         };
+
+        var insulationHost = _doc.GetElement(ductIns.HostElementId);
+        if(insulationHost.Category.IsId(BuiltInCategory.OST_DuctFitting) && IsMultiPortFitting(insulationHost)) {
+            SetEmptyDuctInsulationValues(calculationElement);
+            return calculationElement;
+        }
         
         calculationElement.SystemSharedName =
             ductIns.GetParamValueOrDefault<string>(SharedParamsConfig.Instance.VISSystemName, "");
         
         calculationElement.Length_mm = ductIns.GetParamValueOrDefault<double>(BuiltInParameter.CURVE_ELEM_LENGTH);
-        
-        var insulationHost = _doc.GetElement(ductIns.HostElementId);
 
         if(insulationHost.Category.IsId(BuiltInCategory.OST_DuctFitting)) {
             calculationElement.Area_m2 = GetFittingArea(insulationHost);

--- a/src/RevitUnmodelingMep/Models/Unmodeling/CalculationElementFactory.cs
+++ b/src/RevitUnmodelingMep/Models/Unmodeling/CalculationElementFactory.cs
@@ -166,6 +166,7 @@ internal sealed class CalculationElementFactory {
         return calculationElement;
     }
 
+    
     private double GetFittingArea(Element element) {
         double area = 0;
 
@@ -174,21 +175,26 @@ internal sealed class CalculationElementFactory {
             area += face.Area;
         }
 
-        if(area <= 0) {
-            return area;
+        double areaM2 = ToRoundedSquareMeters(area);
+        if(areaM2 <= 0) {
+            return UnitUtils.ConvertToInternalUnits(areaM2, UnitTypeId.SquareMeters);
         }
 
-        double connectorArea = 0;
+        double connectorAreaM2 = 0;
         foreach(Connector connector in GetConnectors(element)) {
             if(connector.Shape == ConnectorProfileType.Rectangular) {
-                connectorArea += connector.Height * connector.Width;
+                connectorAreaM2 += ToRoundedSquareMeters(connector.Height * connector.Width);
             }
             if(connector.Shape == ConnectorProfileType.Round) {
-                connectorArea += Math.PI * Math.Pow(connector.Radius, 2);
+                connectorAreaM2 += ToRoundedSquareMeters(connector.Radius * connector.Radius * 3.14);
             }
         }
 
-        return area - connectorArea;
+        return UnitUtils.ConvertToInternalUnits(areaM2 - connectorAreaM2, UnitTypeId.SquareMeters);
+    }
+
+    private static double ToRoundedSquareMeters(double value) {
+        return Math.Round(UnitUtils.ConvertFromInternalUnits(value, UnitTypeId.SquareMeters), 2);
     }
 
     private List<Connector> GetConnectors(Element element) {
@@ -197,6 +203,64 @@ internal sealed class CalculationElementFactory {
         }
 
         return instance.MEPModel.ConnectorManager.Connectors.Cast<Connector>().ToList();
+    }
+
+    private void SetDuctInsulationFittingGeometry(CalculationElementDuctIns calculationElement, Element fitting) {
+        List<Connector> connectors = GetConnectors(fitting);
+        if(connectors.Count == 0) {
+            return;
+        }
+
+        Connector connector = connectors.First();
+        calculationElement.Length_mm = GetMaxConnectorDistance(connectors);
+
+        if(connector.Shape == ConnectorProfileType.Round) {
+            double diameter = connector.Radius * 2;
+
+            calculationElement.IsRound = true;
+            calculationElement.Diameter_mm = diameter;
+            calculationElement.Perimeter_mm = Math.PI * diameter;
+        } else if(connector.Shape == ConnectorProfileType.Rectangular) {
+            calculationElement.IsRound = false;
+            calculationElement.Width_mm = connector.Width;
+            calculationElement.Height_mm = connector.Height;
+            calculationElement.Perimeter_mm = connector.Width * 2 + connector.Height * 2;
+        }
+    }
+
+    private static double GetMaxConnectorDistance(IReadOnlyList<Connector> connectors) {
+        if(connectors.Count < 2) {
+            return 0;
+        }
+
+        double maxDistance = 0;
+        for(int i = 0; i < connectors.Count - 1; i++) {
+            for(int j = i + 1; j < connectors.Count; j++) {
+                double distance = connectors[i].Origin.DistanceTo(connectors[j].Origin);
+                if(distance > maxDistance) {
+                    maxDistance = distance;
+                }
+            }
+        }
+
+        return maxDistance;
+    }
+
+    private static void SetDuctInsulationCurveGeometry(
+        CalculationElementDuctIns calculationElement,
+        DuctInsulation ductIns,
+        DuctType ductType) {
+
+        if(ductType.Shape == ConnectorProfileType.Round) {
+            calculationElement.IsRound = true;
+            calculationElement.Diameter_mm = ductIns.Diameter;
+            calculationElement.Perimeter_mm = Math.PI * ductIns.Diameter;
+        } else {
+            calculationElement.IsRound = false;
+            calculationElement.Width_mm = ductIns.Width;
+            calculationElement.Height_mm = ductIns.Height;
+            calculationElement.Perimeter_mm = ductIns.Width * 2 + ductIns.Height * 2;
+        }
     }
 
     private CalculationElementBase CreateDuctInsulation(DuctInsulation ductIns) {
@@ -216,6 +280,8 @@ internal sealed class CalculationElementFactory {
             
             calculationElement.SystemTypeName =
                 insulationHost.get_Parameter(BuiltInParameter.RBS_DUCT_SYSTEM_TYPE_PARAM).AsValueString();
+
+            SetDuctInsulationFittingGeometry(calculationElement, insulationHost);
             
             return calculationElement;
         }
@@ -228,17 +294,7 @@ internal sealed class CalculationElementFactory {
         calculationElement.SystemTypeName = duct.MEPSystem?.GetElementType()?.Name ?? string.Empty;
         
         DuctType ductType = (DuctType) duct.GetElementType();
-
-        if(ductType.Shape == ConnectorProfileType.Round) {
-            calculationElement.IsRound = true;
-            calculationElement.Diameter_mm = ductIns.Diameter;
-            calculationElement.Perimeter_mm = Math.PI * ductIns.Diameter;
-        } else {
-            calculationElement.IsRound = false;
-            calculationElement.Width_mm = ductIns.Width;
-            calculationElement.Height_mm = ductIns.Height;
-            calculationElement.Perimeter_mm = ductIns.Width * 2 + ductIns.Height * 2;
-        }
+        SetDuctInsulationCurveGeometry(calculationElement, ductIns, ductType);
 
         return calculationElement;
     }

--- a/src/RevitUnmodelingMep/Models/Unmodeling/CalculationElementFactory.cs
+++ b/src/RevitUnmodelingMep/Models/Unmodeling/CalculationElementFactory.cs
@@ -170,9 +170,10 @@ internal sealed class CalculationElementFactory {
     private double GetFittingArea(Element element) {
         double area = 0;
 
-        foreach(Solid solid in element.GetSolids())
-        foreach(Face face in solid.Faces) {
-            area += face.Area;
+        foreach(Solid solid in element.GetSolids()) {
+            foreach(Face face in solid.Faces) {
+                area += face.Area;
+            }
         }
 
         double areaM2 = ToRoundedSquareMeters(area);
@@ -186,7 +187,7 @@ internal sealed class CalculationElementFactory {
                 connectorAreaM2 += ToRoundedSquareMeters(connector.Height * connector.Width);
             }
             if(connector.Shape == ConnectorProfileType.Round) {
-                connectorAreaM2 += ToRoundedSquareMeters(connector.Radius * connector.Radius * 3.14);
+                connectorAreaM2 += ToRoundedSquareMeters(connector.Radius * connector.Radius * Math.PI);
             }
         }
 
@@ -236,7 +237,7 @@ internal sealed class CalculationElementFactory {
             return connector.Height * connector.Width;
         }
         if(connector.Shape == ConnectorProfileType.Round) {
-            return connector.Radius * connector.Radius * 3.14;
+            return connector.Radius * connector.Radius * Math.PI;
         }
 
         return 0;

--- a/src/RevitUnmodelingMep/Models/UnmodelingCalculator.cs
+++ b/src/RevitUnmodelingMep/Models/UnmodelingCalculator.cs
@@ -54,19 +54,19 @@ internal class UnmodelingCalculator {
                 draftRow.CalculationElement ?? _calculationElementFactory.Create(draftRow.Element);
 
             draftRow.CalculationElement = calcElement;
-            draftRow.Number = _formulaEvaluator.Evaluate(config.Formula, calcElement);
+            draftRow.Number = Math.Round(_formulaEvaluator.Evaluate(config.Formula, calcElement), 2);
             draftRow.NoteValue = string.IsNullOrWhiteSpace(config.NoteValue)
                 ? 0
-                : _formulaEvaluator.Evaluate(config.NoteValue, calcElement);
+                : Math.Round(_formulaEvaluator.Evaluate(config.NoteValue, calcElement), 2);
             calculationElements.Add(calcElement);
         }
 
         NewRowElement baseRow = draftRows[0];
         double totalNumber = draftRows.Sum(r => r.Number);
         double totalNoteValue = draftRows.Sum(r => r.NoteValue);
-        totalNoteValue = Math.Round(totalNoteValue, 2, MidpointRounding.AwayFromZero);
 
-        totalNumber = Math.Round(totalNumber, 2, MidpointRounding.AwayFromZero);
+        totalNumber = Math.Round(totalNumber, 2);
+        totalNoteValue = Math.Round(totalNoteValue, 2);
         if(config.RoundUpTotal) {
             totalNumber = System.Math.Ceiling(totalNumber);
         }


### PR DESCRIPTION
1) В список хостов изоляции которые могут быть обработаны добавлены фиттинги воздуховодов
2) Механизмы округления приведены в соответствие с спецификацией для того чтоб совпадали итоговые расчеты 
3) Добавлены методы обсчета геометрии фитингов, площадь, длина, высота и длина берутся по коннекторам, если они есть . Если нет - в расчет попадают нули 