### PR TITLE
RevitMechanicalSpecification: Удаление пробелов из конца имен

### DIFF
--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamNameFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamNameFiller.cs
@@ -45,7 +45,7 @@ namespace RevitMechanicalSpecification.Models.Fillers {
         }
 
         protected override void PrepareValue(SpecificationElement specificationElement) {
-            specificationElement.ElementName = GetName(specificationElement);
+            specificationElement.ElementName = GetName(specificationElement).Trim();
         }
 
         public override void SetParamValue(SpecificationElement specificationElement) {


### PR DESCRIPTION
Необходимо убирать пробелы на концах имен. Сами по себе имена в спецификации остаются без них по умолчанию, но строки которые используют имена в своем построении могут получить лишний, что приводит к сбою группирования.