### PR TITLE
RevitUnmodelingMep: Обновление интерфейса

### DIFF
--- a/src/RevitUnmodelingMep/ViewModels/CategoryAssignmentBuilder.cs
+++ b/src/RevitUnmodelingMep/ViewModels/CategoryAssignmentBuilder.cs
@@ -5,6 +5,8 @@ using System.Linq;
 
 using Autodesk.Revit.DB;
 
+using dosymep.Revit;
+
 using RevitUnmodelingMep.Models;
 
 namespace RevitUnmodelingMep.ViewModels;
@@ -57,7 +59,7 @@ internal sealed class CategoryAssignmentBuilder {
                 new ObservableCollection<SystemTypeItem>(
                     types
                         .OfType<ElementType>()
-                        .Where(type => placedTypeIds == null || placedTypeIds.Contains(GetElementIdValue(type.Id)))
+                        .Where(type => placedTypeIds == null || placedTypeIds.Contains(unchecked((int) type.Id.GetIdValue())))
                         .OrderBy(type => type?.Name ?? string.Empty, StringComparer.CurrentCultureIgnoreCase)
                         .Select(type => CreateSystemTypeItem(type, configsForCategory)));
 
@@ -92,7 +94,7 @@ internal sealed class CategoryAssignmentBuilder {
                 continue;
             }
 
-            result.Add(GetElementIdValue(typeId));
+            result.Add(unchecked((int) typeId.GetIdValue()));
         }
 
         return result;
@@ -102,7 +104,7 @@ internal sealed class CategoryAssignmentBuilder {
     /// Создает элемент типа системы с назначениями всех расходников, подходящих для его категории.
     /// </summary>
     private static SystemTypeItem CreateSystemTypeItem(ElementType elementType, List<ConsumableTypeItem> configs) {
-        int typeId = GetElementIdValue(elementType.Id);
+        int typeId = unchecked((int) elementType.Id.GetIdValue());
 
         ObservableCollection<ConfigAssignmentItem> configAssignments =
             new ObservableCollection<ConfigAssignmentItem>(
@@ -113,18 +115,5 @@ internal sealed class CategoryAssignmentBuilder {
             Id = typeId,
             Configs = configAssignments
         };
-    }
-
-    /// <summary>
-    /// Возвращает числовое значение ElementId с учетом различий API Revit до и после 2024 версии.
-    /// </summary>
-    private static int GetElementIdValue(ElementId elementId) {
-        long value;
-#if REVIT_2024_OR_GREATER
-        value = elementId?.Value ?? 0;
-#else
-        value = elementId?.IntegerValue ?? 0;
-#endif
-        return unchecked((int) value);
     }
 }

--- a/src/RevitUnmodelingMep/ViewModels/CategoryAssignmentBuilder.cs
+++ b/src/RevitUnmodelingMep/ViewModels/CategoryAssignmentBuilder.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+using Autodesk.Revit.DB;
+
+using RevitUnmodelingMep.Models;
+
+namespace RevitUnmodelingMep.ViewModels;
+
+internal sealed class CategoryAssignmentBuilder {
+    private readonly RevitRepository _revitRepository;
+    
+    public CategoryAssignmentBuilder(RevitRepository revitRepository) {
+        _revitRepository = revitRepository;
+    }
+
+    /// <summary>
+    /// Строит дерево назначений: категории Revit, типы систем и доступные для них конфигурации расходников.
+    /// </summary>
+    public ObservableCollection<CategoryAssignmentItem> Build(
+        IReadOnlyList<CategoryOption> categoryOptions,
+        IEnumerable<ConsumableTypeItem> consumableTypes,
+        bool onlyPlacedInProject,
+        Func<ConsumableTypeItem, int?> resolveCategoryId) {
+        List<BuiltInCategory> categories = new List<BuiltInCategory> {
+            BuiltInCategory.OST_PipeCurves,
+            BuiltInCategory.OST_DuctCurves,
+            BuiltInCategory.OST_PipeInsulations,
+            BuiltInCategory.OST_DuctInsulations,
+            BuiltInCategory.OST_DuctSystem,
+            BuiltInCategory.OST_PipingSystem
+        };
+
+        var assignments = new List<CategoryAssignmentItem>();
+
+        foreach(BuiltInCategory builtInCategory in categories) {
+            CategoryOption option = categoryOptions.FirstOrDefault(o => o.BuiltInCategory == builtInCategory);
+            int optionCategoryId = option?.Id ?? (int) builtInCategory;
+            string categoryName = option?.Name ?? builtInCategory.ToString();
+
+            List<Element> types = CollectionGenerator.GetElementTypesByCategory(_revitRepository.Doc, builtInCategory)
+                                  ?? new List<Element>();
+            if(types.Count == 0) {
+                continue;
+            }
+
+            List<ConsumableTypeItem> configsForCategory = consumableTypes?
+                .Where(c => resolveCategoryId(c) == optionCategoryId)
+                .OrderBy(c => c?.ConsumableTypeName ?? string.Empty, StringComparer.CurrentCultureIgnoreCase)
+                .ToList() ?? new List<ConsumableTypeItem>();
+
+            HashSet<int> placedTypeIds = onlyPlacedInProject ? GetPlacedTypeIds(builtInCategory) : null;
+
+            ObservableCollection<SystemTypeItem> systemTypes =
+                new ObservableCollection<SystemTypeItem>(
+                    types
+                        .OfType<ElementType>()
+                        .Where(type => placedTypeIds == null || placedTypeIds.Contains(GetElementIdValue(type.Id)))
+                        .OrderBy(type => type?.Name ?? string.Empty, StringComparer.CurrentCultureIgnoreCase)
+                        .Select(type => CreateSystemTypeItem(type, configsForCategory)));
+
+            if(systemTypes.Count == 0) {
+                continue;
+            }
+
+            assignments.Add(new CategoryAssignmentItem {
+                Name = categoryName,
+                Category = builtInCategory,
+                SystemTypes = systemTypes
+            });
+        }
+
+        return new ObservableCollection<CategoryAssignmentItem>(
+            assignments.OrderBy(a => a?.Name ?? string.Empty, StringComparer.CurrentCultureIgnoreCase));
+    }
+
+    /// <summary>
+    /// Возвращает идентификаторы типов, которые реально размещены в проекте для указанной категории.
+    /// </summary>
+    private HashSet<int> GetPlacedTypeIds(BuiltInCategory builtInCategory) {
+        var result = new HashSet<int>();
+
+        var collector = new FilteredElementCollector(_revitRepository.Doc)
+            .OfCategory(builtInCategory)
+            .WhereElementIsNotElementType();
+
+        foreach(Element element in collector) {
+            ElementId typeId = element.GetTypeId();
+            if(typeId == null || typeId == ElementId.InvalidElementId) {
+                continue;
+            }
+
+            result.Add(GetElementIdValue(typeId));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Создает элемент типа системы с назначениями всех расходников, подходящих для его категории.
+    /// </summary>
+    private static SystemTypeItem CreateSystemTypeItem(ElementType elementType, List<ConsumableTypeItem> configs) {
+        int typeId = GetElementIdValue(elementType.Id);
+
+        ObservableCollection<ConfigAssignmentItem> configAssignments =
+            new ObservableCollection<ConfigAssignmentItem>(
+                configs.Select(config => new ConfigAssignmentItem(config, typeId)));
+
+        return new SystemTypeItem {
+            Name = elementType.Name,
+            Id = typeId,
+            Configs = configAssignments
+        };
+    }
+
+    /// <summary>
+    /// Возвращает числовое значение ElementId с учетом различий API Revit до и после 2024 версии.
+    /// </summary>
+    private static int GetElementIdValue(ElementId elementId) {
+        long value;
+#if REVIT_2024_OR_GREATER
+        value = elementId?.Value ?? 0;
+#else
+        value = elementId?.IntegerValue ?? 0;
+#endif
+        return unchecked((int) value);
+    }
+}

--- a/src/RevitUnmodelingMep/ViewModels/CategoryOptionsProvider.cs
+++ b/src/RevitUnmodelingMep/ViewModels/CategoryOptionsProvider.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Autodesk.Revit.DB;
+
+using dosymep.SimpleServices;
+
+namespace RevitUnmodelingMep.ViewModels;
+
+internal sealed class CategoryOptionsProvider {
+    private readonly Document _document;
+    private readonly ILocalizationService _localizationService;
+
+    /// <summary>
+    /// Создает поставщик доступных MEP-категорий для настроек расходников.
+    /// </summary>
+    public CategoryOptionsProvider(Document document, ILocalizationService localizationService) {
+        _document = document;
+        _localizationService = localizationService;
+    }
+
+    /// <summary>
+    /// Создает справочник категорий, доступных для выбора в настройках расходников.
+    /// </summary>
+    public IReadOnlyList<CategoryOption> CreateCategoryOptions() {
+        return new List<CategoryOption> {
+            CreateCategoryOption(
+                _localizationService.GetLocalizedString("MainViewModel.DuctsName"),
+                BuiltInCategory.OST_DuctCurves),
+            CreateCategoryOption(
+                _localizationService.GetLocalizedString("MainViewModel.PipesName"),
+                BuiltInCategory.OST_PipeCurves),
+            CreateCategoryOption(
+                _localizationService.GetLocalizedString("MainViewModel.PipeInsName"),
+                BuiltInCategory.OST_PipeInsulations),
+            CreateCategoryOption(
+                _localizationService.GetLocalizedString("MainViewModel.DuctInsName"),
+                BuiltInCategory.OST_DuctInsulations),
+            CreateCategoryOption(
+                _localizationService.GetLocalizedString("MainViewModel.DuctSysName"),
+                BuiltInCategory.OST_DuctSystem),
+            CreateCategoryOption(
+                _localizationService.GetLocalizedString("MainViewModel.PipeSysName"),
+                BuiltInCategory.OST_PipingSystem)
+        };
+    }
+
+    /// <summary>
+    /// Преобразует сохраненное значение категории в один из доступных вариантов выбора.
+    /// </summary>
+    public CategoryOption ResolveCategoryOption(
+        IReadOnlyList<CategoryOption> categoryOptions,
+        string categoryValue) {
+        if(string.IsNullOrWhiteSpace(categoryValue)) {
+            return categoryOptions.FirstOrDefault();
+        }
+
+        if(int.TryParse(categoryValue, out int id)) {
+            return categoryOptions.FirstOrDefault(o => o.Id == id);
+        }
+
+        string trimmed = categoryValue.Trim();
+        if(trimmed.StartsWith("BuiltInCategory.", StringComparison.OrdinalIgnoreCase)) {
+            string enumName = trimmed.Substring("BuiltInCategory.".Length);
+            CategoryOption byEnumName = categoryOptions.FirstOrDefault(o =>
+                string.Equals(o.BuiltInCategory.ToString(), enumName, StringComparison.OrdinalIgnoreCase));
+            if(byEnumName != null) {
+                return byEnumName;
+            }
+        }
+
+        return categoryOptions.FirstOrDefault(o =>
+            string.Equals(o.Name, categoryValue, StringComparison.OrdinalIgnoreCase))
+               ?? categoryOptions.FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Создает один вариант категории с локализованным именем, BuiltInCategory и фактическим id категории в документе.
+    /// </summary>
+    private CategoryOption CreateCategoryOption(string name, BuiltInCategory builtInCategory) {
+        Category category = Category.GetCategory(_document, builtInCategory);
+
+        long idValue;
+#if REVIT_2024_OR_GREATER
+        idValue = category?.Id.Value ?? (long) (int) builtInCategory;
+#else
+        idValue = category?.Id.IntegerValue ?? (int) builtInCategory;
+#endif
+        int id = unchecked((int) idValue);
+
+        return new CategoryOption {
+            Name = name,
+            BuiltInCategory = builtInCategory,
+            Id = id
+        };
+    }
+}

--- a/src/RevitUnmodelingMep/ViewModels/CategoryOptionsProvider.cs
+++ b/src/RevitUnmodelingMep/ViewModels/CategoryOptionsProvider.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 using Autodesk.Revit.DB;
 
+using dosymep.Revit;
 using dosymep.SimpleServices;
 
 namespace RevitUnmodelingMep.ViewModels;
@@ -80,13 +81,7 @@ internal sealed class CategoryOptionsProvider {
     /// </summary>
     private CategoryOption CreateCategoryOption(string name, BuiltInCategory builtInCategory) {
         Category category = Category.GetCategory(_document, builtInCategory);
-
-        long idValue;
-#if REVIT_2024_OR_GREATER
-        idValue = category?.Id.Value ?? (long) (int) builtInCategory;
-#else
-        idValue = category?.Id.IntegerValue ?? (int) builtInCategory;
-#endif
+        long idValue = category?.Id?.GetIdValue() ?? (int) builtInCategory;
         int id = unchecked((int) idValue);
 
         return new CategoryOption {

--- a/src/RevitUnmodelingMep/ViewModels/ConsumableTemplateManager.cs
+++ b/src/RevitUnmodelingMep/ViewModels/ConsumableTemplateManager.cs
@@ -54,7 +54,14 @@ internal sealed class ConsumableTemplateManager {
     /// <summary>
     /// Приводит существующие шаблонные расходники к значениям из шаблона и добавляет отсутствующие шаблонные расходники.
     /// </summary>
-    public void ApplyTemplatesToItems() {
+    /// <summary>
+    /// Проверяет, есть ли в шаблоне расходники, которые отсутствуют в текущей коллекции.
+    /// </summary>
+    public bool HasMissingTemplateItems() {
+        return _items != null && _templateConfigs.Values.Any(template => !ContainsTemplateItem(template));
+    }
+
+    public void ApplyTemplatesToItems(bool addMissingItems) {
         if(_items == null) {
             return;
         }
@@ -77,6 +84,10 @@ internal sealed class ConsumableTemplateManager {
                 continue;
             }
 
+            if(!addMissingItems) {
+                continue;
+            }
+
             string configKey = GetUniqueConfigKey(template.ConfigKey, usedConfigKeys);
             usedConfigKeys.Add(configKey);
 
@@ -86,6 +97,17 @@ internal sealed class ConsumableTemplateManager {
         }
 
         RefreshWarnings();
+    }
+
+    /// <summary>
+    /// Проверяет, есть ли в текущей коллекции расходник с именем указанного шаблонного расходника.
+    /// </summary>
+    private bool ContainsTemplateItem(TemplateConsumable template) {
+        return _items.Any(item =>
+            string.Equals(
+                item?.ConsumableTypeName,
+                template.Config.ConfigName,
+                StringComparison.CurrentCultureIgnoreCase));
     }
 
     /// <summary>

--- a/src/RevitUnmodelingMep/ViewModels/ConsumableTemplateManager.cs
+++ b/src/RevitUnmodelingMep/ViewModels/ConsumableTemplateManager.cs
@@ -52,15 +52,15 @@ internal sealed class ConsumableTemplateManager {
     }
 
     /// <summary>
-    /// Приводит существующие шаблонные расходники к значениям из шаблона и добавляет отсутствующие шаблонные расходники.
-    /// </summary>
-    /// <summary>
     /// Проверяет, есть ли в шаблоне расходники, которые отсутствуют в текущей коллекции.
     /// </summary>
     public bool HasMissingTemplateItems() {
         return _items != null && _templateConfigs.Values.Any(template => !ContainsTemplateItem(template));
     }
 
+    /// <summary>
+    /// Приводит существующие шаблонные расходники к значениям из шаблона и при необходимости добавляет отсутствующие.
+    /// </summary>
     public void ApplyTemplatesToItems(bool addMissingItems) {
         if(_items == null) {
             return;

--- a/src/RevitUnmodelingMep/ViewModels/ConsumableTemplateManager.cs
+++ b/src/RevitUnmodelingMep/ViewModels/ConsumableTemplateManager.cs
@@ -324,28 +324,4 @@ internal sealed class ConsumableTemplateManager {
         return string.Equals(left ?? string.Empty, right ?? string.Empty, StringComparison.CurrentCulture);
     }
 
-    /// <summary>
-    /// Хранит шаблонный расходник вместе с исходным ключом конфигурации,
-    /// чтобы при добавлении недостающего расходника сохранить ключ из шаблона или проверить его на конфликт.
-    /// </summary>
-    private sealed class TemplateConsumable {
-        /// <summary>
-        /// Создает внутреннее представление шаблонного расходника и подставляет пустую конфигурацию,
-        /// если из настроек пришло null-значение.
-        /// </summary>
-        public TemplateConsumable(string configKey, UnmodelingConfigItem config) {
-            ConfigKey = configKey;
-            Config = config ?? new UnmodelingConfigItem();
-        }
-
-        /// <summary>
-        /// Исходный ключ шаблона в словаре настроек, который используется при создании недостающего расходника.
-        /// </summary>
-        public string ConfigKey { get; }
-
-        /// <summary>
-        /// Значения шаблона, с которыми сравнивается и синхронизируется редактируемый расходник.
-        /// </summary>
-        public UnmodelingConfigItem Config { get; }
-    }
 }

--- a/src/RevitUnmodelingMep/ViewModels/ConsumableTemplateManager.cs
+++ b/src/RevitUnmodelingMep/ViewModels/ConsumableTemplateManager.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+using RevitUnmodelingMep.Models;
+
+namespace RevitUnmodelingMep.ViewModels;
+
+internal sealed class ConsumableTemplateManager {
+    private readonly VisSettingsStorage _settingsStorage;
+    private readonly Func<string, CategoryOption> _resolveCategoryOption;
+    private readonly Dictionary<string, TemplateConsumable> _templateConfigs;
+    private ObservableCollection<ConsumableTypeItem> _items;
+
+    /// <summary>
+    /// Создает менеджер предупреждений и загружает шаблонные расходники для дальнейшего сравнения.
+    /// </summary>
+    public ConsumableTemplateManager(
+        VisSettingsStorage settingsStorage,
+        Func<string, CategoryOption> resolveCategoryOption) {
+        _settingsStorage = settingsStorage;
+        _resolveCategoryOption = resolveCategoryOption;
+        _templateConfigs = LoadTemplateConfigs();
+    }
+
+    /// <summary>
+    /// Подключает менеджер к текущей коллекции расходников и обновляет все флаги предупреждений.
+    /// </summary>
+    public void Attach(ObservableCollection<ConsumableTypeItem> items) {
+        if(ReferenceEquals(_items, items)) {
+            RefreshWarnings();
+            return;
+        }
+
+        Detach();
+
+        _items = items;
+        if(_items == null) {
+            return;
+        }
+
+        _items.CollectionChanged += OnItemsCollectionChanged;
+        foreach(ConsumableTypeItem item in _items) {
+            AttachItem(item);
+        }
+
+        RefreshWarnings();
+    }
+
+    /// <summary>
+    /// Приводит существующие шаблонные расходники к значениям из шаблона и добавляет отсутствующие шаблонные расходники.
+    /// </summary>
+    public void ApplyTemplatesToItems() {
+        if(_items == null) {
+            return;
+        }
+
+        var usedConfigKeys = new HashSet<string>(
+            _items
+                .Select(item => item?.ConfigKey)
+                .Where(key => !string.IsNullOrWhiteSpace(key)),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach(TemplateConsumable template in _templateConfigs.Values) {
+            ConsumableTypeItem existingItem = _items.FirstOrDefault(item =>
+                string.Equals(
+                    item?.ConsumableTypeName,
+                    template.Config.ConfigName,
+                    StringComparison.CurrentCultureIgnoreCase));
+
+            if(existingItem != null) {
+                ApplyTemplateToItem(existingItem, template.Config, keepAssignments: true);
+                continue;
+            }
+
+            string configKey = GetUniqueConfigKey(template.ConfigKey, usedConfigKeys);
+            usedConfigKeys.Add(configKey);
+
+            ConsumableTypeItem newItem = ConsumableTypeItem.FromConfig(configKey, template.Config);
+            newItem.SelectedCategory = _resolveCategoryOption?.Invoke(newItem.CategoryId);
+            _items.Add(newItem);
+        }
+
+        RefreshWarnings();
+    }
+
+    /// <summary>
+    /// Снимает подписки с ранее подключенной коллекции и ее элементов.
+    /// </summary>
+    private void Detach() {
+        if(_items == null) {
+            return;
+        }
+
+        _items.CollectionChanged -= OnItemsCollectionChanged;
+        foreach(ConsumableTypeItem item in _items) {
+            DetachItem(item);
+        }
+
+        _items = null;
+    }
+
+    /// <summary>
+    /// Загружает шаблонные расходники и индексирует их по названию шаблонного расходника.
+    /// </summary>
+    private Dictionary<string, TemplateConsumable> LoadTemplateConfigs() {
+        UnmodelingSettingsDocument defaultSettings = _settingsStorage.GetDefaultSettings();
+        IReadOnlyDictionary<string, UnmodelingConfigItem> configs = defaultSettings?.UnmodelingConfig;
+
+        return configs?
+            .Where(pair => !string.IsNullOrWhiteSpace(pair.Value?.ConfigName))
+            .GroupBy(pair => pair.Value.ConfigName, StringComparer.CurrentCultureIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => new TemplateConsumable(group.First().Key, group.First().Value),
+                StringComparer.CurrentCultureIgnoreCase)
+               ?? new Dictionary<string, TemplateConsumable>(StringComparer.CurrentCultureIgnoreCase);
+    }
+
+    /// <summary>
+    /// Синхронизирует подписки при добавлении и удалении расходников из коллекции.
+    /// </summary>
+    private void OnItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e) {
+        if(e.OldItems != null) {
+            foreach(ConsumableTypeItem item in e.OldItems.OfType<ConsumableTypeItem>()) {
+                DetachItem(item);
+            }
+        }
+
+        if(e.NewItems != null) {
+            foreach(ConsumableTypeItem item in e.NewItems.OfType<ConsumableTypeItem>()) {
+                AttachItem(item);
+                RefreshWarning(item);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Подписывается на изменения полей одного расходника, чтобы предупреждение обновлялось сразу.
+    /// </summary>
+    private void AttachItem(ConsumableTypeItem item) {
+        if(item == null) {
+            return;
+        }
+
+        item.PropertyChanged += OnItemPropertyChanged;
+    }
+
+    /// <summary>
+    /// Снимает подписку на изменения полей одного расходника.
+    /// </summary>
+    private void DetachItem(ConsumableTypeItem item) {
+        if(item == null) {
+            return;
+        }
+
+        item.PropertyChanged -= OnItemPropertyChanged;
+    }
+
+    /// <summary>
+    /// Пересчитывает предупреждение одного расходника после изменения редактируемых полей.
+    /// </summary>
+    private void OnItemPropertyChanged(object sender, PropertyChangedEventArgs e) {
+        if(sender is ConsumableTypeItem item && e.PropertyName != nameof(ConsumableTypeItem.IsTemplateDifferenceVisible)) {
+            RefreshWarning(item);
+        }
+    }
+
+    /// <summary>
+    /// Пересчитывает видимость предупреждений для всех подключенных расходников.
+    /// </summary>
+    private void RefreshWarnings() {
+        if(_items == null) {
+            return;
+        }
+
+        foreach(ConsumableTypeItem item in _items) {
+            RefreshWarning(item);
+        }
+    }
+
+    /// <summary>
+    /// Обновляет флаг предупреждения одного расходника по результату сравнения с шаблоном.
+    /// </summary>
+    private void RefreshWarning(ConsumableTypeItem item) {
+        if(item == null) {
+            return;
+        }
+
+        item.IsTemplateDifferenceVisible = IsDifferentFromTemplate(item);
+    }
+
+    /// <summary>
+    /// Проверяет, что расходник все еще совпадает с шаблоном по имени, но отличается редактируемыми значениями.
+    /// </summary>
+    private bool IsDifferentFromTemplate(ConsumableTypeItem item) {
+        if(string.IsNullOrWhiteSpace(item.ConsumableTypeName)
+           || !_templateConfigs.TryGetValue(item.ConsumableTypeName, out TemplateConsumable template)) {
+            return false;
+        }
+
+        UnmodelingConfigItem current = item.ToConfigItem();
+        UnmodelingConfigItem templateConfig = template.Config;
+
+        return !StringEquals(current.Category, ResolveTemplateCategory(templateConfig.Category))
+               || !StringEquals(current.Group, templateConfig.Group)
+               || !StringEquals(current.Name, templateConfig.Name)
+               || !StringEquals(current.Mark, templateConfig.Mark)
+               || !StringEquals(current.Code, templateConfig.Code)
+               || !StringEquals(current.Unit, templateConfig.Unit)
+               || !StringEquals(current.Creator, templateConfig.Creator)
+               || !StringEquals(current.ValueFormula, templateConfig.ValueFormula)
+               || !StringEquals(current.NoteValue, templateConfig.NoteValue)
+               || !StringEquals(current.NoteFormat, templateConfig.NoteFormat)
+               || current.RoundUpTotal != templateConfig.RoundUpTotal
+               || current.RoundUpNoteTotal != templateConfig.RoundUpNoteTotal;
+    }
+
+    /// <summary>
+    /// Копирует шаблонные значения в расходник, при необходимости сохраняя текущие назначения на элементы.
+    /// </summary>
+    private void ApplyTemplateToItem(
+        ConsumableTypeItem item,
+        UnmodelingConfigItem template,
+        bool keepAssignments) {
+        List<int> assignedElementIds = keepAssignments && item.AssignedElementIds != null
+            ? new List<int>(item.AssignedElementIds)
+            : template.AssignedElementIds != null
+                ? new List<int>(template.AssignedElementIds)
+                : new List<int>();
+
+        item.Title = template.ConfigName;
+        item.ConsumableTypeName = template.ConfigName;
+        item.Name = template.Name;
+        item.Grouping = template.Group;
+        item.Mark = template.Mark;
+        item.Code = template.Code;
+        item.Unit = template.Unit;
+        item.Maker = template.Creator;
+        item.Formula = template.ValueFormula;
+        item.NoteValue = template.NoteValue;
+        item.Note = template.NoteFormat;
+        item.RoundUpTotal = template.RoundUpTotal;
+        item.RoundUpNoteTotal = template.RoundUpNoteTotal;
+        item.SelectedCategory = _resolveCategoryOption?.Invoke(template.Category);
+        item.CategoryId = item.SelectedCategory?.Id.ToString() ?? template.Category;
+        item.AssignedElementIds = assignedElementIds;
+        item.ExtensionData = template.ExtensionData != null
+            ? new Dictionary<string, object>(template.ExtensionData)
+            : null;
+    }
+
+    /// <summary>
+    /// Возвращает свободный ключ конфигурации: сначала пытается использовать ключ из шаблона, затем генерирует следующий config_NNN.
+    /// </summary>
+    private string GetUniqueConfigKey(string templateConfigKey, HashSet<string> usedConfigKeys) {
+        if(!string.IsNullOrWhiteSpace(templateConfigKey) && !usedConfigKeys.Contains(templateConfigKey)) {
+            return templateConfigKey;
+        }
+
+        int nextIndex = GetMaxConfigIndex(usedConfigKeys) + 1;
+        string configKey;
+        do {
+            configKey = $"config_{nextIndex:000}";
+            nextIndex++;
+        } while(usedConfigKeys.Contains(configKey));
+
+        return configKey;
+    }
+
+    /// <summary>
+    /// Находит максимальный числовой индекс среди ключей вида config_NNN.
+    /// </summary>
+    private static int GetMaxConfigIndex(IEnumerable<string> configKeys) {
+        int maxIndex = 0;
+        foreach(string configKey in configKeys ?? Enumerable.Empty<string>()) {
+            Match match = Regex.Match(configKey ?? string.Empty, @"config_(\d+)", RegexOptions.IgnoreCase);
+            if(match.Success && int.TryParse(match.Groups[1].Value, out int index) && index > maxIndex) {
+                maxIndex = index;
+            }
+        }
+
+        return maxIndex;
+    }
+
+    /// <summary>
+    /// Приводит значение категории шаблона к тому же формату идентификатора, который используют редактируемые элементы.
+    /// </summary>
+    private string ResolveTemplateCategory(string category) {
+        return _resolveCategoryOption?.Invoke(category)?.Id.ToString() ?? category ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Сравнивает nullable-строки как пустые строки по правилам текущей культуры.
+    /// </summary>
+    private static bool StringEquals(string left, string right) {
+        return string.Equals(left ?? string.Empty, right ?? string.Empty, StringComparison.CurrentCulture);
+    }
+
+    private sealed class TemplateConsumable {
+        /// <summary>
+        /// Создает внутреннее представление шаблонного расходника вместе с его ключом конфигурации.
+        /// </summary>
+        public TemplateConsumable(string configKey, UnmodelingConfigItem config) {
+            ConfigKey = configKey;
+            Config = config ?? new UnmodelingConfigItem();
+        }
+
+        public string ConfigKey { get; }
+
+        public UnmodelingConfigItem Config { get; }
+    }
+}

--- a/src/RevitUnmodelingMep/ViewModels/ConsumableTemplateManager.cs
+++ b/src/RevitUnmodelingMep/ViewModels/ConsumableTemplateManager.cs
@@ -310,7 +310,7 @@ internal sealed class ConsumableTemplateManager {
     }
 
     /// <summary>
-    /// Приводит значение категории шаблона к тому же формату идентификатора, который используют редактируемые элементы.
+    /// Возвращает идентификатор категории шаблона в том виде, в котором он хранится у редактируемого расходника.
     /// </summary>
     private string ResolveTemplateCategory(string category) {
         return _resolveCategoryOption?.Invoke(category)?.Id.ToString() ?? category ?? string.Empty;

--- a/src/RevitUnmodelingMep/ViewModels/ConsumableTemplateManager.cs
+++ b/src/RevitUnmodelingMep/ViewModels/ConsumableTemplateManager.cs
@@ -317,23 +317,35 @@ internal sealed class ConsumableTemplateManager {
     }
 
     /// <summary>
-    /// Сравнивает nullable-строки как пустые строки по правилам текущей культуры.
+    /// Сравнивает nullable-строки как пустые строки по правилам текущей культуры,
+    /// чтобы не показывать предупреждение о расхождении шаблона только из-за разницы между null и пустым значением.
     /// </summary>
     private static bool StringEquals(string left, string right) {
         return string.Equals(left ?? string.Empty, right ?? string.Empty, StringComparison.CurrentCulture);
     }
 
+    /// <summary>
+    /// Хранит шаблонный расходник вместе с исходным ключом конфигурации,
+    /// чтобы при добавлении недостающего расходника сохранить ключ из шаблона или проверить его на конфликт.
+    /// </summary>
     private sealed class TemplateConsumable {
         /// <summary>
-        /// Создает внутреннее представление шаблонного расходника вместе с его ключом конфигурации.
+        /// Создает внутреннее представление шаблонного расходника и подставляет пустую конфигурацию,
+        /// если из настроек пришло null-значение.
         /// </summary>
         public TemplateConsumable(string configKey, UnmodelingConfigItem config) {
             ConfigKey = configKey;
             Config = config ?? new UnmodelingConfigItem();
         }
 
+        /// <summary>
+        /// Исходный ключ шаблона в словаре настроек, который используется при создании недостающего расходника.
+        /// </summary>
         public string ConfigKey { get; }
 
+        /// <summary>
+        /// Значения шаблона, с которыми сравнивается и синхронизируется редактируемый расходник.
+        /// </summary>
         public UnmodelingConfigItem Config { get; }
     }
 }

--- a/src/RevitUnmodelingMep/ViewModels/MainViewModel.cs
+++ b/src/RevitUnmodelingMep/ViewModels/MainViewModel.cs
@@ -61,6 +61,7 @@ internal class MainViewModel : BaseViewModel {
         RemoveConsumableTypeCommand = RelayCommand.Create<ConsumableTypeItem>(RemoveConsumableType, CanRemoveConsumableType);
         ImportConfigsCommand = RelayCommand.Create(ImportConfigs);
         ExportConfigsCommand = RelayCommand.Create(ExportConfigs);
+        RefreshConfigsCommand = RelayCommand.Create(RefreshConfigs);
         ResetConfigsCommand = RelayCommand.Create<Window>(ResetConfigs);
 
         ConsumableTypes = new ObservableCollection<ConsumableTypeItem>();
@@ -82,6 +83,8 @@ internal class MainViewModel : BaseViewModel {
     public ICommand ImportConfigsCommand { get; }
 
     public ICommand ExportConfigsCommand { get; }
+
+    public ICommand RefreshConfigsCommand { get; }
 
     public ICommand ResetConfigsCommand { get; }
 
@@ -232,6 +235,21 @@ internal class MainViewModel : BaseViewModel {
 
         UnmodelingSettingsDocument defaults = _revitRepository.VisSettingsStorage.GetDefaultSettings();
         LoadConsumableTypesFromSettings(defaults);
+    }
+
+    private void RefreshConfigs() {
+        string title = _localizationService.GetLocalizedString("MainWindow.Title");
+        string confirmMessage = _localizationService.GetLocalizedString("MainWindow.RefreshConfirmMessage");
+        if(MessageBoxService.Show(
+            confirmMessage,
+            title,
+            MessageBoxButton.OKCancel,
+            MessageBoxImage.Question) != MessageBoxResult.OK) {
+            return;
+        }
+
+        string placeholderMessage = _localizationService.GetLocalizedString("MainWindow.RefreshPlaceholderMessage");
+        MessageBoxService.Show(placeholderMessage, title, MessageBoxButton.OK, MessageBoxImage.Information);
     }
 
     private void ImportConfigs() {

--- a/src/RevitUnmodelingMep/ViewModels/MainViewModel.cs
+++ b/src/RevitUnmodelingMep/ViewModels/MainViewModel.cs
@@ -12,7 +12,6 @@ using dosymep.WPF.Commands;
 using dosymep.WPF.ViewModels;
 
 using pyRevitLabs.Json;
-using Autodesk.Revit.DB;
 
 using RevitUnmodelingMep.Models;
 
@@ -28,6 +27,8 @@ internal class MainViewModel : BaseViewModel {
     public IMessageBoxService MessageBoxService { get; }
     private readonly IConfigSerializer _configSerializer;
     private readonly ConsumableTemplateManager _consumableTemplateManager;
+    private readonly CategoryOptionsProvider _categoryOptionsProvider;
+    private readonly CategoryAssignmentBuilder _categoryAssignmentBuilder;
 
     private string _errorText;
     private string _saveProperty;
@@ -37,8 +38,7 @@ internal class MainViewModel : BaseViewModel {
     private int _lastConfigIndex;
     private readonly IReadOnlyList<CategoryOption> _categoryOptions;
     private bool _isViewLoaded;
-     
-
+    
     public MainViewModel(
         PluginConfig pluginConfig,
         RevitRepository revitRepository,
@@ -55,7 +55,9 @@ internal class MainViewModel : BaseViewModel {
         _saveFileDialogService = saveFileDialogService;
         MessageBoxService = messageBoxService;
         _configSerializer = configSerializer;
-        _categoryOptions = CreateCategoryOptions();
+        _categoryOptionsProvider = new CategoryOptionsProvider(_revitRepository.Document, _localizationService);
+        _categoryAssignmentBuilder = new CategoryAssignmentBuilder(_revitRepository);
+        _categoryOptions = _categoryOptionsProvider.CreateCategoryOptions();
         _consumableTemplateManager = new ConsumableTemplateManager(
             _revitRepository.VisSettingsStorage,
             ResolveCategoryOption);
@@ -98,17 +100,26 @@ internal class MainViewModel : BaseViewModel {
     public ISaveFileDialogService SaveFileDialogService => _saveFileDialogService;
 
 
+    /// <summary>
+    /// Хранит текст ошибки валидации, который показывается в нижней части окна.
+    /// </summary>
     public string ErrorText {
         get => _errorText;
         set => RaiseAndSetIfChanged(ref _errorText, value);
     }
 
 
+    /// <summary>
+    /// Хранит имя параметра, в который сохраняется результат работы настроек.
+    /// </summary>
     public string SaveProperty {
         get => _saveProperty;
         set => RaiseAndSetIfChanged(ref _saveProperty, value);
     }
 
+    /// <summary>
+    /// Хранит редактируемый список расходников и переподключает к нему менеджер шаблонов при замене коллекции.
+    /// </summary>
     public ObservableCollection<ConsumableTypeItem> ConsumableTypes {
         get => _consumableTypes;
         set {
@@ -117,6 +128,9 @@ internal class MainViewModel : BaseViewModel {
         }
     }
 
+    /// <summary>
+    /// Хранит построенные группы назначений расходников на типы элементов Revit.
+    /// </summary>
     public ObservableCollection<CategoryAssignmentItem> CategoryAssignments {
         get => _categoryAssignments;
         set => RaiseAndSetIfChanged(ref _categoryAssignments, value);
@@ -125,6 +139,9 @@ internal class MainViewModel : BaseViewModel {
     public IReadOnlyList<CategoryOption> CategoryOptions => _categoryOptions;
     public bool IsViewLoaded => _isViewLoaded;
 
+    /// <summary>
+    /// Управляет режимом отображения только размещенных в проекте типов и пересобирает списки после изменения.
+    /// </summary>
     public bool OnlyPlacedInProject {
         get => _onlyPlacedInProject;
         set {
@@ -141,15 +158,24 @@ internal class MainViewModel : BaseViewModel {
     }
 
 
+    /// <summary>
+    /// Загружает данные окна после события Loaded.
+    /// </summary>
     private void LoadView() {
         LoadConfig();
     }
 
 
+    /// <summary>
+    /// Сохраняет настройки после подтверждения окна.
+    /// </summary>
     private void AcceptView() {
         SaveConfig();
     }
 
+    /// <summary>
+    /// Проверяет корректность формул и обязательных настроек перед сохранением окна.
+    /// </summary>
     private bool CanAcceptView() {
         bool isValid = FormulaValidator.ValidateFormulas(
             ConsumableTypes,
@@ -164,6 +190,9 @@ internal class MainViewModel : BaseViewModel {
     }
 
 
+    /// <summary>
+    /// Загружает проектные настройки, настройки расходников и начальные списки назначений.
+    /// </summary>
     private void LoadConfig() {
         RevitSettings setting = _pluginConfig.GetSettings(_revitRepository.Document);
 
@@ -174,6 +203,9 @@ internal class MainViewModel : BaseViewModel {
         _isViewLoaded = true;
     }
 
+    /// <summary>
+    /// Сохраняет параметр результата, настройки расходников и проектный конфиг плагина.
+    /// </summary>
     private void SaveConfig() {
         RevitSettings setting = _pluginConfig.GetSettings(_revitRepository.Document)
                                 ?? _pluginConfig.AddSettings(_revitRepository.Document);
@@ -183,6 +215,9 @@ internal class MainViewModel : BaseViewModel {
         _pluginConfig.SaveProjectConfig();
     }
 
+    /// <summary>
+    /// Обновляет списки назначений после изменений расходников, когда представление уже загружено.
+    /// </summary>
     public void RefreshAssignmentsFromConsumableTypes() {
         if(!_isViewLoaded) {
             return;
@@ -191,6 +226,9 @@ internal class MainViewModel : BaseViewModel {
         UpdateTypesLists();
     }
 
+    /// <summary>
+    /// Создает новый пользовательский расходник с новым ключом конфигурации и категорией по умолчанию.
+    /// </summary>
     private void AddConsumableType() {
         int index = ConsumableTypes.Count + 1;
         string configKey = GetNextConfigKey();
@@ -208,10 +246,16 @@ internal class MainViewModel : BaseViewModel {
         UpdateTypesLists();
     }
 
+    /// <summary>
+    /// Разрешает удаление расходника, если в коллекции есть хотя бы один элемент.
+    /// </summary>
     private bool CanRemoveConsumableType(ConsumableTypeItem item) {
         return ConsumableTypes?.Count > 0;
     }
 
+    /// <summary>
+    /// Удаляет расходник из коллекции и пересобирает списки назначений.
+    /// </summary>
     private void RemoveConsumableType(ConsumableTypeItem item) {
         if(ConsumableTypes == null || ConsumableTypes.Count == 0 || item == null) {
             return;
@@ -232,6 +276,9 @@ internal class MainViewModel : BaseViewModel {
         UpdateTypesLists();
     }
 
+    /// <summary>
+    /// После подтверждения заменяет текущие настройки расходников настройками из файла шаблона.
+    /// </summary>
     private void ResetConfigs(Window owner) {
         string message = _localizationService.GetLocalizedString("MainWindow.ResetConfirmMessage");
         string title = _localizationService.GetLocalizedString("MainWindow.Title");
@@ -245,6 +292,9 @@ internal class MainViewModel : BaseViewModel {
         LoadConsumableTypesFromSettings(defaults);
     }
 
+    /// <summary>
+    /// После подтверждения приводит шаблонные расходники к значениям шаблона и опционально добавляет отсутствующие.
+    /// </summary>
     private void RefreshConfigs() {
         string title = _localizationService.GetLocalizedString("MainWindow.Title");
         string confirmMessage = _localizationService.GetLocalizedString("MainWindow.RefreshConfirmMessage");
@@ -256,11 +306,25 @@ internal class MainViewModel : BaseViewModel {
             return;
         }
 
-        _consumableTemplateManager.ApplyTemplatesToItems();
+        bool addMissingTemplateItems = true;
+        if(_consumableTemplateManager.HasMissingTemplateItems()) {
+            string addMissingMessage = _localizationService.GetLocalizedString(
+                "MainWindow.AddMissingTemplateConsumablesConfirmMessage");
+            addMissingTemplateItems = MessageBoxService.Show(
+                addMissingMessage,
+                title,
+                MessageBoxButton.OKCancel,
+                MessageBoxImage.Question) == MessageBoxResult.OK;
+        }
+
+        _consumableTemplateManager.ApplyTemplatesToItems(addMissingTemplateItems);
         SyncLastConfigIndex();
         UpdateTypesLists();
     }
 
+    /// <summary>
+    /// Импортирует настройки расходников из JSON-файла и заменяет ими текущую коллекцию.
+    /// </summary>
     private void ImportConfigs() {
         _openFileDialogService.Filter = "JSON files | *.json";
         if(!_openFileDialogService.ShowDialog()) {
@@ -282,6 +346,9 @@ internal class MainViewModel : BaseViewModel {
         }
     }
 
+    /// <summary>
+    /// Экспортирует текущие настройки расходников и сопутствующие настройки в JSON-файл.
+    /// </summary>
     private void ExportConfigs() {
         _saveFileDialogService.AddExtension = true;
         _saveFileDialogService.Filter = "JSON files | *.json";
@@ -305,6 +372,9 @@ internal class MainViewModel : BaseViewModel {
             _configSerializer.Serialize(exported));
     }
 
+    /// <summary>
+    /// Применяет документ настроек к модели окна и заменяет коллекцию расходников отсортированными элементами.
+    /// </summary>
     private void LoadConsumableTypesFromSettings(UnmodelingSettingsDocument settings) {
         settings ??= new UnmodelingSettingsDocument();
         ApplySettings(settings);
@@ -319,6 +389,9 @@ internal class MainViewModel : BaseViewModel {
         UpdateTypesLists();
     }
 
+    /// <summary>
+    /// Загружает сохраненные в проекте настройки расходников из хранилища VISSettings.
+    /// </summary>
     private void LoadUnmodelingConfigs() {
         UnmodelingSettingsDocument settings = _revitRepository.VisSettingsStorage.GetUnmodelingSettings();
         ApplySettings(settings);
@@ -332,6 +405,9 @@ internal class MainViewModel : BaseViewModel {
         ConsumableTypes = CreateSortedConsumableTypes(consumableTypes);
     }
 
+    /// <summary>
+    /// Собирает текущие настройки расходников и сохраняет их в хранилище VISSettings.
+    /// </summary>
     private void SaveUnmodelingConfigs() {
         UnmodelingSettingsDocument settings = _revitRepository.VisSettingsStorage.GetUnmodelingSettings();
         settings ??= new UnmodelingSettingsDocument();
@@ -340,6 +416,9 @@ internal class MainViewModel : BaseViewModel {
         _revitRepository.VisSettingsStorage.SaveUnmodelingSettings(settings);
     }
 
+    /// <summary>
+    /// Преобразует редактируемые расходники окна в словарь конфигурации для хранения и экспорта.
+    /// </summary>
     private Dictionary<string, UnmodelingConfigItem> BuildUnmodelingConfigs() {
         var configs = new Dictionary<string, UnmodelingConfigItem>();
         if(ConsumableTypes == null) {
@@ -357,6 +436,9 @@ internal class MainViewModel : BaseViewModel {
         return configs;
     }
 
+    /// <summary>
+    /// Создает новую коллекцию расходников, отсортированную по ключу конфигурации.
+    /// </summary>
     private static ObservableCollection<ConsumableTypeItem> CreateSortedConsumableTypes(
         IEnumerable<ConsumableTypeItem> consumableTypes) {
         return new ObservableCollection<ConsumableTypeItem>(
@@ -364,23 +446,35 @@ internal class MainViewModel : BaseViewModel {
                 .OrderBy(item => item?.ConfigKey ?? string.Empty, StringComparer.CurrentCultureIgnoreCase));
     }
 
+    /// <summary>
+    /// Собирает дополнительные настройки раздела немоделируемых элементов.
+    /// </summary>
     private UnmodelingSettingsOptions BuildUnmodelingSettings() {
         return new UnmodelingSettingsOptions {
             OnlyProjectInstances = OnlyPlacedInProject
         };
     }
 
+    /// <summary>
+    /// Применяет дополнительные настройки документа к состоянию окна.
+    /// </summary>
     private void ApplySettings(UnmodelingSettingsDocument settings) {
         if(settings?.UnmodelingSettings != null) {
             OnlyPlacedInProject = settings.UnmodelingSettings.OnlyProjectInstances;
         }
     }
 
+    /// <summary>
+    /// Возвращает следующий ключ конфигурации вида config_NNN и продвигает внутренний счетчик.
+    /// </summary>
     private string GetNextConfigKey() {
         _lastConfigIndex++;
         return $"config_{_lastConfigIndex:000}";
     }
 
+    /// <summary>
+    /// Синхронизирует внутренний счетчик ключей после массового добавления или замены расходников.
+    /// </summary>
     private void SyncLastConfigIndex() {
         int lastConfigIndex = 0;
         foreach(ConsumableTypeItem item in ConsumableTypes ?? Enumerable.Empty<ConsumableTypeItem>()) {
@@ -393,102 +487,20 @@ internal class MainViewModel : BaseViewModel {
         _lastConfigIndex = lastConfigIndex;
     }
 
+    /// <summary>
+    /// Строит дерево назначений: категории Revit, типы систем и доступные для них конфигурации расходников.
+    /// </summary>
     private void UpdateTypesLists() {
-        List<BuiltInCategory> categories = new List<BuiltInCategory> {
-            BuiltInCategory.OST_PipeCurves,
-            BuiltInCategory.OST_DuctCurves,
-            BuiltInCategory.OST_PipeInsulations,
-            BuiltInCategory.OST_DuctInsulations,
-            BuiltInCategory.OST_DuctSystem,
-            BuiltInCategory.OST_PipingSystem
-        };
-
-        var assignments = new List<CategoryAssignmentItem>();
-
-        foreach(BuiltInCategory builtInCategory in categories) {
-            CategoryOption option = CategoryOptions.FirstOrDefault(o => o.BuiltInCategory == builtInCategory);
-            int optionCategoryId = option?.Id ?? (int) builtInCategory;
-            string categoryName = option?.Name ?? builtInCategory.ToString();
-
-            List<Element> types = CollectionGenerator.GetElementTypesByCategory(_revitRepository.Doc, builtInCategory) 
-                ?? new List<Element>();
-            if(types.Count == 0) {
-                continue;
-            }
-
-            List<ConsumableTypeItem> configsForCategory = ConsumableTypes?
-                .Where(c => TryGetCategoryId(c, out int cid) && cid == optionCategoryId)
-                .OrderBy(c => c?.ConsumableTypeName ?? string.Empty, StringComparer.CurrentCultureIgnoreCase)
-                .ToList() ?? new List<ConsumableTypeItem>();
-
-            HashSet<int> placedTypeIds = OnlyPlacedInProject ? GetPlacedTypeIds(builtInCategory) : null;
-
-            ObservableCollection<SystemTypeItem> systemTypes =
-                new ObservableCollection<SystemTypeItem>(
-                    types
-                        .OfType<ElementType>()
-                        .Where(type => placedTypeIds == null || placedTypeIds.Contains(GetElementIdValue(type.Id)))
-                        .OrderBy(type => type?.Name ?? string.Empty, StringComparer.CurrentCultureIgnoreCase)
-                        .Select(type => CreateSystemTypeItem(type, configsForCategory)));
-
-            if(systemTypes.Count == 0) {
-                continue;
-            }
-
-            assignments.Add(new CategoryAssignmentItem {
-                Name = categoryName,
-                Category = builtInCategory,
-                SystemTypes = systemTypes
-            });
-        }
-
-        CategoryAssignments = new ObservableCollection<CategoryAssignmentItem>(
-            assignments.OrderBy(a => a?.Name ?? string.Empty, StringComparer.CurrentCultureIgnoreCase));
+        CategoryAssignments = _categoryAssignmentBuilder.Build(
+            CategoryOptions,
+            ConsumableTypes,
+            OnlyPlacedInProject,
+            ResolveCategoryId);
     }
 
-    private HashSet<int> GetPlacedTypeIds(BuiltInCategory builtInCategory) {
-        var result = new HashSet<int>();
-
-        var collector = new FilteredElementCollector(_revitRepository.Doc)
-            .OfCategory(builtInCategory)
-            .WhereElementIsNotElementType();
-
-        foreach(Element element in collector) {
-            ElementId typeId = element.GetTypeId();
-            if(typeId == null || typeId == ElementId.InvalidElementId) {
-                continue;
-            }
-
-            result.Add(GetElementIdValue(typeId));
-        }
-
-        return result;
-    }
-
-    private SystemTypeItem CreateSystemTypeItem(ElementType elementType, List<ConsumableTypeItem> configs) {
-        int typeId = GetElementIdValue(elementType.Id);
-
-        ObservableCollection<ConfigAssignmentItem> configAssignments =
-            new ObservableCollection<ConfigAssignmentItem>(
-                configs.Select(config => new ConfigAssignmentItem(config, typeId)));
-
-        return new SystemTypeItem {
-            Name = elementType.Name,
-            Id = typeId,
-            Configs = configAssignments
-        };
-    }
-
-    private static int GetElementIdValue(ElementId elementId) {
-        long value;
-#if REVIT_2024_OR_GREATER
-        value = elementId?.Value ?? 0;
-#else
-        value = elementId?.IntegerValue ?? 0;
-#endif
-        return unchecked((int) value);
-    }
-
+    /// <summary>
+    /// Пытается получить числовой идентификатор категории из выбранной категории или сохраненного строкового значения.
+    /// </summary>
     private static bool TryGetCategoryId(ConsumableTypeItem item, out int categoryId) {
         if(item?.SelectedCategory != null) {
             categoryId = item.SelectedCategory.Id;
@@ -504,75 +516,17 @@ internal class MainViewModel : BaseViewModel {
         return false;
     }
 
+    /// <summary>
+    /// Возвращает nullable-идентификатор категории расходника для валидатора формул.
+    /// </summary>
     private int? ResolveCategoryId(ConsumableTypeItem item) {
         return TryGetCategoryId(item, out int cid) ? cid : (int?) null;
     }
 
-    private IReadOnlyList<CategoryOption> CreateCategoryOptions() {
-        List<CategoryOption> options = new List<CategoryOption> {
-            
-            CreateCategoryOption(
-                _localizationService.GetLocalizedString("MainViewModel.DuctsName"), 
-                BuiltInCategory.OST_DuctCurves),
-            CreateCategoryOption(
-                _localizationService.GetLocalizedString("MainViewModel.PipesName"), 
-                BuiltInCategory.OST_PipeCurves),
-            CreateCategoryOption(
-                _localizationService.GetLocalizedString("MainViewModel.PipeInsName"), 
-                BuiltInCategory.OST_PipeInsulations),
-            CreateCategoryOption(
-                _localizationService.GetLocalizedString("MainViewModel.DuctInsName"), 
-                BuiltInCategory.OST_DuctInsulations),
-            CreateCategoryOption(
-                _localizationService.GetLocalizedString("MainViewModel.DuctSysName"), 
-                BuiltInCategory.OST_DuctSystem),
-            CreateCategoryOption(
-                _localizationService.GetLocalizedString("MainViewModel.PipeSysName"), 
-                BuiltInCategory.OST_PipingSystem)
-        };
-
-        return options;
-    }
-
-    private CategoryOption CreateCategoryOption(string name, BuiltInCategory builtInCategory) {
-        Category category = Category.GetCategory(_revitRepository.Document, builtInCategory);
-
-        long idValue;
-#if REVIT_2024_OR_GREATER
-        idValue = category?.Id.Value ?? (long) (int) builtInCategory;
-#else
-        idValue = category?.Id.IntegerValue ?? (int) builtInCategory;
-#endif
-        int id = unchecked((int) idValue);
-
-        return new CategoryOption {
-            Name = name,
-            BuiltInCategory = builtInCategory,
-            Id = id
-        };
-    }
-
+    /// <summary>
+    /// Преобразует сохраненное значение категории в один из доступных вариантов выбора.
+    /// </summary>
     private CategoryOption ResolveCategoryOption(string categoryValue) {
-        if(string.IsNullOrWhiteSpace(categoryValue)) {
-            return CategoryOptions.FirstOrDefault();
-        }
-
-        if(int.TryParse(categoryValue, out int id)) {
-            return CategoryOptions.FirstOrDefault(o => o.Id == id);
-        }
-
-        string trimmed = categoryValue.Trim();
-        if(trimmed.StartsWith("BuiltInCategory.", StringComparison.OrdinalIgnoreCase)) {
-            string enumName = trimmed.Substring("BuiltInCategory.".Length);
-            CategoryOption byEnumName = CategoryOptions.FirstOrDefault(o =>
-                string.Equals(o.BuiltInCategory.ToString(), enumName, StringComparison.OrdinalIgnoreCase));
-            if(byEnumName != null) {
-                return byEnumName;
-            }
-        }
-
-        return CategoryOptions.FirstOrDefault(o =>
-            string.Equals(o.Name, categoryValue, StringComparison.OrdinalIgnoreCase))
-               ?? CategoryOptions.FirstOrDefault();
+        return _categoryOptionsProvider.ResolveCategoryOption(CategoryOptions, categoryValue);
     }
 }

--- a/src/RevitUnmodelingMep/ViewModels/MainViewModel.cs
+++ b/src/RevitUnmodelingMep/ViewModels/MainViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Input;
 using dosymep.Bim4Everyone.ProjectConfigs;
@@ -26,6 +27,7 @@ internal class MainViewModel : BaseViewModel {
     private readonly ISaveFileDialogService _saveFileDialogService;
     public IMessageBoxService MessageBoxService { get; }
     private readonly IConfigSerializer _configSerializer;
+    private readonly ConsumableTemplateManager _consumableTemplateManager;
 
     private string _errorText;
     private string _saveProperty;
@@ -54,6 +56,9 @@ internal class MainViewModel : BaseViewModel {
         MessageBoxService = messageBoxService;
         _configSerializer = configSerializer;
         _categoryOptions = CreateCategoryOptions();
+        _consumableTemplateManager = new ConsumableTemplateManager(
+            _revitRepository.VisSettingsStorage,
+            ResolveCategoryOption);
 
         LoadViewCommand = RelayCommand.Create(LoadView);
         AcceptViewCommand = RelayCommand.Create(AcceptView, CanAcceptView);
@@ -106,7 +111,10 @@ internal class MainViewModel : BaseViewModel {
 
     public ObservableCollection<ConsumableTypeItem> ConsumableTypes {
         get => _consumableTypes;
-        set => RaiseAndSetIfChanged(ref _consumableTypes, value);
+        set {
+            RaiseAndSetIfChanged(ref _consumableTypes, value);
+            _consumableTemplateManager?.Attach(_consumableTypes);
+        }
     }
 
     public ObservableCollection<CategoryAssignmentItem> CategoryAssignments {
@@ -248,8 +256,9 @@ internal class MainViewModel : BaseViewModel {
             return;
         }
 
-        string placeholderMessage = _localizationService.GetLocalizedString("MainWindow.RefreshPlaceholderMessage");
-        MessageBoxService.Show(placeholderMessage, title, MessageBoxButton.OK, MessageBoxImage.Information);
+        _consumableTemplateManager.ApplyTemplatesToItems();
+        SyncLastConfigIndex();
+        UpdateTypesLists();
     }
 
     private void ImportConfigs() {
@@ -370,6 +379,18 @@ internal class MainViewModel : BaseViewModel {
     private string GetNextConfigKey() {
         _lastConfigIndex++;
         return $"config_{_lastConfigIndex:000}";
+    }
+
+    private void SyncLastConfigIndex() {
+        int lastConfigIndex = 0;
+        foreach(ConsumableTypeItem item in ConsumableTypes ?? Enumerable.Empty<ConsumableTypeItem>()) {
+            Match match = Regex.Match(item?.ConfigKey ?? string.Empty, @"config_(\d+)", RegexOptions.IgnoreCase);
+            if(match.Success && int.TryParse(match.Groups[1].Value, out int index) && index > lastConfigIndex) {
+                lastConfigIndex = index;
+            }
+        }
+
+        _lastConfigIndex = lastConfigIndex;
     }
 
     private void UpdateTypesLists() {

--- a/src/RevitUnmodelingMep/ViewModels/TemplateConsumable.cs
+++ b/src/RevitUnmodelingMep/ViewModels/TemplateConsumable.cs
@@ -1,0 +1,28 @@
+using RevitUnmodelingMep.Models;
+
+namespace RevitUnmodelingMep.ViewModels;
+
+/// <summary>
+/// Хранит шаблонный расходник вместе с исходным ключом конфигурации,
+/// чтобы при добавлении недостающего расходника сохранить ключ из шаблона или проверить его на конфликт.
+/// </summary>
+internal sealed class TemplateConsumable {
+    /// <summary>
+    /// Создает внутреннее представление шаблонного расходника и подставляет пустую конфигурацию,
+    /// если из настроек пришло null-значение.
+    /// </summary>
+    public TemplateConsumable(string configKey, UnmodelingConfigItem config) {
+        ConfigKey = configKey;
+        Config = config ?? new UnmodelingConfigItem();
+    }
+
+    /// <summary>
+    /// Исходный ключ шаблона в словаре настроек, который используется при создании недостающего расходника.
+    /// </summary>
+    public string ConfigKey { get; }
+
+    /// <summary>
+    /// Значения шаблона, с которыми сравнивается и синхронизируется редактируемый расходник.
+    /// </summary>
+    public UnmodelingConfigItem Config { get; }
+}

--- a/src/RevitUnmodelingMep/ViewModels/VMEntities/ConsumableTypeItem.cs
+++ b/src/RevitUnmodelingMep/ViewModels/VMEntities/ConsumableTypeItem.cs
@@ -22,6 +22,7 @@ internal class ConsumableTypeItem : BaseViewModel {
     private string _note;
     private bool _roundUpTotal;
     private bool _roundUpNoteTotal;
+    private bool _isTemplateDifferenceVisible;
     private CategoryOption _selectedCategory;
 
     public string Title {
@@ -96,6 +97,11 @@ internal class ConsumableTypeItem : BaseViewModel {
     public bool RoundUpNoteTotal {
         get => _roundUpNoteTotal;
         set => RaiseAndSetIfChanged(ref _roundUpNoteTotal, value);
+    }
+
+    public bool IsTemplateDifferenceVisible {
+        get => _isTemplateDifferenceVisible;
+        set => RaiseAndSetIfChanged(ref _isTemplateDifferenceVisible, value);
     }
 
     public CategoryOption SelectedCategory {

--- a/src/RevitUnmodelingMep/Views/MainWindow.xaml
+++ b/src/RevitUnmodelingMep/Views/MainWindow.xaml
@@ -306,7 +306,18 @@
                                                                 VerticalAlignment="Center"
                                                                 Foreground="OrangeRed"
                                                                 FontSize="12"
-                                                                Text="{DynamicResource MainWindow.TemplateDifferenceText}" />
+                                                                Text="{DynamicResource MainWindow.TemplateDifferenceText}">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding IsTemplateDifferenceVisible}" Value="True">
+                                                                                <Setter Property="Visibility" Value="Visible" />
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
                                                         </Grid>
                                                     </Expander.Header>
 

--- a/src/RevitUnmodelingMep/Views/MainWindow.xaml
+++ b/src/RevitUnmodelingMep/Views/MainWindow.xaml
@@ -45,6 +45,10 @@
             <Setter Property="Margin" Value="0 6 0 2" />
         </Style>
 
+        <Style TargetType="ToolTip">
+            <Setter Property="MaxWidth" Value="500" />
+        </Style>
+
         <Style
             TargetType="ListBoxItem"
             x:Key="NavItemStyle">
@@ -282,12 +286,28 @@
                                                     <ColumnDefinition Width="Auto" />
                                                 </Grid.ColumnDefinitions>
 
-                                                <Expander Grid.Column="0" IsExpanded="False">
+                                                <Expander Grid.Column="0" IsExpanded="False" HorizontalContentAlignment="Stretch">
                                                     <Expander.Header>
-                                                        <TextBlock
-                                                            FontWeight="SemiBold"
-                                                            VerticalAlignment="Center"
-                                                            Text="{Binding ConsumableTypeName}" />
+                                                        <Grid HorizontalAlignment="Stretch">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="Auto" />
+                                                            </Grid.ColumnDefinitions>
+
+                                                            <TextBlock
+                                                                Grid.Column="0"
+                                                                FontWeight="SemiBold"
+                                                                VerticalAlignment="Center"
+                                                                Text="{Binding ConsumableTypeName}" />
+
+                                                            <TextBlock
+                                                                Grid.Column="1"
+                                                                Margin="8 0 8 0"
+                                                                VerticalAlignment="Center"
+                                                                Foreground="OrangeRed"
+                                                                FontSize="12"
+                                                                Text="{DynamicResource MainWindow.TemplateDifferenceText}" />
+                                                        </Grid>
                                                     </Expander.Header>
 
                                                     <Border Padding="5">
@@ -539,6 +559,11 @@
                     Width="100"
                     Content="{me:LocalizationSource MainWindow.ButtonExport}"
                     Command="{Binding ExportConfigsCommand}" />
+                <ui:Button
+                    Margin="0 0 8 0"
+                    Width="100"
+                    Content="{me:LocalizationSource MainWindow.ButtonRefresh}"
+                    Command="{Binding RefreshConfigsCommand}" />
                 <ui:Button
                     Width="100"
                     Content="{me:LocalizationSource MainWindow.ButtonDefault}"

--- a/src/RevitUnmodelingMep/Views/MainWindow.xaml
+++ b/src/RevitUnmodelingMep/Views/MainWindow.xaml
@@ -300,7 +300,7 @@
                                                                 Grid.Column="1"
                                                                 Margin="8 0 8 0"
                                                                 VerticalAlignment="Center"
-                                                                Foreground="OrangeRed"
+                                                                Foreground="Orange"
                                                                 FontSize="12"
                                                                 Text="{DynamicResource MainWindow.TemplateDifferenceText}">
                                                                 <TextBlock.Style>

--- a/src/RevitUnmodelingMep/Views/MainWindow.xaml
+++ b/src/RevitUnmodelingMep/Views/MainWindow.xaml
@@ -45,10 +45,6 @@
             <Setter Property="Margin" Value="0 6 0 2" />
         </Style>
 
-        <Style TargetType="ToolTip">
-            <Setter Property="MaxWidth" Value="500" />
-        </Style>
-
         <Style
             TargetType="ListBoxItem"
             x:Key="NavItemStyle">

--- a/src/RevitUnmodelingMep/Views/MainWindow.xaml
+++ b/src/RevitUnmodelingMep/Views/MainWindow.xaml
@@ -251,7 +251,7 @@
                     Style="{StaticResource ContentTabControlStyle}"
                     Background="Transparent"
                     BorderThickness="0"
-                    SelectedIndex="0"
+                    SelectedIndex="1"
                      SelectionChanged="ContentTabs_OnSelectionChanged">
                      <TabItem Header="{me:LocalizationSource MainWindow.TabTypesName}">
                         <Grid>

--- a/src/RevitUnmodelingMep/assets/Localization/Language.en-US.xaml
+++ b/src/RevitUnmodelingMep/assets/Localization/Language.en-US.xaml
@@ -20,7 +20,6 @@
     <system:String x:Key="MainWindow.ButtonDefault">Reset</system:String>
     <system:String x:Key="MainWindow.RefreshConfirmMessage">Refreshing will reset all template consumables to the default view. Continue?</system:String>
     <system:String x:Key="MainWindow.AddMissingTemplateConsumablesConfirmMessage">The template contains consumable items that do not exist in the project. Add them?</system:String>
-    <system:String x:Key="MainWindow.RefreshPlaceholderMessage">Refresh is not implemented yet.</system:String>
     <system:String x:Key="MainWindow.ResetConfirmMessage">Are you sure you want to reset to default values?</system:String>
     <system:String x:Key="MainWindow.TemplateDifferenceText">Does not match the template. Refresh or rename.</system:String>
     <system:String x:Key="MainWindow.CheckboxOnlyInstances">Only placed in project</system:String>

--- a/src/RevitUnmodelingMep/assets/Localization/Language.en-US.xaml
+++ b/src/RevitUnmodelingMep/assets/Localization/Language.en-US.xaml
@@ -16,8 +16,12 @@
     <system:String x:Key="MainWindow.ButtonCancel">Cancel</system:String>
     <system:String x:Key="MainWindow.ButtonImport">Import</system:String>
     <system:String x:Key="MainWindow.ButtonExport">Export</system:String>
+    <system:String x:Key="MainWindow.ButtonRefresh">Refresh</system:String>
     <system:String x:Key="MainWindow.ButtonDefault">Reset</system:String>
+    <system:String x:Key="MainWindow.RefreshConfirmMessage">Refreshing will reset all template consumables to the default view and add new templates. Continue?</system:String>
+    <system:String x:Key="MainWindow.RefreshPlaceholderMessage">Refresh is not implemented yet.</system:String>
     <system:String x:Key="MainWindow.ResetConfirmMessage">Are you sure you want to reset to default values?</system:String>
+    <system:String x:Key="MainWindow.TemplateDifferenceText">Does not match the template. Refresh or rename.</system:String>
     <system:String x:Key="MainWindow.CheckboxOnlyInstances">Only placed in project</system:String>
     <system:String x:Key="MainWindow.SelectAll">Select all</system:String>
 

--- a/src/RevitUnmodelingMep/assets/Localization/Language.en-US.xaml
+++ b/src/RevitUnmodelingMep/assets/Localization/Language.en-US.xaml
@@ -18,7 +18,8 @@
     <system:String x:Key="MainWindow.ButtonExport">Export</system:String>
     <system:String x:Key="MainWindow.ButtonRefresh">Refresh</system:String>
     <system:String x:Key="MainWindow.ButtonDefault">Reset</system:String>
-    <system:String x:Key="MainWindow.RefreshConfirmMessage">Refreshing will reset all template consumables to the default view and add new templates. Continue?</system:String>
+    <system:String x:Key="MainWindow.RefreshConfirmMessage">Refreshing will reset all template consumables to the default view. Continue?</system:String>
+    <system:String x:Key="MainWindow.AddMissingTemplateConsumablesConfirmMessage">The template contains consumable items that do not exist in the project. Add them?</system:String>
     <system:String x:Key="MainWindow.RefreshPlaceholderMessage">Refresh is not implemented yet.</system:String>
     <system:String x:Key="MainWindow.ResetConfirmMessage">Are you sure you want to reset to default values?</system:String>
     <system:String x:Key="MainWindow.TemplateDifferenceText">Does not match the template. Refresh or rename.</system:String>

--- a/src/RevitUnmodelingMep/assets/Localization/Language.ru-RU.xaml
+++ b/src/RevitUnmodelingMep/assets/Localization/Language.ru-RU.xaml
@@ -18,7 +18,8 @@
     <system:String x:Key="MainWindow.ButtonExport">Экспорт</system:String>
     <system:String x:Key="MainWindow.ButtonRefresh">Обновить</system:String>
     <system:String x:Key="MainWindow.ButtonDefault">Сброс</system:String>
-    <system:String x:Key="MainWindow.RefreshConfirmMessage">При обновлении все шаблонные расходники будут сброшены к виду по умолчанию, а новые шаблоны будут добавлены. Продолжить?</system:String>
+    <system:String x:Key="MainWindow.RefreshConfirmMessage">При обновлении все шаблонные расходники будут сброшены к виду по умолчанию. Продолжить?</system:String>
+    <system:String x:Key="MainWindow.AddMissingTemplateConsumablesConfirmMessage">В шаблоне обнаружены расходные элементы, не существующие в проекте. Добавить их?</system:String>
     <system:String x:Key="MainWindow.RefreshPlaceholderMessage">Обновление пока не реализовано.</system:String>
     <system:String x:Key="MainWindow.ResetConfirmMessage">Вы уверены что хотите сбросить до значений по умолчанию?</system:String>
     <system:String x:Key="MainWindow.TemplateDifferenceText">Не соответствует шаблону. Выполните обновление или переименуйте.</system:String>

--- a/src/RevitUnmodelingMep/assets/Localization/Language.ru-RU.xaml
+++ b/src/RevitUnmodelingMep/assets/Localization/Language.ru-RU.xaml
@@ -20,9 +20,8 @@
     <system:String x:Key="MainWindow.ButtonDefault">Сброс</system:String>
     <system:String x:Key="MainWindow.RefreshConfirmMessage">При обновлении все шаблонные расходники будут сброшены к виду по умолчанию. Продолжить?</system:String>
     <system:String x:Key="MainWindow.AddMissingTemplateConsumablesConfirmMessage">В шаблоне обнаружены расходные элементы, не существующие в проекте. Добавить их?</system:String>
-    <system:String x:Key="MainWindow.RefreshPlaceholderMessage">Обновление пока не реализовано.</system:String>
     <system:String x:Key="MainWindow.ResetConfirmMessage">Вы уверены что хотите сбросить до значений по умолчанию?</system:String>
-    <system:String x:Key="MainWindow.TemplateDifferenceText">Не соответствует шаблону. Выполните обновление или переименуйте.</system:String>
+    <system:String x:Key="MainWindow.TemplateDifferenceText">Не соответствует шаблону. Нажмите кнопку "Обновить" или переименуйте.</system:String>
     <system:String x:Key="MainWindow.CheckboxOnlyInstances">Только размещенные в проекте</system:String>
     <system:String x:Key="MainWindow.SelectAll">Выбрать все</system:String>
     

--- a/src/RevitUnmodelingMep/assets/Localization/Language.ru-RU.xaml
+++ b/src/RevitUnmodelingMep/assets/Localization/Language.ru-RU.xaml
@@ -16,8 +16,12 @@
     <system:String x:Key="MainWindow.ButtonCancel">Отмена</system:String>
     <system:String x:Key="MainWindow.ButtonImport">Импорт</system:String>
     <system:String x:Key="MainWindow.ButtonExport">Экспорт</system:String>
+    <system:String x:Key="MainWindow.ButtonRefresh">Обновить</system:String>
     <system:String x:Key="MainWindow.ButtonDefault">Сброс</system:String>
+    <system:String x:Key="MainWindow.RefreshConfirmMessage">При обновлении все шаблонные расходники будут сброшены к виду по умолчанию, а новые шаблоны будут добавлены. Продолжить?</system:String>
+    <system:String x:Key="MainWindow.RefreshPlaceholderMessage">Обновление пока не реализовано.</system:String>
     <system:String x:Key="MainWindow.ResetConfirmMessage">Вы уверены что хотите сбросить до значений по умолчанию?</system:String>
+    <system:String x:Key="MainWindow.TemplateDifferenceText">Не соответствует шаблону. Выполните обновление или переименуйте.</system:String>
     <system:String x:Key="MainWindow.CheckboxOnlyInstances">Только размещенные в проекте</system:String>
     <system:String x:Key="MainWindow.SelectAll">Выбрать все</system:String>
     


### PR DESCRIPTION
1) Добавлена проверка расхождения текущих расходных элементов с шаблоном. При отличии выводится предупреждение.
2) Добавлена кнопка "Обновить". По ее нажатию расходные элементы с именем как в шаблоне получают актуальные формулы, и, при необходимости, добавляются новые элементы которые есть в шаблоне, но отсутствуют в модели.
<img width="1161" height="767" alt="image" src="https://github.com/user-attachments/assets/b9912b96-097f-4fd4-81a8-3a24fe6c0a29" />
<img width="1083" height="896" alt="image" src="https://github.com/user-attachments/assets/34c4ff60-22a8-418a-83d4-17bfdf97b228" />

3) Декомпозирован MainViewModel, добавлена документация

