### PR TITLE
RevitBatchPrint: Исправлена ошибка "Ссылка на объект не указывает на экземпляр объекта"

### DIFF
--- a/src/RevitBatchPrint/ViewModels/PrintOptionsViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/PrintOptionsViewModel.cs
@@ -41,7 +41,7 @@ internal sealed class PrintOptionsViewModel : BaseViewModel {
         
         FilePath = printOptions.FilePath;
         PrinterName = PrinterNames
-                          .FirstOrDefault(item => printOptions.PrinterName.Equals(item))
+                          .FirstOrDefault(item => item.Equals(printOptions.PrinterName))
                       ?? PrinterNames.FirstOrDefault();
 
         Zoom = printOptions.Zoom;


### PR DESCRIPTION
- при открытии плагина автоматически выбирался принтер, и в случае, когда конфигурация была сохранена без принтера появлялась ошибка NRE