### PR TITLE
RevitRoundingOfAreas: Исправление ошибки получения параметров для записи

### DIFF
--- a/src/RevitRoundingOfAreas/ViewModels/MainViewModel.cs
+++ b/src/RevitRoundingOfAreas/ViewModels/MainViewModel.cs
@@ -133,15 +133,17 @@ internal class MainViewModel : BaseViewModel {
 
     // Метод получения коллекции ParamViewModel для TargetParams
     private IEnumerable<ParamViewModel> GetTargetParamViewModels() {
+        var spatialElements = _revitRepository.GetAllSpatialElements().ToList();
+
         return _paramService.AllRevitParams
             .Where(revitParam => {
-                var spatialElements = _revitRepository.GetAllSpatialElements();
-                var randomSpatialElement = spatialElements.FirstOrDefault();
-                if(randomSpatialElement is null) {
-                    return false;
-                }
-                var param = revitParam.GetParam(randomSpatialElement);
-                return !param.IsReadOnly;
+                if (!spatialElements.Any())
+                    return true;
+
+                return spatialElements.All(spatialElement => {
+                    var param = revitParam.GetParam(spatialElement);
+                    return param != null && !param.IsReadOnly;
+                });
             })
             .Select(param => new ParamViewModel {
                 Name = param.Name,

--- a/src/RevitRoundingOfAreas/ViewModels/MainViewModel.cs
+++ b/src/RevitRoundingOfAreas/ViewModels/MainViewModel.cs
@@ -6,6 +6,7 @@ using System.Windows.Input;
 
 using Autodesk.Revit.DB;
 
+using dosymep.Bim4Everyone;
 using dosymep.Revit;
 using dosymep.SimpleServices;
 using dosymep.WPF.Commands;
@@ -140,15 +141,24 @@ internal class MainViewModel : BaseViewModel {
                 if (!spatialElements.Any())
                     return true;
 
-                return spatialElements.All(spatialElement => {
-                    var param = revitParam.GetParam(spatialElement);
-                    return param != null && !param.IsReadOnly;
-                });
+                return spatialElements.All(spatialElement => 
+                    TryGetParam(revitParam, spatialElement, out var param) && !param.IsReadOnly);
             })
             .Select(param => new ParamViewModel {
                 Name = param.Name,
                 RevitParam = param
             });
+    }
+    
+    // Метод получения параметра по RevitParam и Element
+    private static bool TryGetParam(RevitParam revitParam, Element element, out Parameter param) {
+        try {
+            param = revitParam.GetParam(element);
+            return param != null;
+        } catch {
+            param = null;
+            return false;
+        }
     }
 
     // Метод получения коллекции PhaseViewModel для Phases


### PR DESCRIPTION
Исправление ошибки получения параметров для записи: при пустой коллекции помещений, выводятся все параметры