### PR TITLE
RevitRoundingOfAreas: Добавление епсилона в число округления

### DIFF
--- a/src/RevitRoundingOfAreas/Models/RevitRepository.cs
+++ b/src/RevitRoundingOfAreas/Models/RevitRepository.cs
@@ -33,7 +33,7 @@ internal class RevitRepository(
             if(sourceValue is 0) {
                 continue;
             }
-
+            
             double roundedValue = RoundWithAccuracy(sourceValue, accuracy);
 
             if(roundedValue is 0) {
@@ -178,9 +178,11 @@ internal class RevitRepository(
 
     // Метод округления числа с заданной точкой после запятой
     private double RoundWithAccuracy(double? value, int accuracy) {
+        double step = Math.Pow(10, -accuracy); // Зависимость от знаков после запятой
+        double eps  = step / 1000.0; // Погрешность
         return value.HasValue
             ? Math.Round(
-                ConvertValueFromInternalUnits(value.Value),
+                ConvertValueFromInternalUnits(value.Value) + eps,
                 accuracy,
                 systemPluginConfig.MidpointRounding)
             : 0;


### PR DESCRIPTION
Из-за неточностей в переводе из квадратных футов в квадратные метры, возникает погрешность, которая приводит к округлению в меньшую сторону. Нужно добавлять дифференцированное значение эпсилона, чтобы перевести число в большую сторону и избегать таких случаев:

<img width="975" height="366" alt="image" src="https://github.com/user-attachments/assets/42762729-7c14-4079-a142-11104ec419fa" />

<img width="705" height="223" alt="image" src="https://github.com/user-attachments/assets/cb387b2e-f405-4983-ba74-17f394eb892e" />
