### PR TITLE
RevitUnmodelingMep: Переход на число ДЕ

### DIFF
--- a/src/RevitUnmodelingMep/Models/UnmodelingCreator.cs
+++ b/src/RevitUnmodelingMep/Models/UnmodelingCreator.cs
@@ -37,8 +37,6 @@ internal class UnmodelingCreator {
     private WorksetId? _ws_id;
     private FamilySymbol? _famylySymbol;
     private readonly string _libDir;
-    private bool _numberParamInitialized;
-    private SharedParam? _numberParam;
     
     private const double _coordinateStep = 0.001;
     private double _maxLocationY = 0;
@@ -197,16 +195,6 @@ internal class UnmodelingCreator {
             throw new InvalidOperationException("_ws_id is null");
         instWorkset.Set(_ws_id.IntegerValue);
 
-        if(!_numberParamInitialized) {
-            _numberParam = _doc.IsExistsParam(SharedParamsConfig.Instance.VISSpecNumbersCurrency)
-                ? SharedParamsConfig.Instance.VISSpecNumbersCurrency
-                : SharedParamsConfig.Instance.VISSpecNumbers;
-            _numberParamInitialized = true;
-        }
-        if(_numberParam is null) {
-            throw new InvalidOperationException("_numberParam is null");
-        }
-
         void SetUnmodelingValue(FamilyInstance familyInstance, SharedParam sharedParam, object? value) {
             if(value is null)
                 return;
@@ -234,7 +222,7 @@ internal class UnmodelingCreator {
         SetUnmodelingValue(familyInstance, SharedParamsConfig.Instance.VISItemCode, newRowElement.Code);
         SetUnmodelingValue(familyInstance, SharedParamsConfig.Instance.VISManufacturer, newRowElement.Maker);
         SetUnmodelingValue(familyInstance, SharedParamsConfig.Instance.VISUnit, newRowElement.Unit);
-        SetUnmodelingValue(familyInstance, _numberParam, newRowElement.Number);
+        SetUnmodelingValue(familyInstance, SharedParamsConfig.Instance.VISSpecNumbersCurrency, newRowElement.Number);
         SetUnmodelingValue(familyInstance, SharedParamsConfig.Instance.VISMass, newRowElement.Mass);
         SetUnmodelingValue(familyInstance, SharedParamsConfig.Instance.VISNote, newRowElement.Note);
         SetUnmodelingValue(familyInstance, SharedParamsConfig.Instance.EconomicFunction, newRowElement.Function);

--- a/src/RevitUnmodelingMep/Models/UnmodelingCreator.cs
+++ b/src/RevitUnmodelingMep/Models/UnmodelingCreator.cs
@@ -72,7 +72,8 @@ internal class UnmodelingCreator {
                         SharedParamsConfig.Instance.BuildingWorksSection,
                         SharedParamsConfig.Instance.BuildingWorksLevel,
                         SharedParamsConfig.Instance.BuildingWorksLevelCurrency,
-                        SharedParamsConfig.Instance.VISSettings
+                        SharedParamsConfig.Instance.VISSettings,
+                        SharedParamsConfig.Instance.VISSpecNumbersCurrency
             ];
 
         ProjectParameters projectParameters = ProjectParameters.Create(_doc.Application);


### PR DESCRIPTION
В рамках полного перехода спецификации на денежную единицу немоделируемые перестают заполнять ФОП_ВИС_Число и переходят на ФОП_ВИС_Число ДЕ.