### PR TITLE
RevitRoomAnnotations: Исправление синтаксических ошибок

### DIFF
--- a/src/RevitRoomAnnotations/Views/CustomStyles.xaml
+++ b/src/RevitRoomAnnotations/Views/CustomStyles.xaml
@@ -2,9 +2,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:local="clr-namespace:RevitListOfSchedules.Views"
-    xmlns:controls="clr-namespace:Wpf.Ui.Controls;assembly=Wpf.Ui"
-    xmlns:me="clr-namespace:dosymep.WpfCore.MarkupExtensions;assembly=dosymep.WpfCore">
+    xmlns:controls="clr-namespace:Wpf.Ui.Controls;assembly=Wpf.Ui">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary
             Source="pack://application:,,,/Wpf.Ui;component/Controls/DataGrid/DataGrid.xaml" />

--- a/src/RevitRoomAnnotations/Views/MainWindow.xaml
+++ b/src/RevitRoomAnnotations/Views/MainWindow.xaml
@@ -4,8 +4,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:base="clr-namespace:dosymep.WPF.Views"
-    xmlns:local="clr-namespace:RevitRoomAnnotations.Views"
     xmlns:vms="clr-namespace:RevitRoomAnnotations.ViewModels"
     xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
     xmlns:core="clr-namespace:dosymep.WpfUI.Core"
@@ -119,12 +117,10 @@
             </ui:DataGrid>
         </Border>        
         <StackPanel
-            Grid.Row="3"
-            Grid.Column="2"
+            Grid.Row="2"
             Orientation="Horizontal"
             HorizontalAlignment="Right">
             <ui:TextBlock
-                VerticalAlignment="Center"
                 Style="{StaticResource CustomErrorText}"
                 Text="{Binding ErrorText, UpdateSourceTrigger=PropertyChanged}" />
             <ui:Button


### PR DESCRIPTION
Исправлены ошибки - в словаре указаны лишние, неиспользуемые строки. В разметке главного окна неверно заданы индексы для Grid