### PR TITLE
RevitDeclarations: Добавление условия для расчета параметра, добавления дефиса префикса

### DIFF
--- a/src/RevitDeclarations/Models/Configs/CommercialConfig.cs
+++ b/src/RevitDeclarations/Models/Configs/CommercialConfig.cs
@@ -62,7 +62,7 @@ internal class CommercialConfigSettings : DeclarationConfigSettings {
             ProjectNameID = "",
 
             AddPrefixToNumber = true,
-            AddHyphenToPrefix = true,
+            AddHyphenToPrefix = false,
 
             RoomAreaParam = SharedParamsConfig.Instance.RoomArea.Name,
             RoomNameParam = LabelUtils.GetLabelFor(BuiltInParameter.ROOM_NAME),

--- a/src/RevitDeclarations/Models/Configs/CommercialConfig.cs
+++ b/src/RevitDeclarations/Models/Configs/CommercialConfig.cs
@@ -29,6 +29,7 @@ internal class CommercialConfigSettings : DeclarationConfigSettings {
     public string BuildingNumberParam { get; set; }
     public string ConstrWorksNumberParam { get; set; }
     public bool AddPrefixToNumber { get; set; }
+    public bool AddHyphenToPrefix { get; set; }
     public string RoomsHeightParam { get; set; }
     public string ParkingSpaceClass { get; set; }
     public string ParkingInfo { get; set; }
@@ -38,7 +39,7 @@ internal class CommercialConfigSettings : DeclarationConfigSettings {
     public CommercialConfigSettings GetCompanyConfig() {
         return new CommercialConfigSettings() {
             FilterRoomsParam = LabelUtils.GetLabelFor(BuiltInParameter.ROOM_DEPARTMENT),
-            FilterRoomsValues = new[] { "нежилое помещение", "машино-место", "кладовая" },
+            FilterRoomsValues = ["нежилое помещение", "машино-место", "кладовая"],
             GroupingBySectionParam = SharedParamsConfig.Instance.RoomGroupShortName.Name,
             GroupingByGroupParam = LabelUtils.GetLabelFor(BuiltInParameter.ROOM_NUMBER),
             MultiStoreyParam = SharedParamsConfig.Instance.RoomMultilevelGroup.Name,
@@ -61,6 +62,7 @@ internal class CommercialConfigSettings : DeclarationConfigSettings {
             ProjectNameID = "",
 
             AddPrefixToNumber = true,
+            AddHyphenToPrefix = true,
 
             RoomAreaParam = SharedParamsConfig.Instance.RoomArea.Name,
             RoomNameParam = LabelUtils.GetLabelFor(BuiltInParameter.ROOM_NAME),

--- a/src/RevitDeclarations/Models/Configs/PublicAreasConfig.cs
+++ b/src/RevitDeclarations/Models/Configs/PublicAreasConfig.cs
@@ -27,6 +27,7 @@ internal class PublicAreasConfig : ProjectConfig<PublicAreasConfigSettings> {
 
 internal class PublicAreasConfigSettings : DeclarationConfigSettings {
     public bool AddPrefixToNumber { get; set; }
+    public bool AddHyphenToPrefix { get; set; }
 
     public PublicAreasConfigSettings GetCompanyConfig() {
         return new PublicAreasConfigSettings() {
@@ -45,6 +46,7 @@ internal class PublicAreasConfigSettings : DeclarationConfigSettings {
             ApartmentNumberParam = SharedParamsConfig.Instance.RoomGroupShortName.Name,
 
             AddPrefixToNumber = true,
+            AddHyphenToPrefix = false,
             ProjectNameID = "",
 
             RoomAreaParam = SharedParamsConfig.Instance.RoomArea.Name,

--- a/src/RevitDeclarations/Models/RoomParamProvider.cs
+++ b/src/RevitDeclarations/Models/RoomParamProvider.cs
@@ -6,18 +6,23 @@ using RevitDeclarations.Comparators;
 namespace RevitDeclarations.Models;
 internal class RoomParamProvider {
     private readonly DeclarationSettings _settings;
+    private const string _hyphen = "-";
+
     public RoomParamProvider(DeclarationSettings settings) {
         _settings = settings;
     }
-    public string GetTwoParamsWithHyphen(RoomElement room, bool addPrefix) {
+    public string GetTwoParamsWithHyphen(RoomElement room, bool addPrefix, bool addHyphen) {
         string number = room.GetTextParamValue(_settings.RoomNumberParam);
-        if(addPrefix) {
-            string group = room.GetTextParamValue(_settings.ApartmentNumberParam);
-            if(!string.IsNullOrEmpty(group)) {
-                return $"{group}-{number}";
-            }
+        if(!addPrefix) {
+            return number;
         }
-        return number;
+        string group = room.GetTextParamValue(_settings.ApartmentNumberParam);
+        if(string.IsNullOrEmpty(group)) {
+            return number;
+        }
+        return addHyphen 
+            ? $"{group}{_hyphen}{number}" 
+            : $"{group}{number}";
     }
 
     public string GetDepartment(RoomElement room, string name) {

--- a/src/RevitDeclarations/Models/Rooms/CommercialRooms.cs
+++ b/src/RevitDeclarations/Models/Rooms/CommercialRooms.cs
@@ -29,7 +29,7 @@ internal class CommercialRooms : RoomGroup {
     public string PositionType => _firstRoom.GetTextParamValue(_settings.PositionType);
 
     public string DeclarationNumber =>
-        _paramProvider.GetTwoParamsWithHyphen(_firstRoom, _settings.AddPrefixToNumber);
+        _paramProvider.GetTwoParamsWithHyphen(_firstRoom, _settings.AddPrefixToNumber, _settings.AddHyphenToPrefix);
 
     public override double AreaMain => _isOneRoomGroup ? _firstRoom.Area : base.AreaMain;
 

--- a/src/RevitDeclarations/Models/Rooms/PublicArea.cs
+++ b/src/RevitDeclarations/Models/Rooms/PublicArea.cs
@@ -22,7 +22,7 @@ internal class PublicArea : RoomGroup {
     }
 
     public string DeclarationNumber =>
-        _paramProvider.GetTwoParamsWithHyphen(_firstRoom, _settings.AddPrefixToNumber);
+        _paramProvider.GetTwoParamsWithHyphen(_firstRoom, _settings.AddPrefixToNumber, _settings.AddHyphenToPrefix);
 
     public override string Department => _paramProvider.GetDepartment(_firstRoom, "МОП");
     public override double AreaMain => _isOneRoomGroup ? _firstRoom.Area : base.AreaMain;

--- a/src/RevitDeclarations/Models/Settings/CommercialSettings.cs
+++ b/src/RevitDeclarations/Models/Settings/CommercialSettings.cs
@@ -11,4 +11,5 @@ internal class CommercialSettings : DeclarationSettings {
 
     public Parameter GroupNameParam { get; set; }
     public bool AddPrefixToNumber { get; set; }
+    public bool AddHyphenToPrefix { get; set; }
 }

--- a/src/RevitDeclarations/Models/Settings/PublicAreasSettings.cs
+++ b/src/RevitDeclarations/Models/Settings/PublicAreasSettings.cs
@@ -1,4 +1,5 @@
 namespace RevitDeclarations.Models;
 internal class PublicAreasSettings : DeclarationSettings {
     public bool AddPrefixToNumber { get; set; }
+    public bool AddHyphenToPrefix { get; set; }
 }

--- a/src/RevitDeclarations/Models/UtpCalculator.cs
+++ b/src/RevitDeclarations/Models/UtpCalculator.cs
@@ -133,8 +133,9 @@ internal class UtpCalculator {
     public string CalculateExtraSummerRooms(Apartment apartment) {
         int balconies = apartment.GetRoomsByPrior(_priorities.Balcony).Count;
         int loggies = apartment.GetRoomsByPrior(_priorities.Loggia).Count;
+        int terraces = apartment.GetRoomsByPrior(_priorities.Terrace).Count;
 
-        return balconies + loggies > 1 ? _utpYes : _utpNo;
+        return balconies + loggies + terraces > 1 ? _utpYes : _utpNo;
     }
 
     // УТП Мастер-спальня.

--- a/src/RevitDeclarations/ViewModels/MainViewModels/CommercialMainVM.cs
+++ b/src/RevitDeclarations/ViewModels/MainViewModels/CommercialMainVM.cs
@@ -144,6 +144,6 @@ internal class CommercialMainVM : MainViewModel {
         _settings.PositionType = commercialParamsVM.SelectedPositionType;
         _settings.GroupNameParam = commercialParamsVM.SelectedGroupNameParam;
         _settings.AddPrefixToNumber = commercialParamsVM.AddPrefixToNumber;
-        _settings.AddHyphenToPrefix = commercialParamsVM.AddHyphenToPrefix;
+        _settings.AddHyphenToPrefix = commercialParamsVM.AddHyphenToPrefix && commercialParamsVM.AddPrefixToNumber;
     }
 }

--- a/src/RevitDeclarations/ViewModels/MainViewModels/CommercialMainVM.cs
+++ b/src/RevitDeclarations/ViewModels/MainViewModels/CommercialMainVM.cs
@@ -115,6 +115,7 @@ internal class CommercialMainVM : MainViewModel {
         if(settings.AddPrefixToNumber) {
             configSettings.RoomNumberParam = settings.RoomNumberParam?.Definition.Name;
         }
+        configSettings.AddHyphenToPrefix = settings.AddHyphenToPrefix;
 
         config.SaveProjectConfig();
     }
@@ -143,5 +144,6 @@ internal class CommercialMainVM : MainViewModel {
         _settings.PositionType = commercialParamsVM.SelectedPositionType;
         _settings.GroupNameParam = commercialParamsVM.SelectedGroupNameParam;
         _settings.AddPrefixToNumber = commercialParamsVM.AddPrefixToNumber;
+        _settings.AddHyphenToPrefix = commercialParamsVM.AddHyphenToPrefix;
     }
 }

--- a/src/RevitDeclarations/ViewModels/MainViewModels/PublicAreasMainVM.cs
+++ b/src/RevitDeclarations/ViewModels/MainViewModels/PublicAreasMainVM.cs
@@ -110,6 +110,7 @@ internal class PublicAreasMainVM : MainViewModel {
         if(settings.AddPrefixToNumber) {
             configSettings.RoomNumberParam = settings.RoomNumberParam?.Definition.Name;
         }
+        configSettings.AddHyphenToPrefix = settings.AddHyphenToPrefix;
 
         config.SaveProjectConfig();
     }
@@ -131,5 +132,6 @@ internal class PublicAreasMainVM : MainViewModel {
     private void SetPublicAreasSettings() {
         var publicAreasParamsVM = (PublicAreasParamsVM) _parametersViewModel;
         _settings.AddPrefixToNumber = publicAreasParamsVM.AddPrefixToNumber;
+        _settings.AddHyphenToPrefix = publicAreasParamsVM.AddHyphenToPrefix && publicAreasParamsVM.AddPrefixToNumber;
     }
 }

--- a/src/RevitDeclarations/ViewModels/ParametersViewModels/CommercialParamsVM.cs
+++ b/src/RevitDeclarations/ViewModels/ParametersViewModels/CommercialParamsVM.cs
@@ -147,5 +147,6 @@ internal class CommercialParamsVM : ParametersViewModel {
             .FirstOrDefault(x => x.Definition.Name == commercialConfigSettings.GroupNameParam);
 
         AddPrefixToNumber = commercialConfigSettings.AddPrefixToNumber;
+        AddHyphenToPrefix = commercialConfigSettings.AddHyphenToPrefix;
     }
 }

--- a/src/RevitDeclarations/ViewModels/ParametersViewModels/ParametersViewModel.cs
+++ b/src/RevitDeclarations/ViewModels/ParametersViewModels/ParametersViewModel.cs
@@ -34,6 +34,7 @@ internal abstract class ParametersViewModel : BaseViewModel {
     private Parameter _selectedRoomNameParam;
     private Parameter _selectedRoomNumberParam;
     private bool _addPrefixToNumber;
+    private bool _addHyphenToPrefix;
 
     public ParametersViewModel(RevitRepository revitRepository, MainViewModel mainViewModel) {
         _mainViewModel = mainViewModel;
@@ -146,6 +147,11 @@ internal abstract class ParametersViewModel : BaseViewModel {
     public bool AddPrefixToNumber {
         get => _addPrefixToNumber;
         set => RaiseAndSetIfChanged(ref _addPrefixToNumber, value);
+    }
+    
+    public bool AddHyphenToPrefix {
+        get => _addHyphenToPrefix;
+        set => RaiseAndSetIfChanged(ref _addHyphenToPrefix, value);
     }
 
     /// <summary>

--- a/src/RevitDeclarations/Views/Pages/ParamsCommercialPage.xaml
+++ b/src/RevitDeclarations/Views/Pages/ParamsCommercialPage.xaml
@@ -637,7 +637,7 @@
                         Text="{me:LocalizationSource ParametersPage.ComRoomProjectName}"/>
                     <TextBox
                         Grid.Column="2"
-                        Grid.Row="19"
+                        Grid.Row="21"
                         Margin="10, 0"
                         Text="{Binding ProjectName, UpdateSourceTrigger=PropertyChanged}"/>
                 </Grid>

--- a/src/RevitDeclarations/Views/Pages/ParamsCommercialPage.xaml
+++ b/src/RevitDeclarations/Views/Pages/ParamsCommercialPage.xaml
@@ -355,6 +355,7 @@
                         Grid.Column="2"
                         Grid.Row="3"
                         Margin="10, 0"
+                        IsEnabled="{Binding AddPrefixToNumber}"
                         IsChecked="{Binding AddHyphenToPrefix}"/>
 
                     <TextBlock

--- a/src/RevitDeclarations/Views/Pages/ParamsCommercialPage.xaml
+++ b/src/RevitDeclarations/Views/Pages/ParamsCommercialPage.xaml
@@ -303,6 +303,7 @@
                         <RowDefinition Height="43"/>
                         <RowDefinition Height="43"/>
                         <RowDefinition Height="43"/>
+                        <RowDefinition Height="43"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="30"/>
@@ -344,15 +345,26 @@
                         Grid.Row="2"
                         Margin="10, 0"
                         IsChecked="{Binding AddPrefixToNumber}"/>
-
+                    
                     <TextBlock
                         Grid.Column="1"
                         Grid.Row="3"
                         Style="{StaticResource PropertyName}"
+                        Text="{me:LocalizationSource ParametersPage.ComRoomAddHyphen}"/>
+                    <CheckBox
+                        Grid.Column="2"
+                        Grid.Row="3"
+                        Margin="10, 0"
+                        IsChecked="{Binding AddHyphenToPrefix}"/>
+
+                    <TextBlock
+                        Grid.Column="1"
+                        Grid.Row="4"
+                        Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.ComRoomPrefixParam}"/>
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="3"
+                        Grid.Row="4"
                         Margin="10, 0"
                         IsEnabled="{Binding AddPrefixToNumber}"
                         ItemsSource="{Binding TextParameters}"
@@ -360,132 +372,132 @@
                         SelectedItem="{Binding SelectedApartNumParam}"/>
 
                     <ui:Button
-                        Grid.Row="4"
+                        Grid.Row="5"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.DepartmentParamToolTip}" />
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="4"
+                        Grid.Row="5"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.Definition}"/>
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="4"
+                        Grid.Row="5"
                         Margin="10, 0"
                         ItemsSource="{Binding TextParameters}"
                         DisplayMemberPath="Definition.Name"
                         SelectedItem="{Binding SelectedDepartmentParam}"/>
 
                     <ui:Button
-                        Grid.Row="5"
+                        Grid.Row="6"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.LevelParamToolTip}" />
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="5"
+                        Grid.Row="6"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.Level}"/>
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="5"
+                        Grid.Row="6"
                         Margin="10, 0"
                         ItemsSource="{Binding TextParameters}"
                         DisplayMemberPath="Definition.Name"
                         SelectedItem="{Binding SelectedLevelParam}"/>
 
                     <ui:Button
-                        Grid.Row="6"
+                        Grid.Row="7"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.SectionParamToolTip}" />
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="6"
+                        Grid.Row="7"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.Section}"/>
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="6"
+                        Grid.Row="7"
                         Margin="10, 0"
                         ItemsSource="{Binding TextParameters}"
                         DisplayMemberPath="Definition.Name"
                         SelectedItem="{Binding SelectedSectionParam}"/>
 
                     <ui:Button
-                        Grid.Row="7"
+                        Grid.Row="8"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.BuildingParamToolTip}" />
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="7"
+                        Grid.Row="8"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.Building}"/>
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="7"
+                        Grid.Row="8"
                         Margin="10, 0"
                         ItemsSource="{Binding TextParameters}"
                         DisplayMemberPath="Definition.Name"
                         SelectedItem="{Binding SelectedBuildingParam}"/>
 
                     <ui:Button
-                        Grid.Row="8"
+                        Grid.Row="9"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.BuildingNumberParamToolTip}" />
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="8"
+                        Grid.Row="9"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.BuildingNumber}"/>
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="8"
+                        Grid.Row="9"
                         Margin="10, 0"
                         ItemsSource="{Binding TextParameters}"
                         DisplayMemberPath="Definition.Name"
                         SelectedItem="{Binding SelectedBuildingNumberParam}"/>
 
                     <ui:Button
-                        Grid.Row="9"
+                        Grid.Row="10"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.ConstrWorkNumberParamToolTip}" />
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="9"
+                        Grid.Row="10"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.ConstrWorkNumber}"/>
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="9"
+                        Grid.Row="10"
                         Margin="10, 0"
                         ItemsSource="{Binding TextParameters}"
                         DisplayMemberPath="Definition.Name"
                         SelectedItem="{Binding SelectedConstrWorksNumberParam}"/>
 
                     <ui:Button
-                        Grid.Row="10"
+                        Grid.Row="11"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.CommercialAreaParamToolTip}" />
                     <TextBlock
-                        Grid.Row="10"
+                        Grid.Row="11"
                         Grid.Column="1"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.ComRoomArea}"/>
             
                     <TextBlock
-                        Grid.Row="11"
+                        Grid.Row="12"
                         Grid.Column="1"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.ComRoomAreaGroupParam}"/>
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="11"
+                        Grid.Row="12"
                         Margin="10, 0"
                         ItemsSource="{Binding DoubleParameters}"
                         DisplayMemberPath="Definition.Name"
@@ -493,107 +505,107 @@
 
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="12"
+                        Grid.Row="13"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.ComRoomAreaParam}"/>
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="12"
+                        Grid.Row="13"
                         Margin="10, 0"
                         ItemsSource="{Binding DoubleParameters}"
                         DisplayMemberPath="Definition.Name"
                         SelectedItem="{Binding SelectedRoomAreaParam}"/>
 
                     <ui:Button
-                        Grid.Row="13"
+                        Grid.Row="14"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.RoomsHeightParamToolTip}" />
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="13"
+                        Grid.Row="14"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.ComRoomHeight}"/>
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="13"
+                        Grid.Row="14"
                         Margin="10, 0"
                         ItemsSource="{Binding DoubleParameters}"
                         DisplayMemberPath="Definition.Name"
                         SelectedItem="{Binding SelectedRoomsHeightParam}"/>
                     
                     <ui:Button
-                        Grid.Row="14"
+                        Grid.Row="15"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.PositionTypeToolTip}" />
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="14"
+                        Grid.Row="15"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.ComPositionType}"/>
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="14"
+                        Grid.Row="15"
                         Margin="10, 0"
                         ItemsSource="{Binding TextParameters}"
                         DisplayMemberPath="Definition.Name"
                         SelectedItem="{Binding SelectedPositionType}"/>
 
                     <ui:Button
-                        Grid.Row="15"
+                        Grid.Row="16"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.ParkingSpaceClassParamToolTip}" />
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="15"
+                        Grid.Row="16"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.ComRoomCar}"/>
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="15"
+                        Grid.Row="16"
                         Margin="10, 0"
                         ItemsSource="{Binding TextParameters}"
                         DisplayMemberPath="Definition.Name"
                         SelectedItem="{Binding SelectedParkingSpaceClass}"/>
 
                     <ui:Button
-                        Grid.Row="16"
+                        Grid.Row="17"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.ParkingInfoParamToolTip}" />
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="16"
+                        Grid.Row="17"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.ComRoomUse}"/>
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="16"
+                        Grid.Row="17"
                         Margin="10, 0"
                         ItemsSource="{Binding TextParameters}"
                         DisplayMemberPath="Definition.Name"
                         SelectedItem="{Binding SelectedParkingInfo}"/>
 
                     <ui:Button
-                        Grid.Row="17"
+                        Grid.Row="18"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.CommercialNameClassParamToolTip}" />
                     <TextBlock
-                        Grid.Row="17"
+                        Grid.Row="18"
                         Grid.Column="1"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.ComRoomName}"/>
 
                     <TextBlock
-                        Grid.Row="18"
+                        Grid.Row="19"
                         Grid.Column="1"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.ComRoomGroupNameParam}"/>
                     <ComboBox
-                        Grid.Row="18"
+                        Grid.Row="19"
                         Grid.Column="2"
                         Margin="10, 0"
                         ItemsSource="{Binding TextParameters}"
@@ -601,12 +613,12 @@
                         SelectedItem="{Binding SelectedGroupNameParam}"/>
 
                     <TextBlock
-                        Grid.Row="19"
+                        Grid.Row="20"
                         Grid.Column="1"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.ComRoomNameParam}"/>
                     <ComboBox
-                        Grid.Row="19"
+                        Grid.Row="20"
                         Grid.Column="2"
                         Margin="10, 0"
                         ItemsSource="{Binding TextParameters}"
@@ -614,18 +626,18 @@
                         SelectedItem="{Binding SelectedRoomNameParam}"/>
 
                     <ui:Button
-                        Grid.Row="20"
+                        Grid.Row="21"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.ProjectNameToolTip}" />
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="20"
+                        Grid.Row="21"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.ComRoomProjectName}"/>
                     <TextBox
                         Grid.Column="2"
-                        Grid.Row="20"
+                        Grid.Row="19"
                         Margin="10, 0"
                         Text="{Binding ProjectName, UpdateSourceTrigger=PropertyChanged}"/>
                 </Grid>

--- a/src/RevitDeclarations/Views/Pages/ParamsPublicAreasPage.xaml
+++ b/src/RevitDeclarations/Views/Pages/ParamsPublicAreasPage.xaml
@@ -294,6 +294,7 @@
                         <RowDefinition Height="43"/>
                         <RowDefinition Height="43"/>
                         <RowDefinition Height="43"/>
+                        <RowDefinition Height="43"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="30"/>
@@ -335,15 +336,27 @@
                         Grid.Row="2"
                         Margin="10, 0"
                         IsChecked="{Binding AddPrefixToNumber}"/>
-
+                    
                     <TextBlock
                         Grid.Column="1"
                         Grid.Row="3"
                         Style="{StaticResource PropertyName}"
+                        Text="{me:LocalizationSource ParametersPage.ComRoomAddHyphen}"/>
+                    <CheckBox
+                        Grid.Column="2"
+                        Grid.Row="3"
+                        Margin="10, 0"
+                        IsEnabled="{Binding AddPrefixToNumber}"
+                        IsChecked="{Binding AddHyphenToPrefix}"/>
+
+                    <TextBlock
+                        Grid.Column="1"
+                        Grid.Row="4"
+                        Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.PublicAreaPrefixParam}" />
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="3"
+                        Grid.Row="4"
                         Margin="10, 0"
                         IsEnabled="{Binding AddPrefixToNumber}"
                         ItemsSource="{Binding TextParameters}"
@@ -351,36 +364,36 @@
                         SelectedItem="{Binding SelectedApartNumParam}"/>
 
                     <ui:Button
-                        Grid.Row="4"
+                        Grid.Row="5"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.PublicAreaNameParamToolTip}" />
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="4"
+                        Grid.Row="5"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.PublicAreaRoomType}" />
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="4"
+                        Grid.Row="5"
                         Margin="10, 0"
                         ItemsSource="{Binding TextParameters}"
                         DisplayMemberPath="Definition.Name"
                         SelectedItem="{Binding SelectedRoomNameParam}"/>
 
                     <ui:Button
-                        Grid.Row="5"
+                        Grid.Row="6"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.PublicAreaPositionParamToolTip}" />
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="5"
+                        Grid.Row="6"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.PublicAreaPositionBuilding}" />
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="5"
+                        Grid.Row="6"
                         Margin="10, 0"
                         ItemsSource="{Binding TextParameters}"
                         DisplayMemberPath="Definition.Name"
@@ -388,12 +401,12 @@
 
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="6"
+                        Grid.Row="7"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.PublicAreaPositionSection}" />
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="6"
+                        Grid.Row="7"
                         Margin="10, 0"
                         ItemsSource="{Binding TextParameters}"
                         DisplayMemberPath="Definition.Name"
@@ -401,54 +414,54 @@
 
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="7"
+                        Grid.Row="8"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.PublicAreaPositionLevel}" />
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="7"
+                        Grid.Row="8"
                         Margin="10, 0"
                         ItemsSource="{Binding TextParameters}"
                         DisplayMemberPath="Definition.Name"
                         SelectedItem="{Binding SelectedLevelParam}"/>
 
                     <ui:Button
-                        Grid.Row="8"
+                        Grid.Row="9"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.PublicAreaDepartmentParamToolTip}" />
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="8"
+                        Grid.Row="9"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.PublicAreaDefinition}" />
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="8"
+                        Grid.Row="9"
                         Margin="10, 0"
                         ItemsSource="{Binding TextParameters}"
                         DisplayMemberPath="Definition.Name"
                         SelectedItem="{Binding SelectedDepartmentParam}"/>
 
                     <ui:Button
-                        Grid.Row="9"
+                        Grid.Row="10"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.PublicAreaAreaParamToolTip}" />
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="9"
+                        Grid.Row="10"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.PublicAreaArea}" />
 
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="10"
+                        Grid.Row="11"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.PublicAreaAreaForSeveralRooms}" />
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="10"
+                        Grid.Row="11"
                         Margin="10, 0"
                         ItemsSource="{Binding DoubleParameters}"
                         DisplayMemberPath="Definition.Name"
@@ -456,30 +469,30 @@
             
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="11"
+                        Grid.Row="12"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.PublicAreaAreaForOneRoom}" />
                     <ComboBox
                         Grid.Column="2"
-                        Grid.Row="11"
+                        Grid.Row="12"
                         Margin="10, 0"
                         ItemsSource="{Binding DoubleParameters}"
                         DisplayMemberPath="Definition.Name"
                         SelectedItem="{Binding SelectedRoomAreaParam}"/>
 
                     <ui:Button
-                        Grid.Row="12"
+                        Grid.Row="13"
                         Grid.Column="0"
                         Style="{StaticResource ToolTipButton}"
                         ToolTip="{me:LocalizationSource ToolTip.ProjectNameToolTip}" />
                     <TextBlock
                         Grid.Column="1"
-                        Grid.Row="12"
+                        Grid.Row="13"
                         Style="{StaticResource PropertyName}"
                         Text="{me:LocalizationSource ParametersPage.PublicAreaProjectName}" />
                     <TextBox
                         Grid.Column="2"
-                        Grid.Row="12"
+                        Grid.Row="13"
                         Margin="10, 0"
                         Text="{Binding ProjectName, UpdateSourceTrigger=PropertyChanged}"/>
                 </Grid>

--- a/src/RevitDeclarations/assets/localization/Language.en-US.xaml
+++ b/src/RevitDeclarations/assets/localization/Language.en-US.xaml
@@ -95,7 +95,7 @@
     <system:String x:Key="ParametersPage.PublicAreaGroupParams">Parameter for grouping within public area groups:</system:String>
     <system:String x:Key="ParametersPage.PublicAreaRoomNumber">1.1 Room number:</system:String>
     <system:String x:Key="ParametersPage.PublicAreaAddPrefix">1.2 Add prefix:</system:String>
-    <system:String x:Key="ParametersPage.PublicAreaPrefixParam">1.3 Parameter for prefix:</system:String>
+    <system:String x:Key="ParametersPage.PublicAreaPrefixParam">1.4 Parameter for prefix:</system:String>
     <system:String x:Key="ParametersPage.PublicAreaRoomType">2. Room type:</system:String>
     <system:String x:Key="ParametersPage.PublicAreaPositionBuilding">3.1 Location - building block:</system:String>
     <system:String x:Key="ParametersPage.PublicAreaPositionSection">3.2 Location - section:</system:String>

--- a/src/RevitDeclarations/assets/localization/Language.en-US.xaml
+++ b/src/RevitDeclarations/assets/localization/Language.en-US.xaml
@@ -77,7 +77,8 @@
     <system:String x:Key="ParametersPage.DeclParamsHeader">Parameters for filling out the declaration</system:String>
     <system:String x:Key="ParametersPage.ComRoomNumber">1.1 Room number:</system:String>
     <system:String x:Key="ParametersPage.ComRoomAddPrefix">1.2 Add prefix to the number:</system:String>
-    <system:String x:Key="ParametersPage.ComRoomPrefixParam">1.3 Parameter for prefix:</system:String>
+    <system:String x:Key="ParametersPage.ComRoomAddHyphen">1.3 Add hyphen after prefix:</system:String>
+    <system:String x:Key="ParametersPage.ComRoomPrefixParam">1.4 Parameter for prefix:</system:String>
     <system:String x:Key="ParametersPage.ComRoomArea">8. Total area</system:String>
     <system:String x:Key="ParametersPage.ComRoomAreaGroupParam">8.1 For a group of multiple rooms:</system:String>
     <system:String x:Key="ParametersPage.ComRoomAreaParam">8.2 For a single room:</system:String>

--- a/src/RevitDeclarations/assets/localization/Language.ru-RU.xaml
+++ b/src/RevitDeclarations/assets/localization/Language.ru-RU.xaml
@@ -77,7 +77,8 @@
     <system:String x:Key="ParametersPage.DeclParamsHeader">Параметры для заполнения декларации</system:String>
     <system:String x:Key="ParametersPage.ComRoomNumber">1.1 Номер помещения:</system:String>
     <system:String x:Key="ParametersPage.ComRoomAddPrefix">1.2 Добавить префикс в номер:</system:String>
-    <system:String x:Key="ParametersPage.ComRoomPrefixParam">1.3 Параметр для префикса:</system:String>
+    <system:String x:Key="ParametersPage.ComRoomAddHyphen">1.3 Добавить дефис после префикса:</system:String>
+    <system:String x:Key="ParametersPage.ComRoomPrefixParam">1.4 Параметр для префикса:</system:String>
     <system:String x:Key="ParametersPage.ComRoomArea">8. Общая площадь</system:String>
     <system:String x:Key="ParametersPage.ComRoomAreaGroupParam">8.1 Для группы из нескольких помещений:</system:String>
     <system:String x:Key="ParametersPage.ComRoomAreaParam">8.2 Для одного помещения:</system:String>

--- a/src/RevitDeclarations/assets/localization/Language.ru-RU.xaml
+++ b/src/RevitDeclarations/assets/localization/Language.ru-RU.xaml
@@ -95,7 +95,7 @@
     <system:String x:Key="ParametersPage.PublicAreaGroupParams">Параметр группировки внутри групп МОП:</system:String>
     <system:String x:Key="ParametersPage.PublicAreaRoomNumber">1.1 Номер помещения:</system:String>
     <system:String x:Key="ParametersPage.PublicAreaAddPrefix">1.2 Добавить префикс:</system:String>
-    <system:String x:Key="ParametersPage.PublicAreaPrefixParam">1.3 Параметр для префикса:</system:String>
+    <system:String x:Key="ParametersPage.PublicAreaPrefixParam">1.4 Параметр для префикса:</system:String>
     <system:String x:Key="ParametersPage.PublicAreaRoomType">2. Вид помещения:</system:String>
     <system:String x:Key="ParametersPage.PublicAreaPositionBuilding">3.1 Местоположение - корпус:</system:String>
     <system:String x:Key="ParametersPage.PublicAreaPositionSection">3.2 Местоположение - секция:</system:String>


### PR DESCRIPTION
Изменения:
1. Добавление условия для расчета значения параметра ФОП_Доп. летнее помещение, теперь учитывается еще и терраса
2. Добавление кнопки добавления дефиса после префикса для "Параметра для префикса"

Светлая тема 15.3 Нежилые (RUS):
<img width="1012" height="905" alt="image" src="https://github.com/user-attachments/assets/ce965fcc-4b88-4afb-b033-4fb4e8abc9fb" />

Светлая тема 16.1 Моп (RUS):
<img width="1010" height="861" alt="image" src="https://github.com/user-attachments/assets/e081bce2-a0ee-476f-a8e4-010dbfaa55d7" />

Темная тема 15.3 Нежилые (ENG):
<img width="1014" height="870" alt="image" src="https://github.com/user-attachments/assets/928cb7cc-0d0e-4456-9329-fa59f10e3dff" />

Темная тема 16.1 Моп (ENG):
<img width="1013" height="868" alt="image" src="https://github.com/user-attachments/assets/022396ef-3e18-4df8-a0d8-597860527ab7" />
