### PR TITLE
RevitMechanicalSpecification: Обработка соединителей, существование ФОП_ВИС_Число

### DIFF
--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamMarkFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamMarkFiller.cs
@@ -37,14 +37,16 @@ namespace RevitMechanicalSpecification.Models.Fillers {
         /// <param name="specificationElement"></param>
         /// <returns></returns>
         private string GetMark(SpecificationElement specificationElement) {
-            string mark = specificationElement.GetTypeOrInstanceParamStringValue(OriginalParamName);
-
             if(specificationElement.BuiltInCategory == BuiltInCategory.OST_DuctFitting) {
-                mark = _calculator.GetDuctFittingMark(specificationElement.Element);
+                string mark = _calculator.GetDuctFittingMark(specificationElement.Element);
                 specificationElement.ElementMark = mark;
-            }
 
-            return mark;
+                if(!string.IsNullOrEmpty(mark)) {
+                    return mark;
+                }
+            }
+            
+            return specificationElement.GetTypeOrInstanceParamStringValue(OriginalParamName);
         }
     }
 }

--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamNameFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamNameFiller.cs
@@ -194,7 +194,7 @@ namespace RevitMechanicalSpecification.Models.Fillers {
         /// <param name="specificationElement"></param>
         /// <returns></returns>
         private string GetDuctFittingName(SpecificationElement specificationElement) {
-            return $"{_calculator.GetDuctFittingName(specificationElement.Element)} {_nameAddon}";
+            return $"{_calculator.GetDuctFittingName(specificationElement.Element, _nameAddon)} {_nameAddon}";
         }
 
         /// <summary>

--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamNumberFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamNumberFiller.cs
@@ -29,9 +29,11 @@ namespace RevitMechanicalSpecification.Models.Fillers {
             TargetParam.Set(GetNumber(specificationElement));
             
             if(Config.NullifyOutdatedNumber) {
-                Parameter outDateParam = specificationElement.Element.GetParam(Config.OutdatedNameNumber);
-                if(!outDateParam.IsReadOnly) {
-                    outDateParam.Set(0);
+                if(specificationElement.Element.IsExistsParam(Config.OutdatedNameNumber)) {
+                    Parameter outDateParam = specificationElement.Element.GetParam(Config.OutdatedNameNumber);
+                    if(!outDateParam.IsReadOnly) {
+                        outDateParam.Set(0);
+                    }
                 }
             }
         }

--- a/src/RevitMechanicalSpecification/Service/VisElementsCalculator.cs
+++ b/src/RevitMechanicalSpecification/Service/VisElementsCalculator.cs
@@ -50,9 +50,11 @@ namespace RevitMechanicalSpecification.Service {
         public string GetDuctFittingMark(Element element) {
             List<Connector> connectors = GetConnectors(element);
             Element duct = GetDuctFromConnectorList(connectors);
+            
             if(duct is null) {
-                return "!Не учитывать";
+                return String.Empty;
             }
+            
             return duct.GetTypeOrInstanceParamStringValue(duct.GetElementType(), _specConfiguration.OriginalParamNameMark);
         }
 
@@ -61,15 +63,11 @@ namespace RevitMechanicalSpecification.Service {
         /// </summary>
         /// <param name="element"></param>
         /// <returns></returns>
-        public string GetDuctFittingName(Element element) {
+        public string GetDuctFittingName(Element element, string nameAddon) {
             string thikness = GetDuctFittingThikness(element);
             string startName = "Не удалось определить тип фитинга";
             FamilyInstance instanse = element as FamilyInstance;
             MechanicalFitting fitting = instanse.MEPModel as MechanicalFitting;
-            
-            if(thikness is null && fitting.PartType != PartType.MultiPort) {
-                return "!Не учитывать";
-            }
 
             if(!_specConfiguration.IsSpecifyDuctFittings) {
                 return "Металл для фасонных деталей воздуховодов с толщиной стенки " + thikness + " мм";
@@ -122,7 +120,16 @@ namespace RevitMechanicalSpecification.Service {
             if(notTransition && notTee) {
                 size = size.Split('-').First();
             }
-            return startName + " " + size + ", с толщиной стенки " + thikness + " мм";
+            
+            if(string.IsNullOrEmpty(nameAddon) && thikness is null) {
+                return $"{startName} {size}, УКАЖИТЕ ТОЛЩИНУ ЧЕРЕЗ \"ФОП_ВИС_Дополнение к имени\"";
+            }
+
+            if(thikness is null) {
+                return $"{startName} {size},";
+            }
+
+            return $"{startName} {size}, с толщиной стенки {thikness} мм";
         }
 
         /// <summary>


### PR DESCRIPTION
1) Апдейт обработки соединительных деталей. Теперь они не падают в "!Не учитывать" когда не получается определить толщину, а запрашивают ручной ввод толщины в параметр дополнения имени.

2) Перед обнулением ФОП_ВИС_Число теперь проверяется его существование. У некоторых семейств оно убрано в тип, обнулять их там не требуется, но это ломает скрипт