### PR TITLE
RevitMechanicalSpecification: Имя системы, длины переходов в имена, обработка Число_ДЕ

### DIFF
--- a/src/RevitMechanicalSpecification/Models/Fillers/ElementParamNumberFiller.cs
+++ b/src/RevitMechanicalSpecification/Models/Fillers/ElementParamNumberFiller.cs
@@ -31,7 +31,8 @@ namespace RevitMechanicalSpecification.Models.Fillers {
             if(Config.NullifyOutdatedNumber) {
                 if(specificationElement.Element.IsExistsParam(Config.OutdatedNameNumber)) {
                     Parameter outDateParam = specificationElement.Element.GetParam(Config.OutdatedNameNumber);
-                    if(!outDateParam.IsReadOnly) {
+                    if(!outDateParam.IsReadOnly
+                        && specificationElement.Element.GroupId == ElementId.InvalidElementId) {
                         outDateParam.Set(0);
                     }
                 }
@@ -46,11 +47,21 @@ namespace RevitMechanicalSpecification.Models.Fillers {
         private double GetNumber(SpecificationElement specificationElement) {
             string unit = specificationElement.Element.GetSharedParamValue<string>(Config.TargetNameUnit);
 
+            // Для элементов в семейства которых зашит в формулу расчет по старому параметру треубется возвращаение его значения
+            Parameter outDateParam = specificationElement.Element.GetTypeOrInstanceParam(
+                specificationElement.ElementType, 
+                Config.OutdatedNameNumber);
+            if(!(outDateParam is null)) {
+                if(outDateParam.IsReadOnly) {
+                    return outDateParam.AsDouble();
+                }
+            }
+            
             // Если единица измерения штуки или комплекты - возвращаем 1
             if(unit == Config.SingleUnit || unit == Config.KitUnit) {
                 return 1;
             }
-
+            
             // Если единица измерения метры квадратные - забираем или высчитываем (для фитингов) площадь в дабл и переводим в метры квадратные
             if(unit == Config.SquareUnit) {
                 if(specificationElement.BuiltInCategory == BuiltInCategory.OST_DuctInsulations) {

--- a/src/RevitMechanicalSpecification/Service/SystemFunctionNameFactory.cs
+++ b/src/RevitMechanicalSpecification/Service/SystemFunctionNameFactory.cs
@@ -184,8 +184,11 @@ namespace RevitMechanicalSpecification.Service {
 
             List<string> systemNames = GetSystemNames(element);
             if(!string.IsNullOrEmpty(forcedSystemSelector)) {
-                string selectedSystemName = systemNames.FirstOrDefault(systemName =>
-                    systemName.IndexOf(forcedSystemSelector, StringComparison.OrdinalIgnoreCase) >= 0);
+                IEnumerable<string> selectorSystemNames = systemNames.Count > 1
+                    ? systemNames.Skip(1)
+                    : systemNames;
+                string selectedSystemName = selectorSystemNames.FirstOrDefault(systemName =>
+                    systemName.StartsWith(forcedSystemSelector, StringComparison.OrdinalIgnoreCase));
                 VisSystem selectedSystem = GetVisSystemByName(selectedSystemName);
                 if(selectedSystem != null) {
                     return selectedSystem;
@@ -202,10 +205,16 @@ namespace RevitMechanicalSpecification.Service {
                 ? GetInsulationSystem(element as InsulationLiningBase)
                 : GetParamSystemValue(element);
 
-            return systemNames
-                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(item => item.Trim())
-                .Where(item => !string.IsNullOrEmpty(item))
+            if(string.IsNullOrWhiteSpace(systemNames)) {
+                return new List<string>();
+            }
+
+            return new[] { systemNames.Trim() }
+                .Concat(systemNames
+                    .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(item => item.Trim())
+                    .Where(item => !string.IsNullOrEmpty(item)))
+                .Distinct()
                 .ToList();
         }
 

--- a/src/RevitMechanicalSpecification/Service/VisElementsCalculator.cs
+++ b/src/RevitMechanicalSpecification/Service/VisElementsCalculator.cs
@@ -125,16 +125,17 @@ namespace RevitMechanicalSpecification.Service {
             optionalLength = string.IsNullOrEmpty(optionalLength)
                 ? string.Empty
                 : $", L={optionalLength} мм";
+            string fullName = $"{startName} {size}{optionalLength}";
             
             if(string.IsNullOrEmpty(nameAddon) && thikness is null) {
-                return $"{startName} {size}{optionalLength}, УКАЖИТЕ ТОЛЩИНУ ЧЕРЕЗ \"ФОП_ВИС_Дополнение к имени\"";
+                return $"{fullName}, УКАЖИТЕ ТОЛЩИНУ ЧЕРЕЗ \"ФОП_ВИС_Дополнение к имени\"";
             }
 
             if(thikness is null) {
-                return $"{startName} {size}{optionalLength},";
+                return $"{fullName},";
             }
 
-            return $"{startName} {size}{optionalLength}, с толщиной стенки {thikness} мм";
+            return $"{fullName}, с толщиной стенки {thikness} мм";
         }
 
         /// <summary>

--- a/src/RevitMechanicalSpecification/Service/VisElementsCalculator.cs
+++ b/src/RevitMechanicalSpecification/Service/VisElementsCalculator.cs
@@ -121,15 +121,42 @@ namespace RevitMechanicalSpecification.Service {
                 size = size.Split('-').First();
             }
             
+            string optionalLength = GetTransitionLength(element);
+            optionalLength = string.IsNullOrEmpty(optionalLength)
+                ? string.Empty
+                : $", L={optionalLength} мм";
+            
             if(string.IsNullOrEmpty(nameAddon) && thikness is null) {
-                return $"{startName} {size}, УКАЖИТЕ ТОЛЩИНУ ЧЕРЕЗ \"ФОП_ВИС_Дополнение к имени\"";
+                return $"{startName} {size}{optionalLength}, УКАЖИТЕ ТОЛЩИНУ ЧЕРЕЗ \"ФОП_ВИС_Дополнение к имени\"";
             }
 
             if(thikness is null) {
-                return $"{startName} {size},";
+                return $"{startName} {size}{optionalLength},";
             }
 
-            return $"{startName} {size}, с толщиной стенки {thikness} мм";
+            return $"{startName} {size}{optionalLength}, с толщиной стенки {thikness} мм";
+        }
+
+        /// <summary>
+        /// Получение длины перехода
+        /// </summary>
+        /// <param name="element"></param>
+        /// <returns></returns>
+        private string GetTransitionLength(Element element) {
+            FamilyInstance instance = element as FamilyInstance;
+            MechanicalFitting fitting = instance?.MEPModel as MechanicalFitting;
+
+            if(fitting == null || fitting.PartType != PartType.Transition) {
+                return string.Empty;
+            }
+
+            List<Connector> connectors = GetConnectors(element);
+            if(connectors.Count != 2) {
+                return string.Empty;
+            }
+
+            double length = connectors[0].Origin.DistanceTo(connectors[1].Origin);
+            return UnitConverter.DoubleToString(UnitConverter.DoubleToMilimeters(length));
         }
 
         /// <summary>


### PR DESCRIPTION
1) Модификация поиска систем. Теперь многосоставные системы ищутся сначала по полному имени, а потом уже по разделенному. Сделано это для систем с именами перечисленными через запятую (Например "Общий забор систем П1,П2,П3")
2) Обработка селектора, если он есть, стартует перед полным поиском, пропуская поиск полного имени. Если селектор не обнаружен то идет обычный поиск через полное и отдельные имена
3) Пропуск нулификации ФОП_ВИС_Число состоящего в группах модели
4) Элементы у которых было рассчитано ФОП_ВИС_Число в семействе будут возвращать это число параметр ДЕ
5)Для переходов между сечениями теперь вычисляется и выводится в спецификацию их длина