### PR TITLE
RevitExportSpecToExcel: Исправлен стиль заголовков столбцов

### DIFF
--- a/src/RevitExportSpecToExcel/Views/MainWindow.xaml
+++ b/src/RevitExportSpecToExcel/Views/MainWindow.xaml
@@ -87,7 +87,6 @@
                     Style="{StaticResource  CustomResizableDataGridStyle}">
                     <DataGrid.Columns>
                         <DataGridCheckBoxColumn
-                            HeaderStyle="{StaticResource CustomDataGridHeaderStyle}"                          
                             Binding="{Binding Path=IsChecked, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
                                 <DataGridCheckBoxColumn.CellStyle>
                                 <Style TargetType="DataGridCell">
@@ -113,7 +112,6 @@
                         </DataGridCheckBoxColumn>
                         <DataGridTextColumn
                             Width="500"
-                            HeaderStyle="{StaticResource CustomDataGridHeaderStyle}"
                             Binding="{Binding Path=Name}"
                             IsReadOnly="True">
                             <DataGridTextColumn.Header>
@@ -123,10 +121,10 @@
                             </DataGridTextColumn.Header>
                         </DataGridTextColumn>
                         <DataGridTextColumn
-                            HeaderStyle="{StaticResource CustomDataGridHeaderStyle}"
                             Binding="{Binding Path=OpenStatus.Name}"
                             SortMemberPath="OpenStatus.Order"
-                            IsReadOnly="True">
+                            IsReadOnly="True"
+                            Width="*">
                             <DataGridTextColumn.Header>
                                 <TextBlock
                                     TextAlignment="Center"

--- a/src/RevitExportSpecToExcel/Views/Styles.xaml
+++ b/src/RevitExportSpecToExcel/Views/Styles.xaml
@@ -165,18 +165,4 @@
             </Setter.Value>
         </Setter>
     </Style>
-
-    <Style
-        x:Key="CustomDataGridHeaderStyle"
-        TargetType="DataGridColumnHeader">
-        <Setter
-            Property="HorizontalContentAlignment"
-            Value="Center" />
-        <Setter
-            Property="Background"
-            Value="White" />
-        <Setter
-            Property="FontWeight"
-            Value="Bold" />
-    </Style>
 </ResourceDictionary>


### PR DESCRIPTION
# Описание

До этого в темной теме заголовки отображались как белый прямоугольник без текста. Теперь используется стиль по умолчанию.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/98e7265f-6140-4e08-bbfd-d98c78febb3c" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/0ed66e63-de85-4825-b1bb-3750567b1bd3" />
