### PR TITLE
RevitCorrectNamingCheck: Исправлена логика назначания статусов для РН и связей

### DIFF
--- a/src/RevitCorrectNamingCheck/Helpers/NamingRulesHelper.cs
+++ b/src/RevitCorrectNamingCheck/Helpers/NamingRulesHelper.cs
@@ -1,20 +1,20 @@
-using System.Collections.Generic;
-using System.Linq;
 using System.Text.RegularExpressions;
-
-using dosymep.Bim4Everyone;
 
 namespace RevitCorrectNamingCheck.Helpers;
 internal static class NamingRulesHelper {
     /// <summary>
-    /// Проверяет, содержит ли имя указанный фрагмент (ID или Name).
+    /// Проверяет, содержит ли имя указанную метку раздела как отдельное слово.
     /// </summary>
+    /// <remarks>
+    /// Метка засчитывается, только если она отделена символами "_", ".", пробелом
+    /// либо находится в начале/конце строки. Вхождение метки как части другого слова не засчитывается.
+    /// </remarks>
     public static bool ContainsPart(string name, string part) {
         if(string.IsNullOrEmpty(name) || string.IsNullOrEmpty(part)) {
             return false;
         }
 
-        string pattern = $@"(?:_|^){Regex.Escape(part)}(?:_|\.|\s|$)";
+        string pattern = $@"(?:^|[_.\s]){Regex.Escape(part)}(?:[_.\s]|$)";
         return Regex.IsMatch(name, pattern, RegexOptions.IgnoreCase);
     }
 
@@ -23,26 +23,5 @@ internal static class NamingRulesHelper {
     /// </summary>
     public static bool IsLinkWorkset(string name) {
         return name?.ToLower().Contains("связ") == true;
-    }
-
-    /// <summary>
-    /// Считает количество совпадений среди частей.
-    /// </summary>
-    public static int CountMatches(string name, IEnumerable<string> parts) {
-        return parts.Count(part => ContainsPart(name, part));
-    }
-
-    /// <summary>
-    /// Проверяет, соответствует ли имя текущей BIM-модели.
-    /// </summary>
-    public static bool MatchesCurrentPart(string name, BimModelPart part) {
-        return ContainsPart(name, part.Id) || ContainsPart(name, part.Name);
-    }
-
-    /// <summary>
-    /// Проверяет, есть ли ровно одно совпадение.
-    /// </summary>
-    public static bool MatchesExactlyOnePart(string name, IEnumerable<string> parts) {
-        return CountMatches(name, parts) == 1;
     }
 }

--- a/src/RevitCorrectNamingCheck/Models/RevitRepository.cs
+++ b/src/RevitCorrectNamingCheck/Models/RevitRepository.cs
@@ -82,9 +82,9 @@ internal class RevitRepository {
     }
 
     public Dictionary<WorksetId, string> GetUserWorksets() {
-        return WorksharingUtils.GetUserWorksetInfo(
-                Document.GetWorksharingCentralModelPath()
-                ?? ModelPathUtils.ConvertUserVisiblePathToModelPath(Document.PathName))
+        return new FilteredWorksetCollector(Document)
+            .OfKind(WorksetKind.UserWorkset)
+            .ToWorksets()
             .ToDictionary(p => p.Id, p => p.Name);
     }
 
@@ -123,3 +123,4 @@ internal class RevitRepository {
         }
     }
 }
+ 

--- a/src/RevitCorrectNamingCheck/Services/LinkedFileEnricher.cs
+++ b/src/RevitCorrectNamingCheck/Services/LinkedFileEnricher.cs
@@ -1,9 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 
-using dosymep.Bim4Everyone;
-using dosymep.Bim4Everyone.SimpleServices;
-
 using RevitCorrectNamingCheck.Helpers;
 using RevitCorrectNamingCheck.Models;
 using RevitCorrectNamingCheck.ViewModels;
@@ -11,92 +8,94 @@ using RevitCorrectNamingCheck.ViewModels;
 namespace RevitCorrectNamingCheck.Services;
 
 internal class LinkedFileEnricher {
-    private readonly Dictionary<string, string> _partFileToRnMap = new() {
-    { "AR", "AR" },
-    { "KR", "KR" },
-    { "OV", "OV" },
-    { "ITP", "OV" },     // ITP считается частью OV в РН
-    { "VK", "VK" },
-    { "EOM", "EOM" },
-    { "EG", "EOM" },     // EG считается частью EOM в РН
-    { "SS", "SS" }
+    /// <summary>
+    /// Метки разделов в именах файлов (только латиница) и соответствующий им раздел.
+    /// ITP и EG считаются частью разделов OV и EOM соответственно.
+    /// </summary>
+    private readonly Dictionary<string, string> _fileLabelToSection = new() {
+        { "AR", "AR" },
+        { "KR", "KR" },
+        { "OV", "OV" },
+        { "ITP", "OV" },     // ITP считается частью OV
+        { "VK", "VK" },
+        { "EOM", "EOM" },
+        { "EG", "EOM" },     // EG считается частью EOM
+        { "SS", "SS" }
     };
 
+    /// <summary>
+    /// Метки разделов в именах рабочих наборов (кириллица и латиница) и соответствующий им раздел.
+    /// </summary>
+    private readonly Dictionary<string, string> _rnLabelToSection = new() {
+        { "AR", "AR" }, { "АР", "AR" },
+        { "KR", "KR" }, { "КР", "KR" },
+        { "OV", "OV" }, { "ОВ", "OV" },
+        { "VK", "VK" }, { "ВК", "VK" },
+        { "EOM", "EOM" }, { "ЭОМ", "EOM" },
+        { "SS", "SS" }, { "СС", "SS" }
+    };
 
-    private readonly IBimModelPartsService _bimModelPartsService;
+    private NameStatus GetFileNameStatus(string name) {
+        int sections = GetSections(name, _fileLabelToSection).Count;
 
-    public LinkedFileEnricher(IBimModelPartsService bimModelPartsService) {
-        _bimModelPartsService = bimModelPartsService;
+        return sections == 0 ? NameStatus.None : sections == 1 ? NameStatus.Correct : NameStatus.Incorrect;
     }
 
-    private void SetWorksetNameStatus(
-        WorksetInfoViewModel workset,
-        BimModelPart currentPart,
-        List<string> bimIdentifiers) {
-        workset.WorksetNameStatus = GetWorksetNameStatus(workset.Name, currentPart, bimIdentifiers);
+    /// <summary>
+    /// Определяет раздел файла по его имени. Возвращает раздел, только если найден ровно один.
+    /// </summary>
+    private string GetFileSection(string name) {
+        var sections = GetSections(name, _fileLabelToSection);
+
+        return sections.Count == 1 ? sections[0] : null;
     }
 
-    private NameStatus GetFileNameStatus(string name, List<string> bimIdentifiers) {
-        int matches = bimIdentifiers.Count(part => NamingRulesHelper.ContainsPart(name, part));
-
-        return matches == 0 ? NameStatus.None : matches == 1 ? NameStatus.Correct : NameStatus.Incorrect;
-    }
-
-    private NameStatus GetWorksetNameStatus(string worksetName, BimModelPart currentPart, List<string> identifiers) {
-        var mappedIdentifiers = identifiers
-            .Select(i => _partFileToRnMap.TryGetValue(i, out var mapped) ? mapped : i)
-            .Distinct()
-            .ToList();
-
-        bool isLink = NamingRulesHelper.IsLinkWorkset(worksetName);
-
-        bool isCurrent = false;
-        if (currentPart != null) {
-            isCurrent = NamingRulesHelper.MatchesCurrentPart(worksetName, currentPart);
-        }
-        int matches = mappedIdentifiers.Count(part => NamingRulesHelper.ContainsPart(worksetName, part));
-
-        if(!isLink) {
+    private NameStatus GetWorksetNameStatus(string worksetName, string currentSection) {
+        if(!NamingRulesHelper.IsLinkWorkset(worksetName)) {
             return NameStatus.Incorrect;
         }
 
-        if(matches == 1 && isCurrent) {
-            return NameStatus.Correct;
+        var sections = GetSections(worksetName, _rnLabelToSection);
+
+        if(sections.Count > 1) {
+            return NameStatus.PartialCorrect;
         }
 
-        if(matches > 1) {
-            return NameStatus.PartialCorrect;
+        if(sections.Count == 1 && currentSection != null && sections[0] == currentSection) {
+            return NameStatus.Correct;
         }
 
         return NameStatus.None;
     }
 
-    public void Enrich(LinkedFileViewModel linkedFile) {
-
-        var requiredParts = new[] { "AR", "KR", "OV", "ITP", "VK", "EOM", "EG", "SS" };
-
-        var bimModelParts = _bimModelPartsService
-            .GetBimModelParts()
-            .Where(p => requiredParts.Contains(p.Id))
-            .ToList();
-
-        var bimIdentifiers = bimModelParts
-            .SelectMany(p => new[] { p.Id, p.Name })
+    /// <summary>
+    /// Возвращает уникальные разделы, метки которых встречаются в имени.
+    /// </summary>
+    private static List<string> GetSections(string name, Dictionary<string, string> labelToSection) {
+        return labelToSection
+            .Where(pair => NamingRulesHelper.ContainsPart(name, pair.Key))
+            .Select(pair => pair.Value)
             .Distinct()
             .ToList();
+    }
 
-        linkedFile.FileNameStatus = GetFileNameStatus(linkedFile.Name, bimIdentifiers);
+    private void SetWorksetNameStatus(WorksetInfoViewModel workset, string currentSection) {
+        workset.WorksetNameStatus = GetWorksetNameStatus(workset.Name, currentSection);
+    }
 
-        var currentPart = _bimModelPartsService.GetBimModelPart(linkedFile.Name);
+    public void Enrich(LinkedFileViewModel linkedFile) {
+        linkedFile.FileNameStatus = GetFileNameStatus(linkedFile.Name);
 
-        SetWorksetNameStatus(linkedFile.TypeWorkset, currentPart, bimIdentifiers);
-        SetWorksetNameStatus(linkedFile.InstanceWorkset, currentPart, bimIdentifiers);
+        var currentSection = GetFileSection(linkedFile.Name);
+
+        SetWorksetNameStatus(linkedFile.TypeWorkset, currentSection);
+        SetWorksetNameStatus(linkedFile.InstanceWorkset, currentSection);
         foreach(var workset in linkedFile.TypeWorksets) {
-            SetWorksetNameStatus(workset, currentPart, bimIdentifiers);
+            SetWorksetNameStatus(workset, currentSection);
         }
 
         foreach(var workset in linkedFile.InstanceWorksets) {
-            SetWorksetNameStatus(workset, currentPart, bimIdentifiers);
+            SetWorksetNameStatus(workset, currentSection);
         }
     }
 }

--- a/src/RevitCorrectNamingCheck/Services/LinkedFileEnricher.cs
+++ b/src/RevitCorrectNamingCheck/Services/LinkedFileEnricher.cs
@@ -35,6 +35,22 @@ internal class LinkedFileEnricher {
         { "SS", "SS" }, { "СС", "SS" }
     };
 
+    public void Enrich(LinkedFileViewModel linkedFile) {
+        linkedFile.FileNameStatus = GetFileNameStatus(linkedFile.Name);
+
+        var currentSection = GetFileSection(linkedFile.Name);
+
+        SetWorksetNameStatus(linkedFile.TypeWorkset, currentSection);
+        SetWorksetNameStatus(linkedFile.InstanceWorkset, currentSection);
+        foreach(var workset in linkedFile.TypeWorksets) {
+            SetWorksetNameStatus(workset, currentSection);
+        }
+
+        foreach(var workset in linkedFile.InstanceWorksets) {
+            SetWorksetNameStatus(workset, currentSection);
+        }
+    }
+
     private NameStatus GetFileNameStatus(string name) {
         int sections = GetSections(name, _fileLabelToSection).Count;
 
@@ -81,21 +97,5 @@ internal class LinkedFileEnricher {
 
     private void SetWorksetNameStatus(WorksetInfoViewModel workset, string currentSection) {
         workset.WorksetNameStatus = GetWorksetNameStatus(workset.Name, currentSection);
-    }
-
-    public void Enrich(LinkedFileViewModel linkedFile) {
-        linkedFile.FileNameStatus = GetFileNameStatus(linkedFile.Name);
-
-        var currentSection = GetFileSection(linkedFile.Name);
-
-        SetWorksetNameStatus(linkedFile.TypeWorkset, currentSection);
-        SetWorksetNameStatus(linkedFile.InstanceWorkset, currentSection);
-        foreach(var workset in linkedFile.TypeWorksets) {
-            SetWorksetNameStatus(workset, currentSection);
-        }
-
-        foreach(var workset in linkedFile.InstanceWorksets) {
-            SetWorksetNameStatus(workset, currentSection);
-        }
     }
 }

--- a/src/RevitCorrectNamingCheck/ViewModels/LinkedFileViewModel.cs
+++ b/src/RevitCorrectNamingCheck/ViewModels/LinkedFileViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using dosymep.SimpleServices;
 using dosymep.WPF.ViewModels;
 
 using RevitCorrectNamingCheck.Models;
@@ -14,13 +15,16 @@ internal class LinkedFileViewModel : BaseViewModel {
     private WorksetInfoViewModel _instanceWorkset;
     private NameStatus _fileNameStatus;
 
-    public LinkedFileViewModel(LinkedFile linkedFile, ICollection<WorksetInfo> availableWorksets) {
+    public LinkedFileViewModel(
+        LinkedFile linkedFile,
+        ICollection<WorksetInfo> availableWorksets,
+        ILocalizationService localization) {
         LinkedFile = linkedFile ?? throw new ArgumentNullException(nameof(linkedFile));
         _isPinned = LinkedFile.IsPinned;
-        TypeWorkset = new WorksetInfoViewModel(LinkedFile.TypeWorkset);
-        InstanceWorkset = new WorksetInfoViewModel(LinkedFile.InstanceWorkset);
-        TypeWorksets = [..availableWorksets.Select(w => new WorksetInfoViewModel(w)).OrderBy(w => w.Name)];
-        InstanceWorksets = [..availableWorksets.Select(w => new WorksetInfoViewModel(w)).OrderBy(w => w.Name)];
+        TypeWorkset = new WorksetInfoViewModel(LinkedFile.TypeWorkset, localization);
+        InstanceWorkset = new WorksetInfoViewModel(LinkedFile.InstanceWorkset, localization);
+        TypeWorksets = [..availableWorksets.Select(w => new WorksetInfoViewModel(w, localization)).OrderBy(w => w.Name)];
+        InstanceWorksets = [..availableWorksets.Select(w => new WorksetInfoViewModel(w, localization)).OrderBy(w => w.Name)];
     }
 
     public LinkedFile LinkedFile { get; }

--- a/src/RevitCorrectNamingCheck/ViewModels/MainViewModel.cs
+++ b/src/RevitCorrectNamingCheck/ViewModels/MainViewModel.cs
@@ -55,7 +55,7 @@ internal class MainViewModel : BaseViewModel {
         var links = _revitRepository.GetLinkedFiles();
         var worksets = _revitRepository.GetUserWorksets().Select(w => new WorksetInfo(w.Key, w.Value)).ToArray();
         foreach(var link in links) {
-            var vm = new LinkedFileViewModel(link, worksets);
+            var vm = new LinkedFileViewModel(link, worksets, _localization);
             _linkedFileEnricher.Enrich(vm);
             LinkedFiles.Add(vm);
         }

--- a/src/RevitCorrectNamingCheck/ViewModels/WorksetInfoViewModel.cs
+++ b/src/RevitCorrectNamingCheck/ViewModels/WorksetInfoViewModel.cs
@@ -2,6 +2,7 @@ using System;
 
 using Autodesk.Revit.DB;
 
+using dosymep.SimpleServices;
 using dosymep.WPF.ViewModels;
 
 using RevitCorrectNamingCheck.Models;
@@ -10,10 +11,12 @@ namespace RevitCorrectNamingCheck.ViewModels;
 
 internal class WorksetInfoViewModel : BaseViewModel, IEquatable<WorksetInfoViewModel> {
     private readonly WorksetInfo _worksetInfo;
+    private readonly ILocalizationService _localization;
     private NameStatus _worksetNameStatus;
 
-    public WorksetInfoViewModel(WorksetInfo worksetInfo) {
+    public WorksetInfoViewModel(WorksetInfo worksetInfo, ILocalizationService localization) {
         _worksetInfo = worksetInfo ?? throw new ArgumentNullException(nameof(worksetInfo));
+        _localization = localization ?? throw new ArgumentNullException(nameof(localization));
     }
 
     public WorksetId Id => _worksetInfo.Id;
@@ -21,8 +24,21 @@ internal class WorksetInfoViewModel : BaseViewModel, IEquatable<WorksetInfoViewM
 
     public NameStatus WorksetNameStatus {
         get => _worksetNameStatus;
-        set => RaiseAndSetIfChanged(ref _worksetNameStatus, value);
+        set {
+            RaiseAndSetIfChanged(ref _worksetNameStatus, value);
+            OnPropertyChanged(nameof(ToolTip));
+        }
     }
+
+    /// <summary>
+    /// Локализованное описание статуса рабочего набора для всплывающей подсказки.
+    /// </summary>
+    public string ToolTip => _localization.GetLocalizedString(WorksetNameStatus switch {
+        NameStatus.Correct => "WorksetNameStatus.WorksetCorrect",
+        NameStatus.Incorrect => "WorksetNameStatus.Incorrect",
+        NameStatus.PartialCorrect => "WorksetNameStatus.PartialCorrect",
+        _ => "WorksetNameStatus.NoMatch"
+    });
 
     public bool Equals(WorksetInfoViewModel other) {
         if(other is null) {

--- a/src/RevitCorrectNamingCheck/Views/MainWindow.xaml
+++ b/src/RevitCorrectNamingCheck/Views/MainWindow.xaml
@@ -95,6 +95,7 @@
                                     ScrollViewer.VerticalScrollBarVisibility="Visible"
                                     ItemsSource="{Binding TypeWorksets}"
                                     SelectedItem="{Binding TypeWorkset, UpdateSourceTrigger=PropertyChanged}"
+                                    ToolTip="{Binding TypeWorkset.ToolTip}"
                                     ItemTemplateSelector="{StaticResource WorksetSelector}" />
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
@@ -116,6 +117,7 @@
                                     ScrollViewer.VerticalScrollBarVisibility="Visible"
                                     ItemsSource="{Binding InstanceWorksets}"
                                     SelectedItem="{Binding InstanceWorkset, UpdateSourceTrigger=PropertyChanged}"
+                                    ToolTip="{Binding InstanceWorkset.ToolTip}"
                                     ItemTemplateSelector="{StaticResource WorksetSelector}" />
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
# Обновления

- Исправлена ошибка получения рабочих наборов в отсоединенном файле
- Скорректирована логика назначения статусов для рабочих наборов и связей
- Для выбранного рабочего набора добавлено отображение tooltip