### PR TITLE
RevitMarkAllDocuments: Исправлены ошибки маркировки

### DIFF
--- a/src/RevitMarkAllDocuments/Models/RevitRepository.cs
+++ b/src/RevitMarkAllDocuments/Models/RevitRepository.cs
@@ -63,13 +63,11 @@ internal class RevitRepository {
         List<FilterableParam> filterableParams = [];
 
         foreach(var param in parameters) {
-            var filterableParam = new FilterableParam() { RevitParam = param };
-
-            if(elementTypes.Any(x => x.IsExistsParam(param))) {
-                filterableParam.IsTypeParam = true;
-            }
-
-            filterableParams.Add(filterableParam);
+            filterableParams.Add(
+                new FilterableParam() {
+                    RevitParam = param,
+                    IsTypeParam = IsTypeParam(param, elementTypes)
+                });
         }
 
         return filterableParams;
@@ -80,6 +78,14 @@ internal class RevitRepository {
             .GetFilterableParametersInCommon(Document, [category.Id])
             .Select(x => _revitParamFactory.Create(Document, x))
             .Where(p => p != null)];
+    }
+
+    private bool IsTypeParam(RevitParam param, ICollection<Element> elementTypes) {
+        var (definition, binding) = param.GetParamBinding(Document);
+
+        return definition is null
+            ? elementTypes.Any(x => x.IsExistsParam(param))
+            : binding is TypeBinding;
     }
 
     private ICollection<Element> GetElementTypes(Category category) {

--- a/src/RevitMarkAllDocuments/Services/DocumentService.cs
+++ b/src/RevitMarkAllDocuments/Services/DocumentService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 
@@ -6,15 +7,38 @@ using Autodesk.Revit.DB;
 namespace RevitMarkAllDocuments.Services;
 
 internal class DocumentService : IDocumentInterface {
+    private static readonly string[] _endings = ["_отсоединено", "_detached"];
+
     public string GetDocumentFullName(Document document) {
         if(document.IsWorkshared) {
             var modelPath = document.GetWorksharingCentralModelPath();
-            string path = ModelPathUtils.ConvertModelPathToUserVisiblePath(modelPath);
-
-            return ExtractFileName(path);
-        } else {
-            return Path.GetFileNameWithoutExtension(document.Title);
+            if(modelPath != null) {
+                string path = ModelPathUtils.ConvertModelPathToUserVisiblePath(modelPath);
+                string name = ExtractFileName(path);
+                if(!string.IsNullOrEmpty(name)) {
+                    return name;
+                }
+            }
         }
+
+        return GetTitleWithoutSuffixes(document);
+    }
+
+    /// <summary>
+    /// Возвращает имя документа без суффикса пользователя и суффикса "отсоединено"
+    /// </summary>
+    private string GetTitleWithoutSuffixes(Document document) {
+        string name = Path.GetFileNameWithoutExtension(document.Title);
+        string[] endings = [.. _endings, "_" + document.Application.Username];
+
+        foreach(string ending in endings) {
+            int index = name.IndexOf(ending, StringComparison.OrdinalIgnoreCase);
+            if(index > -1) {
+                name = name.Substring(0, index);
+            }
+        }
+
+        return name;
     }
 
     private string ExtractFileName(string path) {

--- a/src/RevitMarkAllDocuments/Views/Pages/MarkSettingsPage.xaml
+++ b/src/RevitMarkAllDocuments/Views/Pages/MarkSettingsPage.xaml
@@ -50,6 +50,7 @@
                         VerticalAlignment="Center"
                         Text="{me:LocalizationSource MarkPage.Param}" />
                     <ComboBox
+                        ScrollViewer.VerticalScrollBarVisibility="Visible"
                         ItemsSource="{Binding ParamsForMark}"
                         DisplayMemberPath="Name"
                         SelectedItem="{Binding SelectedParam}" />

--- a/src/RevitMarkAllDocuments/assets/Localization/Language.en-US.xaml
+++ b/src/RevitMarkAllDocuments/assets/Localization/Language.en-US.xaml
@@ -32,8 +32,8 @@
     <system:String x:Key="MarkPage.Settings">Set mark values</system:String>
     <system:String x:Key="MarkPage.Param">Parameter:</system:String>
     <system:String x:Key="MarkPage.StartNumber">Start value:</system:String>
-    <system:String x:Key="MarkPage.Prefix">Suffix:</system:String>
-    <system:String x:Key="MarkPage.Suffix">Prefix:</system:String>
+    <system:String x:Key="MarkPage.Prefix">Prefix:</system:String>
+    <system:String x:Key="MarkPage.Suffix">Suffix:</system:String>
     
     <system:String x:Key="MarkList.HeaderId">Id</system:String>
     <system:String x:Key="MarkList.HeaderName">Family name</system:String>

--- a/src/RevitMarkAllDocuments/assets/Localization/Language.ru-RU.xaml
+++ b/src/RevitMarkAllDocuments/assets/Localization/Language.ru-RU.xaml
@@ -32,8 +32,8 @@
     <system:String x:Key="MarkPage.Settings">Настройте параметры для значений марок</system:String>
     <system:String x:Key="MarkPage.Param">Параметр:</system:String>
     <system:String x:Key="MarkPage.StartNumber">Начальный номер:</system:String>
-    <system:String x:Key="MarkPage.Prefix">Суффикс:</system:String>
-    <system:String x:Key="MarkPage.Suffix">Префикс:</system:String>
+    <system:String x:Key="MarkPage.Prefix">Префикс:</system:String>
+    <system:String x:Key="MarkPage.Suffix">Суффикс:</system:String>
     
     <system:String x:Key="MarkList.HeaderId">Id</system:String>
     <system:String x:Key="MarkList.HeaderName">Имя семейства</system:String>


### PR DESCRIPTION
# Исправления

- Исправлены лэйблы для суффикса и префикса в окне
- Исправлено получение названий документов
- Дополнен список параметров для маркировки
- Исправлена ошибка маркировки элементов в отсоединенном файле

