### PR TITLE
RevitPylonLoadAreas: Нескольких элементов перекрытий теперь считаются одним физическим перекрытием

### DIFF
--- a/src/RevitPylonLoadAreas/FindPylonLoadAreasCommand.cs
+++ b/src/RevitPylonLoadAreas/FindPylonLoadAreasCommand.cs
@@ -72,12 +72,12 @@ public class FindPylonLoadAreasCommand : BasePluginCommand {
 
         ValidateView(repo, msg, localization);
         ValidateParams(repo, msg, localization);
-        var floor = repo.PickFloor(localization.GetLocalizedString("Pick.Floor"));
+        var floors = repo.PickFloors(localization.GetLocalizedString("Pick.Floors"));
         var pylons = repo.GetPylonsFromView();
         var walls = repo.GetWallsFromView();
 
         var loadAreasFinder = kernel.Get<LoadAreasFinder>();
-        var loadAreas = loadAreasFinder.Process(floor, pylons, walls);
+        var loadAreas = loadAreasFinder.Process(floors, pylons, walls);
 
         var drawer = kernel.Get<FilledRegionDrawer>();
         using var t = repo.Document.StartTransaction(localization.GetLocalizedString("Transaction.DrawLoadAreas"));

--- a/src/RevitPylonLoadAreas/GetLandThicknessOnLoadAreaCommand.cs
+++ b/src/RevitPylonLoadAreas/GetLandThicknessOnLoadAreaCommand.cs
@@ -145,12 +145,7 @@ public class GetLandThicknessOnLoadAreaCommand : BasePluginCommand {
         var walls = repo.GetWallsFromView();
 
         var loadAreasFinder = kernel.Get<LoadAreasFinder>();
-        List<LoadArea> loadAreas = [];
-        foreach(var floor in floors) {
-            loadAreas.AddRange(loadAreasFinder.Process(floor, pylons, walls).Where(l => l.ElementIsPylon()));
-        }
-
-        return loadAreas;
+        return loadAreasFinder.Process(floors, pylons, walls).Where(l => l.ElementIsPylon()).ToArray();
     }
 
     private void ShowError(IMessageBoxService msg, string str) {

--- a/src/RevitPylonLoadAreas/Models/Geometry/LoadArea.cs
+++ b/src/RevitPylonLoadAreas/Models/Geometry/LoadArea.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Autodesk.Revit.DB;
 
@@ -12,7 +13,6 @@ namespace RevitPylonLoadAreas.Models.Geometry;
 /// </summary>
 internal sealed class LoadArea {
     private readonly RevitRepository _repo;
-    private PlanarFace _face;
     private Solid _solid;
 
     /// <summary>
@@ -20,7 +20,7 @@ internal sealed class LoadArea {
     /// </summary>
     /// <param name="element">Вертикальный элемент</param>
     /// <param name="repo">Репозиторий Revit</param>
-    /// <param name="circuits">Список контуров грузовой площади в плоскости XOY. Первый контур - наружный, остальные - отверстия</param>
+    /// <param name="circuits">Список контуров грузовой площади в плоскости XOY</param>
     public LoadArea(Element element, RevitRepository repo, IList<CurveLoop> circuits) {
         _repo = repo ?? throw new ArgumentNullException(nameof(repo));
         Element = element ?? throw new ArgumentNullException(nameof(element));
@@ -43,7 +43,7 @@ internal sealed class LoadArea {
     /// Возвращает площадь в единицах Revit
     /// </summary>
     public double GetArea() {
-        return GetFace().Area;
+        return _repo.GetBottomFaces(GetSolid()).Sum(f => f.Area);
     }
 
     public bool Intersects(Polygon2D polygon) {
@@ -52,10 +52,6 @@ internal sealed class LoadArea {
         return BooleanOperationsUtils.ExecuteBooleanOperation(polygonSolid, solid, BooleanOperationsType.Intersect)
                    .Volume
                > 0;
-    }
-
-    private PlanarFace GetFace() {
-        return _face ??= _repo.GetBottomFace(GetSolid());
     }
 
     private Solid GetSolid() {

--- a/src/RevitPylonLoadAreas/Models/Geometry/Voronoi/FaceVoronoiData.cs
+++ b/src/RevitPylonLoadAreas/Models/Geometry/Voronoi/FaceVoronoiData.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Autodesk.Revit.DB;
+
+using RevitPylonLoadAreas.Services;
+
+namespace RevitPylonLoadAreas.Models.Geometry.Voronoi;
+
+internal class FaceVoronoiData {
+    private readonly RevitRepository _repo;
+    private readonly CurveLoopsSimplifier _simplifier;
+
+    /// <summary>
+    /// Пороговая площадь, меньше которой отверстия не учитываются
+    /// </summary>
+    private readonly double _openingsAreaThreshold;
+
+    /// <summary>
+    /// Исходная нижняя грань перекрытия
+    /// </summary>
+    private readonly PlanarFace _sourceFace;
+
+    /// <summary>
+    /// Контур грани в плоскости XOY для построения грузовых площадей с учетом заданной пороговой площади отверстий
+    /// </summary>
+    private IList<CurveLoop> _voronoiOutline;
+
+    /// <summary>
+    /// Грань для построения диаграммы Вороного с учетом заданной пороговой площади отверстий
+    /// </summary>
+    private PlanarFace _voronoiFace;
+
+    /// <summary>
+    /// Поверхность <see cref="_voronoiFace"/>
+    /// </summary>
+    private Surface _voronoiSurface;
+
+    /// <summary>
+    /// Солид грани с учетом заданной пороговой площади отверстий
+    /// </summary>
+    private Solid _voronoiSolid;
+
+    /// <summary>
+    /// Конструирует нижнюю грань перекрытия для построения на ней диаграммы Вороного
+    /// </summary>
+    /// <param name="face">Нижняя грань перекрытия</param>
+    /// <param name="repo">Revit репозиторий</param>
+    /// <param name="openingsAreaThreshold">Площадь отверстий в единицах Revit, меньше которой они не учитываются</param>
+    public FaceVoronoiData(PlanarFace face, RevitRepository repo, double openingsAreaThreshold) {
+        _sourceFace = face ?? throw new ArgumentNullException(nameof(face));
+        _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+        _openingsAreaThreshold = openingsAreaThreshold;
+        _simplifier = new CurveLoopsSimplifier();
+    }
+
+    public bool IsInside(XY point) {
+        var face = GetVoronoiFace();
+        _voronoiSurface ??= face.GetSurface();
+        _voronoiSurface.Project(point.AsXYZ(), out var uv, out _);
+        return face.IsInside(uv);
+    }
+
+    /// <summary>
+    /// Возвращает солид грани в плоскости XOY с учетом заданной пороговой площади отверстий,
+    /// по которому производится обрезка ячеек диаграммы Вороного
+    /// </summary>
+    public Solid GetVoronoiSolid() {
+        return _voronoiSolid ??= _repo.CreateSolid(1, [..GetVoronoiOutline()]);
+    }
+
+    /// <summary>
+    /// Возвращает список контуров грани в плоскости XOY с учетом заданной пороговой площади отверстий
+    /// </summary>
+    /// <returns>Первая петля - наружняя, остальные - отверстия, удовлетворяющие допуску</returns>
+    private IList<CurveLoop> GetVoronoiOutline() {
+        if(_voronoiOutline is not null) {
+            return _voronoiOutline;
+        }
+
+        double z = _sourceFace.Evaluate(new UV(0, 0)).Z;
+        var transform = Transform.CreateTranslation(new XYZ(0, 0, -z));
+        _voronoiOutline = _simplifier.GetEdgesAsSimplifiedCurveLoops(_sourceFace)
+            .Where(l => _repo.GetArea(l) >= _openingsAreaThreshold)
+            .Select(l => CurveLoop.CreateViaTransform(l, transform))
+            .OrderBy(l => l.Sum(c => c.Length))
+            .ToArray();
+        return _voronoiOutline;
+    }
+
+    private PlanarFace GetVoronoiFace() {
+        return _voronoiFace ??= _repo.GetBottomFace(GetVoronoiSolid());
+    }
+}

--- a/src/RevitPylonLoadAreas/Models/Geometry/Voronoi/FloorVoronoiData.cs
+++ b/src/RevitPylonLoadAreas/Models/Geometry/Voronoi/FloorVoronoiData.cs
@@ -12,7 +12,6 @@ namespace RevitPylonLoadAreas.Models.Geometry.Voronoi;
 
 internal class FloorVoronoiData {
     private readonly RevitRepository _repo;
-    private readonly CurveLoopsSimplifier _simplifier;
 
     /// <summary>
     /// Пороговая площадь, меньше которой отверстия не учитываются
@@ -20,24 +19,9 @@ internal class FloorVoronoiData {
     private readonly double _openingsAreaThreshold;
 
     /// <summary>
-    /// Контур перекрытия в плоскости XOY для построения грузовых площадей с учетом заданной пороговой площади отверстий
+    /// Данные диаграммы Вороного для каждой нижней грани солида перекрытия
     /// </summary>
-    private IList<CurveLoop> _outline;
-
-    /// <summary>
-    /// Грань перекрытия для построения грузовых площадей с учетом заданной пороговой площади отверстий
-    /// </summary>
-    private PlanarFace _face;
-
-    /// <summary>
-    /// Поверхность <see cref="_face"/>
-    /// </summary>
-    private Surface _surface;
-
-    /// <summary>
-    /// Солид перекрытия с учетом заданной пороговой площади отверстий
-    /// </summary>
-    private Solid _solid;
+    private IList<FaceVoronoiData> _facesData;
 
     /// <summary>
     /// Конструирует перекрытие для построения на нём диаграммы Вороного
@@ -49,82 +33,33 @@ internal class FloorVoronoiData {
         _repo = repo ?? throw new ArgumentNullException(nameof(repo));
         _openingsAreaThreshold = openingsAreaThreshold;
         Floor = floor ?? throw new ArgumentNullException(nameof(floor));
-        _simplifier = new CurveLoopsSimplifier();
     }
 
     public Floor Floor { get; }
 
     public bool IsInside(XY point) {
-        var face = GetVoronoiFace();
-        _surface ??= face.GetSurface();
-        _surface.Project(point.AsXYZ(), out var uv, out _);
-        return face.IsInside(uv);
+        return GetFacesData().Any(f => f.IsInside(point));
     }
 
-    /// <summary>
-    /// Обрезает ячейку диаграммы Вороного по контуру перекрытием с учетом заданной пороговой площади отверстий
-    /// </summary>
-    /// <param name="cell">Ячейка диаграммы Вороного</param>
-    /// <returns>Список петель в плоскости XOY плоской фигуры, полученной после обрезки</returns>
-    public IList<CurveLoop> Clip(VoronoiCell cell) {
-        var cellSolid = _repo.CreateSolid(1, cell.Polygon.AsCurveLoop());
-        var floorSolid = GetVoronoiSolid();
-        var intersection = _repo.Intersect(cellSolid, floorSolid);
-        var bottomFace = _repo.GetBottomFace(intersection);
-        return _simplifier.GetEdgesAsSimplifiedCurveLoops(bottomFace);
-    }
-
-    /// <summary>
-    /// Объединяет заданные ячейки и обрезает их по контуру перекрытия с учетом заданной пороговой площади отверстий
-    /// </summary>
-    /// <param name="wallCells">Ячейки диаграммы Вороного, построенные для одной стены</param>
-    /// <returns>Список петель ячейки диаграммы для всей стены в плоскости XOY</returns>
-    public IList<CurveLoop> Clip(IList<VoronoiCell> wallCells) {
-        var unitedSolid = CreateUnitedSolid(wallCells);
-        var intersection = _repo.Intersect(unitedSolid, GetVoronoiSolid());
-        var bottomFaces = _repo.GetBottomFaces(intersection);
-        return bottomFaces.SelectMany(f => _simplifier.GetEdgesAsSimplifiedCurveLoops(f)).ToArray();
-    }
-
-    private Solid CreateUnitedSolid(IList<VoronoiCell> cells) {
-        var solid = _repo.CreateSolid(1, cells[0].Polygon.AsCurveLoop());
-        for(int i = 1; i < cells.Count; i++) {
-            var isolid = _repo.CreateSolid(1, cells[i].Polygon.AsCurveLoop());
-            solid = _repo.Unite(solid, isolid);
+    public Solid GetVoronoiSolid() {
+        var faces = GetFacesData();
+        var solid = faces.First().GetVoronoiSolid();
+        for(int i = 1; i < faces.Count; i++) {
+            solid = _repo.Unite(solid, faces[i].GetVoronoiSolid());
         }
 
         return solid;
     }
 
-    /// <summary>
-    /// Возвращает список контуров перекрытия в плоскости XOY с учетом заданной пороговой площади отверстий
-    /// </summary>
-    /// <returns>Первая петля - наружняя, остальные - отверстия, удовлетворяющие допуску</returns>
-    private IList<CurveLoop> GetVoronoiOutline() {
-        if(_outline is not null) {
-            return _outline;
+    private IList<FaceVoronoiData> GetFacesData() {
+        if(_facesData is not null) {
+            return _facesData;
         }
 
-        // у 1 элемента перекрытия должно быть только 1 тело
-        var solid = Floor.GetSolids()
-            .OrderByDescending(s => s.Volume)
-            .First();
-        var bottomFace = _repo.GetBottomFace(solid);
-        double z = bottomFace.Evaluate(new UV(0, 0)).Z;
-        var transform = Transform.CreateTranslation(new XYZ(0, 0, -z));
-        _outline = _simplifier.GetEdgesAsSimplifiedCurveLoops(bottomFace)
-            .Where(l => _repo.GetArea(l) >= _openingsAreaThreshold)
-            .Select(l => CurveLoop.CreateViaTransform(l, transform))
-            .OrderBy(l => l.Sum(c => c.Length))
+        var solids = Floor.GetSolids();
+        _facesData = solids.SelectMany(s => _repo.GetBottomFaces(s))
+            .Select(f => new FaceVoronoiData(f, _repo, _openingsAreaThreshold))
             .ToArray();
-        return _outline;
-    }
-
-    private PlanarFace GetVoronoiFace() {
-        return _face ??= _repo.GetBottomFace(GetVoronoiSolid());
-    }
-
-    private Solid GetVoronoiSolid() {
-        return _solid ??= _repo.CreateSolid(1, [..GetVoronoiOutline()]);
+        return _facesData;
     }
 }

--- a/src/RevitPylonLoadAreas/Models/RevitRepository.cs
+++ b/src/RevitPylonLoadAreas/Models/RevitRepository.cs
@@ -112,6 +112,9 @@ internal class RevitRepository {
     }
 
     public Solid CreateUnitedSolid(IList<Solid> solids) {
+        if(solids.Count == 0) {
+            throw new ArgumentOutOfRangeException(nameof(solids));
+        }
         var solid = solids[0];
         for(int i = 1; i < solids.Count; i++) {
             solid = Unite(solid, solids[i]);

--- a/src/RevitPylonLoadAreas/Models/RevitRepository.cs
+++ b/src/RevitPylonLoadAreas/Models/RevitRepository.cs
@@ -16,7 +16,6 @@ using RevitPylonLoadAreas.Models.Selection;
 namespace RevitPylonLoadAreas.Models;
 
 internal class RevitRepository {
-
     public RevitRepository(UIApplication uiApplication) {
         UIApplication = uiApplication ?? throw new ArgumentNullException(nameof(uiApplication));
     }
@@ -28,14 +27,6 @@ internal class RevitRepository {
     public Application Application => UIApplication.Application;
     public Document Document => ActiveUIDocument.Document;
     public View ActiveView => ActiveUIDocument.ActiveView;
-
-    public Floor PickFloor(string statusPrompt) {
-        var reference = ActiveUIDocument.Selection.PickObject(
-            ObjectType.Element,
-            new FloorSelectionFilter(),
-            statusPrompt);
-        return (Floor) Document.GetElement(reference);
-    }
 
     public ICollection<Floor> PickFloors(string statusPrompt) {
         var reference = ActiveUIDocument.Selection.PickObjects(
@@ -120,6 +111,15 @@ internal class RevitRepository {
             BooleanOperationsType.Union);
     }
 
+    public Solid CreateUnitedSolid(IList<Solid> solids) {
+        var solid = solids[0];
+        for(int i = 1; i < solids.Count; i++) {
+            solid = Unite(solid, solids[i]);
+        }
+
+        return solid;
+    }
+
     /// <summary>
     /// Возвращает все видимые несущие колонны с активного вида
     /// </summary>
@@ -147,7 +147,8 @@ internal class RevitRepository {
     /// Показывает и выделяет заданные элементы на активном виде
     /// </summary>
     public void ShowElements(params Element[] elements) {
-        if(elements is null || elements.Length == 0) {
+        if(elements is null
+           || elements.Length == 0) {
             return;
         }
 

--- a/src/RevitPylonLoadAreas/Models/Selection/FloorSelectionFilter.cs
+++ b/src/RevitPylonLoadAreas/Models/Selection/FloorSelectionFilter.cs
@@ -13,9 +13,8 @@ internal sealed class FloorSelectionFilter : ISelectionFilter {
             return false;
         }
 
-        // допустимы только перекрытия с 1 телом, у которых есть нижняя горизонтальная грань
+        // допустимы только перекрытия, у которых есть нижняя горизонтальная грань
         var solids = elem.GetSolids()
-            ?.SelectMany(SolidUtils.SplitVolumes)
             ?.Where(s => s?.GetVolumeOrDefault(0) > 0)
             ?.ToArray();
         if(solids?.Length != 1) {
@@ -24,10 +23,9 @@ internal sealed class FloorSelectionFilter : ISelectionFilter {
 
         // должна быть нижняя горизонтальная грань
         return solids[0]
-                   .Faces
-                   .OfType<PlanarFace>()
-                   .FirstOrDefault(f => f.FaceNormal.IsAlmostEqualTo(-XYZ.BasisZ))
-               != null;
+            .Faces
+            .OfType<PlanarFace>()
+            .Any(f => f.FaceNormal.IsAlmostEqualTo(-XYZ.BasisZ));
     }
 
     public bool AllowReference(Reference reference, XYZ position) {

--- a/src/RevitPylonLoadAreas/Services/LoadAreasFinder.cs
+++ b/src/RevitPylonLoadAreas/Services/LoadAreasFinder.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Autodesk.Revit.DB;
 
 using dosymep.Revit;
+using dosymep.Revit.Geometry;
 
 using RevitPylonLoadAreas.Models;
 using RevitPylonLoadAreas.Models.Geometry;
@@ -16,6 +17,7 @@ internal sealed class LoadAreasFinder {
     private readonly SystemConfig _config;
     private readonly RevitRepository _repo;
     private readonly VoronoiBuilder _voronoiBuilder;
+    private readonly CurveLoopsSimplifier _simplifier;
 
     public LoadAreasFinder(
         SystemConfig config,
@@ -24,12 +26,23 @@ internal sealed class LoadAreasFinder {
         _config = config ?? throw new ArgumentNullException(nameof(config));
         _repo = repo ?? throw new ArgumentNullException(nameof(repo));
         _voronoiBuilder = voronoiBuilder ?? throw new ArgumentNullException(nameof(voronoiBuilder));
+        _simplifier = new CurveLoopsSimplifier();
     }
 
-    public ICollection<LoadArea> Process(Floor floor, ICollection<FamilyInstance> pylons, ICollection<Wall> walls) {
-        var floorData = new FloorVoronoiData(floor, _repo, _config.GetOpeningMinArea());
-        var sites = GetSites(floorData, pylons, walls);
-        var elementsCells = _voronoiBuilder.Build(sites, new BoundingBoxXY(floorData.Floor.GetBoundingBox()))
+    public ICollection<LoadArea> Process(
+        ICollection<Floor> floors,
+        ICollection<FamilyInstance> pylons,
+        ICollection<Wall> walls) {
+        if(floors is null
+           || floors.Count == 0) {
+            throw new ArgumentOutOfRangeException(nameof(floors));
+        }
+
+        var floorsData = floors
+            .Select(f => new FloorVoronoiData(f, _repo, _config.GetOpeningMinArea()))
+            .ToArray();
+        var sites = GetSites(floorsData, pylons, walls);
+        var elementsCells = _voronoiBuilder.Build(sites, GetBoundingBox(floors))
             .GroupBy(c => c.Site.Element.Id)
             .ToArray();
 
@@ -39,9 +52,9 @@ internal sealed class LoadAreasFinder {
             IList<CurveLoop> loops;
             var element = cells[0].Site.Element;
             if(cells.Length == 1) {
-                loops = floorData.Clip(cells[0]);
+                loops = Clip(cells[0], floorsData);
             } else {
-                loops = floorData.Clip(cells);
+                loops = Clip(cells, floorsData);
             }
 
             loadAreas.Add(new LoadArea(element, _repo, loops));
@@ -50,22 +63,51 @@ internal sealed class LoadAreasFinder {
         return loadAreas;
     }
 
+    private BoundingBoxXY GetBoundingBox(ICollection<Floor> floors) {
+        var bboxXyz = floors
+            .Select(f => f.GetBoundingBox())
+            .ToArray()
+            .CreateUnitedBoundingBox();
+        return new BoundingBoxXY(bboxXyz);
+    }
+
+    private IList<CurveLoop> Clip(VoronoiCell cell, FloorVoronoiData[] floorsData) {
+        var cellSolid = _repo.CreateSolid(1, cell.Polygon.AsCurveLoop());
+        var floorsUnitedSolid = _repo.CreateUnitedSolid(floorsData.Select(f => f.GetVoronoiSolid()).ToArray());
+        return GetIntersectionLoops(cellSolid, floorsUnitedSolid);
+    }
+
+    private IList<CurveLoop> Clip(VoronoiCell[] wallCells, FloorVoronoiData[] floorsData) {
+        var cellUnitedSolid = _repo.CreateUnitedSolid(
+            wallCells.Select(c => _repo.CreateSolid(1, c.Polygon.AsCurveLoop()))
+                .ToArray());
+        var floorsUnitedSolid = _repo.CreateUnitedSolid(floorsData.Select(f => f.GetVoronoiSolid()).ToArray());
+        return GetIntersectionLoops(cellUnitedSolid, floorsUnitedSolid);
+    }
+
+    private IList<CurveLoop> GetIntersectionLoops(Solid left, Solid right) {
+        var intersection = _repo.Intersect(left, right);
+        var bottomFaces = _repo.GetBottomFaces(intersection);
+        return bottomFaces.SelectMany(f => _simplifier.GetEdgesAsSimplifiedCurveLoops(f)).ToArray();
+    }
+
     private IList<VoronoiSite> GetSites(
-        FloorVoronoiData floorData,
+        ICollection<FloorVoronoiData> floorsData,
         ICollection<FamilyInstance> pylons,
         ICollection<Wall> walls) {
         List<VoronoiSite> sites = [];
 
         foreach(var pylon in pylons) {
             var pylonPoint = new XY(((LocationPoint) pylon.Location).Point);
-            if(floorData.IsInside(pylonPoint)) {
+            if(floorsData.Any(fd => fd.IsInside(pylonPoint))) {
                 sites.Add(new VoronoiSite(pylonPoint, pylon));
             }
         }
 
         foreach(var wall in walls) {
             var wallPoints = GetWallPoints(wall);
-            sites.AddRange(wallPoints.Where(floorData.IsInside).Select(p => new VoronoiSite(p, wall)));
+            sites.AddRange(
+                wallPoints.Where(p => floorsData.Any(fd => fd.IsInside(p))).Select(p => new VoronoiSite(p, wall)));
         }
 
         return sites;

--- a/src/RevitPylonLoadAreas/assets/Localization/Language.en-US.xaml
+++ b/src/RevitPylonLoadAreas/assets/Localization/Language.en-US.xaml
@@ -7,8 +7,6 @@
         x:Key="Plugin.Title">Load Areas</system:String>
 
     <system:String
-        x:Key="Pick.Floor">Select a floor</system:String>
-    <system:String
         x:Key="Pick.Floors">Select one or many floors</system:String>
 
     <system:String

--- a/src/RevitPylonLoadAreas/assets/Localization/Language.ru-RU.xaml
+++ b/src/RevitPylonLoadAreas/assets/Localization/Language.ru-RU.xaml
@@ -7,8 +7,6 @@
         x:Key="Plugin.Title">Грузовые площади</system:String>
 
     <system:String
-        x:Key="Pick.Floor">Выберите плиту перекрытия</system:String>
-    <system:String
         x:Key="Pick.Floors">Выберите одно или несколько перекрытий</system:String>
 
     <system:String


### PR DESCRIPTION
# Изменения

Для кнопок "Грузовая площадь" и "Толщина БИО" изменена логика выбора перекрытий:
- теперь в обеих командах выбираются несколько элементов перекрытий и они считаются одним физическим перекрытием.
- при выборе перекрытий теперь допустимо выбирать элементы с несколькими контурами