### PR TITLE
RevitDeclarations: Добавление условий по определению мастер-спальни

### DIFF
--- a/src/RevitDeclarations/Models/Rooms/RoomElement.cs
+++ b/src/RevitDeclarations/Models/Rooms/RoomElement.cs
@@ -87,10 +87,10 @@ internal class RoomElement {
             : RevitRoom.GetParamValueOrDefault<int>(parameter.Definition.Name);
     }
 
-    public IReadOnlyList<ElementId> GetBoundaries() {
-        return RevitRoom.GetBoundarySegments(SpatialElementExtensions.DefaultBoundaryOptions)
-            .SelectMany(item => item)
-            .Select(item => item.ElementId)
+    public IReadOnlyList<BoundarySegment> GetBoundaries() {
+        return RevitRoom
+            .GetBoundarySegments(SpatialElementExtensions.DefaultBoundaryOptions)
+            .SelectMany(x => x)
             .ToList();
     }
 

--- a/src/RevitDeclarations/Models/Rooms/Separators/CurveRoomSeparator.cs
+++ b/src/RevitDeclarations/Models/Rooms/Separators/CurveRoomSeparator.cs
@@ -2,6 +2,8 @@ using System.Linq;
 
 using Autodesk.Revit.DB;
 
+using dosymep.Revit;
+
 namespace RevitDeclarations.Models;
 internal class CurveRoomSeparator : RoomSeparator {
     private readonly CurveElement _curve;
@@ -15,8 +17,41 @@ internal class CurveRoomSeparator : RoomSeparator {
     }
 
     private void AddRoom(RoomElement room) {
-        if(room.GetBoundaries().Contains(_curve.Id)) {
-            Rooms.Add(room.RevitRoom);
+        var roomSegments = room.GetBoundaries()
+            .Where(x => x.ElementId == _curve.Id)
+            .ToList();
+
+        if(roomSegments.Count == 0) {
+            return;
         }
+
+        if(Rooms.Count == 0) {
+            Rooms.Add(room.RevitRoom);
+            return;
+        }
+
+        foreach(var addedRoom in Rooms) {
+            var addedSegments = addedRoom
+                .GetBoundarySegments(SpatialElementExtensions.DefaultBoundaryOptions)
+                .SelectMany(x => x)
+                .Where(x => x.ElementId == _curve.Id);
+
+            if(!roomSegments.Any(x => addedSegments.Any(y => IsIntersectSegment(x, y)))) {
+                continue;
+            }
+
+            Rooms.Add(room.RevitRoom);
+            return;
+        }
+    }
+    
+    private static bool IsIntersectSegment(BoundarySegment first, BoundarySegment second) {
+        var result = first.GetCurve().Intersect(second.GetCurve());
+
+        return result 
+            is SetComparisonResult.Overlap 
+            or SetComparisonResult.Equal 
+            or SetComparisonResult.Subset 
+            or SetComparisonResult.Superset;
     }
 }


### PR DESCRIPTION
Добавлена проверка на пересечения ограничивающих сегментов комнат. 
Если есть общий разделитель и помещения пересекаются, тогда считать помещения смежными.