### PR TITLE
RevitServerFolders: Обновление UI

### DIFF
--- a/src/RevitServerFolders/Behaviors/DataGridSelectedItemsProperty.cs
+++ b/src/RevitServerFolders/Behaviors/DataGridSelectedItemsProperty.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace RevitServerFolders.Behaviors;
+
+internal static class DataGridSelectedItemsProperty {
+    public static readonly DependencyProperty SelectedItemsProperty =
+        DependencyProperty.RegisterAttached(
+            "SelectedItems",
+            typeof(IList),
+            typeof(DataGridSelectedItemsProperty),
+            new FrameworkPropertyMetadata(default, OnSelectedItemsChanged));
+
+    public static IList GetSelectedItems(DataGrid dataGrid) {
+        return (IList) dataGrid.GetValue(SelectedItemsProperty);
+    }
+
+    public static void SetSelectedItems(DataGrid dataGrid, IList value) {
+        dataGrid.SetValue(SelectedItemsProperty, value);
+    }
+
+    private static void OnSelectedItemsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+        if(d is DataGrid dataGrid) {
+            dataGrid.SelectionChanged -= OnSelectionChanged;
+            dataGrid.SelectionChanged += OnSelectionChanged;
+        }
+    }
+
+    private static void OnSelectionChanged(object sender, SelectionChangedEventArgs e) {
+        if(sender is DataGrid dataGrid) {
+            IList selectedItems = GetSelectedItems(dataGrid);
+            selectedItems.Clear();
+            foreach(var item in dataGrid.SelectedItems) {
+                selectedItems.Add(item);
+            }
+        }
+    }
+}

--- a/src/RevitServerFolders/Behaviors/GridViewColumnHeaderProperty.cs
+++ b/src/RevitServerFolders/Behaviors/GridViewColumnHeaderProperty.cs
@@ -1,0 +1,42 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+
+namespace RevitServerFolders.Behaviors;
+/// <summary>
+/// Прикрепляемое свойство для запрета изменения ширины столбца <see cref="GridView"/>.
+/// У <see cref="GridViewColumnHeader"/> нет своего свойства для этого,
+/// поэтому скрывается ползунок из шаблона шапки.
+/// </summary>
+internal static class GridViewColumnHeaderProperty {
+    public static readonly DependencyProperty CanUserResizeProperty =
+        DependencyProperty.RegisterAttached(
+            "CanUserResize",
+            typeof(bool),
+            typeof(GridViewColumnHeaderProperty),
+            new FrameworkPropertyMetadata(true, OnCanUserResizeChanged));
+
+    public static bool GetCanUserResize(GridViewColumnHeader header) {
+        return (bool) header.GetValue(CanUserResizeProperty);
+    }
+
+    public static void SetCanUserResize(GridViewColumnHeader header, bool value) {
+        header.SetValue(CanUserResizeProperty, value);
+    }
+
+    private static void OnCanUserResizeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+        if(d is GridViewColumnHeader header) {
+            header.Loaded -= OnHeaderLoaded;
+            if(e.NewValue is false) {
+                header.Loaded += OnHeaderLoaded;
+            }
+        }
+    }
+
+    private static void OnHeaderLoaded(object sender, RoutedEventArgs e) {
+        var header = (GridViewColumnHeader) sender;
+        if(header.Template?.FindName("PART_HeaderGripper", header) is Thumb gripper) {
+            gripper.Visibility = Visibility.Collapsed;
+        }
+    }
+}

--- a/src/RevitServerFolders/Converters/MiddleEllipsisConverter.cs
+++ b/src/RevitServerFolders/Converters/MiddleEllipsisConverter.cs
@@ -7,15 +7,25 @@ using System.Windows.Media;
 
 namespace RevitServerFolders.Converters;
 /// <summary>
-/// Конвертирует длинный текст из TextBlock в соответствии с текущей шириной этого TextBlock:
+/// Конвертирует длинный текст из TextBlock в соответствии с заданной шириной:
 /// "Очень длинная строка, которая не помещается на экран" => "Очень длинная...на экран"
 /// </summary>
+/// <remarks>
+/// Третье значение — доступная ширина. В параметре можно передать отступ в пикселях,
+/// который будет из нее вычтен: это нужно, когда ширина берется не у самого TextBlock,
+/// а у контейнера, в котором рядом с текстом лежат другие элементы.
+/// </remarks>
 internal class MiddleEllipsisConverter : IMultiValueConverter {
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture) {
         if(values[0] is not string text
             || values[1] is not TextBlock textBlock
             || values[2] is not double actualWidth) {
             return DependencyProperty.UnsetValue;
+        }
+
+        if(parameter is string offsetText
+           && double.TryParse(offsetText, NumberStyles.Any, CultureInfo.InvariantCulture, out double offset)) {
+            actualWidth -= offset;
         }
         if(string.IsNullOrWhiteSpace(text) || actualWidth <= 0) {
             return text;

--- a/src/RevitServerFolders/Converters/MiddleEllipsisConverter.cs
+++ b/src/RevitServerFolders/Converters/MiddleEllipsisConverter.cs
@@ -7,26 +7,55 @@ using System.Windows.Media;
 
 namespace RevitServerFolders.Converters;
 /// <summary>
-/// Конвертирует длинный текст из TextBlock в соответствии с заданной шириной:
-/// "Очень длинная строка, которая не помещается на экран" => "Очень длинная...на экран"
+/// Сокращает длинный текст многоточием посередине по ширине, доступной под него:
+/// "Очень длинная строка, которая не помещается на экран" => "Очень длинная...на экран".
+/// Если текст помещается целиком, возвращается как есть.
 /// </summary>
 /// <remarks>
-/// Третье значение — доступная ширина. В параметре можно передать отступ в пикселях,
-/// который будет из нее вычтен: это нужно, когда ширина берется не у самого TextBlock,
-/// а у контейнера, в котором рядом с текстом лежат другие элементы.
+/// Принимает ровно четыре значения, по порядку:
+/// <list type="number">
+/// <item>
+/// <term>текст </term>
+/// <description><see cref="string"/> — исходная строка, которую надо сократить.</description>
+/// </item>
+/// <item>
+/// <term>элемент</term>
+/// <description>
+/// <see cref="TextBlock"/>, в котором текст отображается. Нужен только чтобы посчитать
+/// ширину строки его шрифтом, поэтому передается через <c>RelativeSource Self</c>.
+/// </description>
+/// </item>
+/// <item>
+/// <term>ширина контейнера</term>
+/// <description>
+/// <see cref="double"/> — ширина места, отведенного под строку.
+/// Брать <c>ActualWidth</c> у самого <see cref="TextBlock"/> нельзя, если он лежит в
+/// <c>GridView</c>: там это ширина текста, а не выделенного под него места, и сокращение
+/// никогда не сработает. Поэтому передается ширина контейнера, например колонки.
+/// </description>
+/// </item>
+/// <item>
+/// <term>отступ</term>
+/// <description>
+/// <see cref="double"/> — сколько пикселей вычесть из предыдущего значения:
+/// ширина соседних элементов контейнера и отступов, то есть все, что занято не текстом.
+/// </description>
+/// </item>
+/// </list>
+/// Если значений не четыре или тип любого из них не совпал,
+/// возвращается <see cref="DependencyProperty.UnsetValue"/>.
 /// </remarks>
 internal class MiddleEllipsisConverter : IMultiValueConverter {
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture) {
-        if(values[0] is not string text
-            || values[1] is not TextBlock textBlock
-            || values[2] is not double actualWidth) {
+        if(values is not { Length: 4 }
+           || values[0] is not string text
+           || values[1] is not TextBlock textBlock
+           || values[2] is not double actualWidth
+           || values[3] is not double offset) {
             return DependencyProperty.UnsetValue;
         }
 
-        if(parameter is string offsetText
-           && double.TryParse(offsetText, NumberStyles.Any, CultureInfo.InvariantCulture, out double offset)) {
-            actualWidth -= offset;
-        }
+        actualWidth -= offset;
         if(string.IsNullOrWhiteSpace(text) || actualWidth <= 0) {
             return text;
         }

--- a/src/RevitServerFolders/Models/ExcludedObjectPattern.cs
+++ b/src/RevitServerFolders/Models/ExcludedObjectPattern.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace RevitServerFolders.Models;
+
+internal class ExcludedObjectPattern {
+    /// <summary>
+    /// Идентификатор подстроки.
+    /// </summary>
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>
+    /// Подстрока для скрытия файлов из списка моделей набора.
+    /// </summary>
+    public string Value { get; set; }
+}

--- a/src/RevitServerFolders/Models/ExcludedObjectPattern.cs
+++ b/src/RevitServerFolders/Models/ExcludedObjectPattern.cs
@@ -1,15 +1,48 @@
 using System;
 
+using pyRevitLabs.Json;
+
 namespace RevitServerFolders.Models;
 
-internal class ExcludedObjectPattern {
+internal class ExcludedObjectPattern : IEquatable<ExcludedObjectPattern> {
+    public ExcludedObjectPattern(string value) {
+        if(string.IsNullOrWhiteSpace(value)) {
+            throw new ArgumentException(nameof(value));
+        }
+
+        Id = Guid.NewGuid();
+        Value = value;
+    }
+
     /// <summary>
     /// Идентификатор подстроки.
     /// </summary>
-    public Guid Id { get; set; } = Guid.NewGuid();
+    [JsonProperty(nameof(Id))]
+    public Guid Id { get; }
 
     /// <summary>
     /// Подстрока для скрытия файлов из списка моделей набора.
     /// </summary>
-    public string Value { get; set; }
+    [JsonProperty(nameof(Value))]
+    public string Value { get; }
+
+    public bool Equals(ExcludedObjectPattern other) {
+        if(other is null) {
+            return false;
+        }
+
+        if(ReferenceEquals(this, other)) {
+            return true;
+        }
+
+        return Id.Equals(other.Id);
+    }
+
+    public override bool Equals(object obj) {
+        return Equals(obj as ExcludedObjectPattern);
+    }
+
+    public override int GetHashCode() {
+        return Id.GetHashCode();
+    }
 }

--- a/src/RevitServerFolders/Models/ExportSettings.cs
+++ b/src/RevitServerFolders/Models/ExportSettings.cs
@@ -11,4 +11,9 @@ internal abstract class ExportSettings {
     public bool OpenTargetWhenFinish { get; set; } = true;
     public string[] SkippedObjects { get; set; }
     public bool IsSelected { get; set; } = true;
+
+    /// <summary>
+    /// Подстроки, по которым файлы скрываются из списка моделей набора
+    /// </summary>
+    public ExcludedObjectPattern[] ExcludedObjectPatterns { get; set; } = [];
 }

--- a/src/RevitServerFolders/Models/ExportSettings.cs
+++ b/src/RevitServerFolders/Models/ExportSettings.cs
@@ -13,7 +13,7 @@ internal abstract class ExportSettings {
     public bool IsSelected { get; set; } = true;
 
     /// <summary>
-    /// Подстроки, по которым файлы скрываются из списка моделей набора
+    /// Подстроки, по которым файлы скрываются из списка и снимаются с экспорта
     /// </summary>
     public ExcludedObjectPattern[] ExcludedObjectPatterns { get; set; } = [];
 }

--- a/src/RevitServerFolders/Resources/CustomStyles.xaml
+++ b/src/RevitServerFolders/Resources/CustomStyles.xaml
@@ -15,11 +15,15 @@
         <ResourceDictionary
             Source="pack://application:,,,/Wpf.Ui;component/Controls/GridView/GridViewHeaderRowIndicator.xaml" />
         <ResourceDictionary
+            Source="pack://application:,,,/Wpf.Ui;component/Controls/GridView/GridViewColumnHeader.xaml" />
+        <ResourceDictionary
             Source="pack://application:,,,/Wpf.Ui;component/Controls/Button/Button.xaml" />
         <ResourceDictionary
             Source="pack://application:,,,/Wpf.Ui;component/Resources/Typography.xaml" />
         <ResourceDictionary
             Source="pack://application:,,,/Wpf.Ui;component/Controls/TreeView/TreeViewItem.xaml" />
+        <ResourceDictionary
+            Source="pack://application:,,,/Wpf.Ui;component/Controls/ListView/ListView.xaml" />
         <ResourceDictionary
             Source="pack://application:,,,/Wpf.Ui;component/Controls/ListView/ListViewItem.xaml" />
     </ResourceDictionary.MergedDictionaries>

--- a/src/RevitServerFolders/ViewModels/ExcludedObjectPatternViewModel.cs
+++ b/src/RevitServerFolders/ViewModels/ExcludedObjectPatternViewModel.cs
@@ -1,0 +1,27 @@
+using System;
+
+using dosymep.WPF.ViewModels;
+
+using RevitServerFolders.Models;
+
+namespace RevitServerFolders.ViewModels;
+internal sealed class ExcludedObjectPatternViewModel : BaseViewModel {
+    private readonly ExcludedObjectPattern _excludedObjectPattern;
+
+    public ExcludedObjectPatternViewModel(ExcludedObjectPattern excludedObjectPattern) {
+        _excludedObjectPattern = excludedObjectPattern
+            ?? throw new ArgumentNullException(nameof(excludedObjectPattern));
+    }
+
+    public Guid Id => _excludedObjectPattern.Id;
+
+    public string Value => _excludedObjectPattern.Value;
+
+    public ExcludedObjectPattern GetSettings() {
+        return _excludedObjectPattern;
+    }
+
+    public override string ToString() {
+        return Value;
+    }
+}

--- a/src/RevitServerFolders/ViewModels/ExcludedObjectPatternViewModel.cs
+++ b/src/RevitServerFolders/ViewModels/ExcludedObjectPatternViewModel.cs
@@ -6,7 +6,7 @@ using RevitServerFolders.Models;
 
 namespace RevitServerFolders.ViewModels;
 
-internal sealed class ExcludedObjectPatternViewModel : BaseViewModel, IEquatable<ExcludedObjectPatternViewModel> {
+internal class ExcludedObjectPatternViewModel : BaseViewModel, IEquatable<ExcludedObjectPatternViewModel> {
 
     private readonly ExcludedObjectPattern _excludedObjectPattern;
 

--- a/src/RevitServerFolders/ViewModels/ExcludedObjectPatternViewModel.cs
+++ b/src/RevitServerFolders/ViewModels/ExcludedObjectPatternViewModel.cs
@@ -5,17 +5,19 @@ using dosymep.WPF.ViewModels;
 using RevitServerFolders.Models;
 
 namespace RevitServerFolders.ViewModels;
-internal sealed class ExcludedObjectPatternViewModel : BaseViewModel {
+
+internal sealed class ExcludedObjectPatternViewModel : BaseViewModel, IEquatable<ExcludedObjectPatternViewModel> {
+
     private readonly ExcludedObjectPattern _excludedObjectPattern;
 
     public ExcludedObjectPatternViewModel(ExcludedObjectPattern excludedObjectPattern) {
-        _excludedObjectPattern = excludedObjectPattern
-            ?? throw new ArgumentNullException(nameof(excludedObjectPattern));
+        _excludedObjectPattern =
+            excludedObjectPattern ?? throw new ArgumentNullException(nameof(excludedObjectPattern));
+
+        Value = _excludedObjectPattern.Value;
     }
 
-    public Guid Id => _excludedObjectPattern.Id;
-
-    public string Value => _excludedObjectPattern.Value;
+    public string Value { get; }
 
     public ExcludedObjectPattern GetSettings() {
         return _excludedObjectPattern;
@@ -23,5 +25,25 @@ internal sealed class ExcludedObjectPatternViewModel : BaseViewModel {
 
     public override string ToString() {
         return Value;
+    }
+
+    public bool Equals(ExcludedObjectPatternViewModel other) {
+        if(other is null) {
+            return false;
+        }
+
+        if(ReferenceEquals(this, other)) {
+            return true;
+        }
+
+        return Equals(_excludedObjectPattern, other._excludedObjectPattern);
+    }
+
+    public override bool Equals(object obj) {
+        return Equals(obj as ExcludedObjectPatternViewModel);
+    }
+
+    public override int GetHashCode() {
+        return _excludedObjectPattern.GetHashCode();
     }
 }

--- a/src/RevitServerFolders/ViewModels/ExportSettingsViewModel.cs
+++ b/src/RevitServerFolders/ViewModels/ExportSettingsViewModel.cs
@@ -324,11 +324,17 @@ internal class ExportSettingsViewModel<T> : BaseViewModel where T : ExportSettin
     }
 
     private void AddExcludedObjectPattern() {
-        ExcludedObjectPatterns.Add(
-            new ExcludedObjectPatternViewModel(
-                new ExcludedObjectPattern(ExcludedObjectPatternText.Trim())));
+        var excludedObjectPattern = new ExcludedObjectPattern(ExcludedObjectPatternText.Trim());
+        ExcludedObjectPatterns.Add(new ExcludedObjectPatternViewModel(excludedObjectPattern));
+        SkipObjects(item => Contains(item.FullName, excludedObjectPattern.Value));
         ExcludedObjectPatternText = null;
         ModelObjectsView.View?.Refresh();
+    }
+
+    private void SkipObjects(Func<ModelObjectViewModel, bool> predicate) {
+        foreach(var item in ModelObjects.Where(predicate)) {
+            item.SkipObject = true;
+        }
     }
 
     private bool CanAddExcludedObjectPattern() {
@@ -366,5 +372,7 @@ internal class ExportSettingsViewModel<T> : BaseViewModel where T : ExportSettin
             modelObjectViewModel.SkipObject = skippedObjects?
                 .Contains(modelObjectViewModel.FullName, StringComparer.OrdinalIgnoreCase) == true;
         }
+
+        SkipObjects(IsExcluded);
     }
 }

--- a/src/RevitServerFolders/ViewModels/ExportSettingsViewModel.cs
+++ b/src/RevitServerFolders/ViewModels/ExportSettingsViewModel.cs
@@ -67,8 +67,9 @@ internal class ExportSettingsViewModel<T> : BaseViewModel where T : ExportSettin
         OpenFolderDialogCommand = RelayCommand.Create(OpenFolderDialog);
         SourceFolderChangedCommand = RelayCommand.CreateAsync(SourceFolderChanged);
         ToggleSkipObjectCommand = RelayCommand.Create<ModelObjectViewModel>(ToggleSkipObject);
-        AddExcludedObjectPatternCommand
-            = RelayCommand.Create(AddExcludedObjectPattern, CanAddExcludedObjectPattern);
+        AddExcludedObjectPatternCommand = RelayCommand.Create(
+            AddExcludedObjectPattern,
+            CanAddExcludedObjectPattern);
         RemoveExcludedObjectPatternCommand = RelayCommand.Create<ExcludedObjectPatternViewModel>(
             RemoveExcludedObjectPattern,
             CanRemoveExcludedObjectPattern);
@@ -325,13 +326,13 @@ internal class ExportSettingsViewModel<T> : BaseViewModel where T : ExportSettin
     private void AddExcludedObjectPattern() {
         ExcludedObjectPatterns.Add(
             new ExcludedObjectPatternViewModel(
-                new ExcludedObjectPattern() { Value = ExcludedObjectPatternText.Trim() }));
+                new ExcludedObjectPattern(ExcludedObjectPatternText.Trim())));
         ExcludedObjectPatternText = null;
         ModelObjectsView.View?.Refresh();
     }
 
     private bool CanAddExcludedObjectPattern() {
-        return !string.IsNullOrWhiteSpace(ExcludedObjectPatternText);
+        return !string.IsNullOrWhiteSpace(ExcludedObjectPatternText?.Trim());
     }
 
     private void RemoveExcludedObjectPattern(ExcludedObjectPatternViewModel pattern) {

--- a/src/RevitServerFolders/ViewModels/ExportSettingsViewModel.cs
+++ b/src/RevitServerFolders/ViewModels/ExportSettingsViewModel.cs
@@ -292,15 +292,15 @@ internal class ExportSettingsViewModel<T> : BaseViewModel where T : ExportSettin
 
     private bool MatchesSearch(ModelObjectViewModel item) {
         string searchText = SearchText?.Trim();
-        return string.IsNullOrEmpty(searchText)
+        return string.IsNullOrWhiteSpace(searchText)
                || Contains(item.Name, searchText)
                || Contains(item.FullName, searchText);
     }
 
     private bool Contains(string source, string value) {
-        return !string.IsNullOrEmpty(source)
-               && !string.IsNullOrEmpty(value)
-               && source.IndexOf(value, StringComparison.CurrentCultureIgnoreCase) >= 0;
+        return !string.IsNullOrWhiteSpace(source)
+               && !string.IsNullOrWhiteSpace(value)
+               && source.IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     private ModelObjectViewModel[] GetVisibleObjects() {

--- a/src/RevitServerFolders/ViewModels/ExportSettingsViewModel.cs
+++ b/src/RevitServerFolders/ViewModels/ExportSettingsViewModel.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows.Data;
 using System.Windows.Input;
 
 using dosymep.SimpleServices;
@@ -22,6 +23,8 @@ internal class ExportSettingsViewModel<T> : BaseViewModel where T : ExportSettin
 
     private string _targetFolder;
     private string _sourceFolder;
+    private string _searchText;
+    private string _excludedObjectPatternText;
 
     private ModelObjectViewModel _selectedObject;
 
@@ -45,6 +48,13 @@ internal class ExportSettingsViewModel<T> : BaseViewModel where T : ExportSettin
         _localization = localization
             ?? throw new ArgumentNullException(nameof(localization));
         ModelObjects = [];
+        SelectedObjects = [];
+        ModelObjectsView = new CollectionViewSource() { Source = ModelObjects };
+        ModelObjectsView.Filter += ModelObjectsFilterHandler;
+        ExcludedObjectPatterns = [
+            .. (_settings.ExcludedObjectPatterns ?? [])
+            .Select(item => new ExcludedObjectPatternViewModel(item))
+        ];
         TargetFolder = _settings.TargetFolder;
         SourceFolder = _settings.SourceFolder;
         ClearTargetFolder = _settings.ClearTargetFolder;
@@ -56,8 +66,15 @@ internal class ExportSettingsViewModel<T> : BaseViewModel where T : ExportSettin
         OpenFromFoldersCommand = RelayCommand.CreateAsync(OpenFromFolder);
         OpenFolderDialogCommand = RelayCommand.Create(OpenFolderDialog);
         SourceFolderChangedCommand = RelayCommand.CreateAsync(SourceFolderChanged);
+        ToggleSkipObjectCommand = RelayCommand.Create<ModelObjectViewModel>(ToggleSkipObject);
+        AddExcludedObjectPatternCommand
+            = RelayCommand.Create(AddExcludedObjectPattern, CanAddExcludedObjectPattern);
+        RemoveExcludedObjectPatternCommand = RelayCommand.Create<ExcludedObjectPatternViewModel>(
+            RemoveExcludedObjectPattern,
+            CanRemoveExcludedObjectPattern);
 
         PropertyChanged += OnSourceFolderChanged;
+        PropertyChanged += OnSearchTextChanged;
     }
 
     public IModelObjectService ObjectService { get; }
@@ -67,6 +84,12 @@ internal class ExportSettingsViewModel<T> : BaseViewModel where T : ExportSettin
     public ICommand OpenFolderDialogCommand { get; }
 
     public IAsyncCommand<object> SourceFolderChangedCommand { get; }
+
+    public ICommand ToggleSkipObjectCommand { get; }
+
+    public ICommand AddExcludedObjectPatternCommand { get; }
+
+    public ICommand RemoveExcludedObjectPatternCommand { get; }
 
     public IOpenFolderDialogService OpenFolderDialogService { get; }
 
@@ -111,12 +134,40 @@ internal class ExportSettingsViewModel<T> : BaseViewModel where T : ExportSettin
 
     public ObservableCollection<ModelObjectViewModel> ModelObjects { get; }
 
+    /// <summary>
+    /// Модели, выделенные в таблице
+    /// </summary>
+    public ObservableCollection<ModelObjectViewModel> SelectedObjects { get; }
+
+    /// <summary>
+    /// Отфильтрованное представление <see cref="ModelObjects"/>: поиск и скрытие по подстрокам
+    /// </summary>
+    public CollectionViewSource ModelObjectsView { get; }
+
+    public ObservableCollection<ExcludedObjectPatternViewModel> ExcludedObjectPatterns { get; }
+
+    /// <summary>
+    /// Подстрока для поиска по списку моделей
+    /// </summary>
+    public string SearchText {
+        get => _searchText;
+        set => RaiseAndSetIfChanged(ref _searchText, value);
+    }
+
+    /// <summary>
+    /// Подстрока для скрытия файлов, из которой создается карточка исключения
+    /// </summary>
+    public string ExcludedObjectPatternText {
+        get => _excludedObjectPatternText;
+        set => RaiseAndSetIfChanged(ref _excludedObjectPatternText, value);
+    }
+
     public bool SkipAll {
         get => _skipAll;
         set {
             if(_skipAll != value) {
                 RaiseAndSetIfChanged(ref _skipAll, value);
-                foreach(var item in ModelObjects) {
+                foreach(var item in GetVisibleObjects()) {
                     item.SkipObject = value;
                 }
             }
@@ -144,6 +195,7 @@ internal class ExportSettingsViewModel<T> : BaseViewModel where T : ExportSettin
             .Where(item => item.SkipObject)
             .Select(item => item.FullName)
             .ToArray();
+        _settings.ExcludedObjectPatterns = [.. ExcludedObjectPatterns.Select(item => item.GetSettings())];
         return _settings;
     }
 
@@ -164,7 +216,7 @@ internal class ExportSettingsViewModel<T> : BaseViewModel where T : ExportSettin
             return _localization.GetLocalizedString("MainWindow.Validation.SourceFolderEmpty");
         }
 
-        if(!ModelObjects.Any(item => !item.SkipObject)) {
+        if(ModelObjects.All(item => item.SkipObject)) {
             return _localization.GetLocalizedString("MainWindow.Validation.AllModelsSkipped");
         }
 
@@ -219,6 +271,76 @@ internal class ExportSettingsViewModel<T> : BaseViewModel where T : ExportSettin
             await Task.Delay(250);
             await SourceFolderChangedCommand.ExecuteAsync(default);
         }
+    }
+
+    private void OnSearchTextChanged(object sender, PropertyChangedEventArgs e) {
+        if(e.PropertyName == nameof(SearchText)) {
+            ModelObjectsView.View?.Refresh();
+        }
+    }
+
+    private void ModelObjectsFilterHandler(object sender, FilterEventArgs e) {
+        if(e.Item is ModelObjectViewModel item) {
+            e.Accepted = !IsExcluded(item) && MatchesSearch(item);
+        }
+    }
+
+    private bool IsExcluded(ModelObjectViewModel item) {
+        return ExcludedObjectPatterns.Any(pattern => Contains(item.FullName, pattern.Value));
+    }
+
+    private bool MatchesSearch(ModelObjectViewModel item) {
+        string searchText = SearchText?.Trim();
+        return string.IsNullOrEmpty(searchText)
+               || Contains(item.Name, searchText)
+               || Contains(item.FullName, searchText);
+    }
+
+    private bool Contains(string source, string value) {
+        return !string.IsNullOrEmpty(source)
+               && !string.IsNullOrEmpty(value)
+               && source.IndexOf(value, StringComparison.CurrentCultureIgnoreCase) >= 0;
+    }
+
+    private ModelObjectViewModel[] GetVisibleObjects() {
+        var view = ModelObjectsView.View;
+        return view is null ? [] : [.. view.OfType<ModelObjectViewModel>()];
+    }
+
+    /// <summary>
+    /// Переносит признак пропуска кликнутой модели на все выделенные строки таблицы
+    /// </summary>
+    private void ToggleSkipObject(ModelObjectViewModel item) {
+        if(item is null
+           || !SelectedObjects.Contains(item)) {
+            return;
+        }
+
+        bool skipObject = item.SkipObject;
+        foreach(var selectedObject in SelectedObjects.ToArray()) {
+            selectedObject.SkipObject = skipObject;
+        }
+    }
+
+    private void AddExcludedObjectPattern() {
+        ExcludedObjectPatterns.Add(
+            new ExcludedObjectPatternViewModel(
+                new ExcludedObjectPattern() { Value = ExcludedObjectPatternText.Trim() }));
+        ExcludedObjectPatternText = null;
+        ModelObjectsView.View?.Refresh();
+    }
+
+    private bool CanAddExcludedObjectPattern() {
+        return !string.IsNullOrWhiteSpace(ExcludedObjectPatternText);
+    }
+
+    private void RemoveExcludedObjectPattern(ExcludedObjectPatternViewModel pattern) {
+        ExcludedObjectPatterns.Remove(pattern);
+        ModelObjectsView.View?.Refresh();
+    }
+
+    private bool CanRemoveExcludedObjectPattern(ExcludedObjectPatternViewModel pattern) {
+        return pattern is not null;
     }
 
     private async Task AddModelObjects(ModelObject modelObject) {

--- a/src/RevitServerFolders/Views/MainWindow.xaml
+++ b/src/RevitServerFolders/Views/MainWindow.xaml
@@ -15,6 +15,7 @@
     xmlns:dosymepConverters="clr-namespace:dosymep.WPF.Converters"
     xmlns:pluginConverters="clr-namespace:RevitServerFolders.Converters"
     xmlns:pluginBehaviors="clr-namespace:RevitServerFolders.Behaviors"
+    xmlns:system="clr-namespace:System;assembly=mscorlib"
     mc:Ignorable="d"
     WindowStartupLocation="CenterOwner"
     Height="450"
@@ -48,6 +49,10 @@
                 x:Key="BooleanToVisibilityConverter" />
             <pluginConverters:MiddleEllipsisConverter
                 x:Key="MiddleEllipsisConverter" />
+            <!-- Ширина метки "Куда:/Откуда:" с отступами: вычитается из ширины колонки,
+                 чтобы получить место, доступное под путь -->
+            <system:Double
+                x:Key="TargetsLabelOffset">80</system:Double>
 
             <ui:TextBlock
                 x:Key="TargetsHeader"
@@ -258,8 +263,7 @@
                                                         </i:Interaction.Behaviors>
                                                         <ui:TextBlock.Text>
                                                             <MultiBinding
-                                                                Converter="{StaticResource MiddleEllipsisConverter}"
-                                                                ConverterParameter="85">
+                                                                Converter="{StaticResource MiddleEllipsisConverter}">
                                                                 <Binding
                                                                     Path="TargetFolder" />
                                                                 <Binding
@@ -267,6 +271,8 @@
                                                                 <Binding
                                                                     Path="Columns[2].ActualWidth"
                                                                     RelativeSource="{RelativeSource AncestorType=GridViewRowPresenter}" />
+                                                                <Binding
+                                                                    Source="{StaticResource TargetsLabelOffset}" />
                                                             </MultiBinding>
                                                         </ui:TextBlock.Text>
                                                     </ui:TextBlock>
@@ -285,8 +291,7 @@
                                                         </i:Interaction.Behaviors>
                                                         <ui:TextBlock.Text>
                                                             <MultiBinding
-                                                                Converter="{StaticResource MiddleEllipsisConverter}"
-                                                                ConverterParameter="85">
+                                                                Converter="{StaticResource MiddleEllipsisConverter}">
                                                                 <Binding
                                                                     Path="SourceFolder" />
                                                                 <Binding
@@ -294,6 +299,8 @@
                                                                 <Binding
                                                                     Path="Columns[2].ActualWidth"
                                                                     RelativeSource="{RelativeSource AncestorType=GridViewRowPresenter}" />
+                                                                <Binding
+                                                                    Source="{StaticResource TargetsLabelOffset}" />
                                                             </MultiBinding>
                                                         </ui:TextBlock.Text>
                                                     </ui:TextBlock>

--- a/src/RevitServerFolders/Views/MainWindow.xaml
+++ b/src/RevitServerFolders/Views/MainWindow.xaml
@@ -247,17 +247,24 @@
                                 CanUserSort="True"
                                 Header="№"
                                 Binding="{Binding Index}" />
-                            <DataGridCheckBoxColumn
+                            <DataGridTemplateColumn
                                 CanUserReorder="False"
                                 CanUserResize="False"
                                 CanUserSort="False"
-                                Width="Auto"
-                                Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}">
-                                <DataGridCheckBoxColumn.Header>
+                                Width="Auto">
+                                <DataGridTemplateColumn.Header>
                                     <CheckBox
                                         IsChecked="{Binding DataContext.AllSelected, RelativeSource={RelativeSource AncestorType=ui:DataGrid}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                                </DataGridCheckBoxColumn.Header>
-                            </DataGridCheckBoxColumn>
+                                </DataGridTemplateColumn.Header>
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <CheckBox
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            IsChecked="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
                             <DataGridTemplateColumn
                                 Width="180"
                                 MinWidth="180"

--- a/src/RevitServerFolders/Views/MainWindow.xaml
+++ b/src/RevitServerFolders/Views/MainWindow.xaml
@@ -44,49 +44,24 @@
                     Source="../Resources/CustomStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
-            <ui:SymbolRegular
-                x:Key="DocumentIcon">Document20</ui:SymbolRegular>
-            <ui:SymbolRegular
-                x:Key="FolderIcon">Folder20</ui:SymbolRegular>
-            <ui:SymbolRegular
-                x:Key="BuildingIcon">Building20</ui:SymbolRegular>
-
-            <dosymepConverters:InverseBooleanConverter
-                x:Key="InverseBooleanConverter" />
             <converters:BoolToVisibilityConverter
                 x:Key="BooleanToVisibilityConverter" />
             <pluginConverters:MiddleEllipsisConverter
                 x:Key="MiddleEllipsisConverter" />
-            <pluginConverters:CellImageConverter
-                x:Key="CellImageConverter"
-                Empty="{StaticResource DocumentIcon}"
-                Model="{StaticResource BuildingIcon}"
-                Folder="{StaticResource FolderIcon}" />
 
-            <ui:TextBlock
-                x:Key="NameHeader"
-                Text="{me:LocalizationSource MainWindow.NameHeader}" />
-            <ui:TextBlock
-                x:Key="FullNameHeader"
-                Text="{me:LocalizationSource MainWindow.FullNameHeader}" />
             <ui:TextBlock
                 x:Key="TargetsHeader"
                 Text="{me:LocalizationSource MainWindow.TargetsHeader}" />
 
             <Style
-                x:Key="CustomDataGridTextDisabledStyle"
-                TargetType="TextBlock"
-                BasedOn="{StaticResource DefaultDataGridTextElementStyle}">
-                <Style.Triggers>
-                    <DataTrigger
-                        Value="True"
-                        Binding="{Binding Path=SkipObject}">
-                        <Setter
-                            Property="Foreground"
-                            Value="{DynamicResource TextFillColorDisabledBrush}" />
-                    </DataTrigger>
-                </Style.Triggers>
+                x:Key="NoResizeColumnHeaderStyle"
+                TargetType="GridViewColumnHeader"
+                BasedOn="{StaticResource UiGridViewColumnHeaderStyle}">
+                <Setter
+                    Property="pluginBehaviors:GridViewColumnHeaderProperty.CanUserResize"
+                    Value="False" />
             </Style>
+
             <Style
                 TargetType="DockPanel"
                 x:Key="VisibleOnExecutingPanel">
@@ -206,7 +181,7 @@
             LastChildFill="True"
             Grid.Row="1"
             Grid.Column="0"
-            Margin="10 0 0 0">
+            Margin="8 0 0 0">
             <Border
                 DockPanel.Dock="Bottom"
                 Visibility="{Binding SelectedSettings.IsNwcExport, Converter={StaticResource BooleanToVisibilityConverter}}"
@@ -228,127 +203,121 @@
                 <DockPanel
                     LastChildFill="True">
                     <ui:Button
-                        Margin="0 0 0 10"
+                        Margin="0 0 0 8"
                         DockPanel.Dock="Top"
                         Content="{ui:SymbolIcon Symbol=Add20}"
                         Command="{Binding AddSettingsCommand}" />
-                    <ui:DataGrid
-                        Grid.Row="5"
-                        Margin="5"
-                        Style="{StaticResource CustomResizableDataGridStyle}"
+                    <ui:ListView
+                        Margin="4"
+                        BorderThickness="0"
                         ItemsSource="{Binding SettingsCollection}"
                         SelectedItem="{Binding SelectedSettings}">
-                        <ui:DataGrid.Columns>
-                            <DataGridTextColumn
-                                Width="Auto"
-                                IsReadOnly="True"
-                                CanUserReorder="False"
-                                CanUserResize="False"
-                                CanUserSort="True"
-                                Header="№"
-                                Binding="{Binding Index}" />
-                            <DataGridTemplateColumn
-                                CanUserReorder="False"
-                                CanUserResize="False"
-                                CanUserSort="False"
-                                Width="Auto">
-                                <DataGridTemplateColumn.Header>
-                                    <CheckBox
-                                        IsChecked="{Binding DataContext.AllSelected, RelativeSource={RelativeSource AncestorType=ui:DataGrid}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                                </DataGridTemplateColumn.Header>
-                                <DataGridTemplateColumn.CellTemplate>
-                                    <DataTemplate>
+                        <ui:ListView.View>
+                            <GridView
+                                ColumnHeaderContainerStyle="{StaticResource UiGridViewColumnHeaderStyle}">
+                                <GridViewColumn
+                                    Header="№"
+                                    Width="30"
+                                    HeaderContainerStyle="{StaticResource NoResizeColumnHeaderStyle}"
+                                    DisplayMemberBinding="{Binding Index}" />
+                                <GridViewColumn
+                                    HeaderContainerStyle="{StaticResource NoResizeColumnHeaderStyle}">
+                                    <GridViewColumn.Header>
                                         <CheckBox
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Center"
-                                            IsChecked="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                                    </DataTemplate>
-                                </DataGridTemplateColumn.CellTemplate>
-                            </DataGridTemplateColumn>
-                            <DataGridTemplateColumn
-                                Width="180"
-                                MinWidth="180"
-                                Header="{StaticResource TargetsHeader}">
-                                <DataGridTemplateColumn.CellTemplate>
-                                    <DataTemplate>
-                                        <StackPanel
-                                            Height="50"
-                                            Margin="5 2">
-                                            <DockPanel
-                                                Margin="0 0 0 5">
-                                                <ui:TextBlock
-                                                    Width="55"
-                                                    Margin="0 0 5 0"
-                                                    Foreground="{DynamicResource LabelForeground}"
-                                                    Text="{Binding TargetToLabel}" />
-                                                <ui:TextBlock
-                                                    Foreground="{DynamicResource LabelForeground}"
-                                                    ToolTip="{Binding TargetFolder}">
-                                                    <i:Interaction.Behaviors>
-                                                        <pluginBehaviors:TextBlockResizeHelper />
-                                                    </i:Interaction.Behaviors>
-                                                    <ui:TextBlock.Text>
-                                                        <MultiBinding
-                                                            Converter="{StaticResource MiddleEllipsisConverter}">
-                                                            <Binding
-                                                                Path="TargetFolder" />
-                                                            <Binding
-                                                                RelativeSource="{RelativeSource Self}" />
-                                                            <Binding
-                                                                RelativeSource="{RelativeSource Self}"
-                                                                Path="ActualWidth" />
-                                                        </MultiBinding>
-                                                    </ui:TextBlock.Text>
-                                                </ui:TextBlock>
-                                            </DockPanel>
-                                            <DockPanel>
-                                                <ui:TextBlock
-                                                    Width="55"
-                                                    Margin="0 0 5 0"
-                                                    Foreground="{DynamicResource LabelForeground}"
-                                                    Text="{Binding TargetFromLabel}" />
-                                                <ui:TextBlock
-                                                    Foreground="{DynamicResource LabelForeground}"
-                                                    ToolTip="{Binding SourceFolder}">
-                                                    <i:Interaction.Behaviors>
-                                                        <pluginBehaviors:TextBlockResizeHelper />
-                                                    </i:Interaction.Behaviors>
-                                                    <ui:TextBlock.Text>
-                                                        <MultiBinding
-                                                            Converter="{StaticResource MiddleEllipsisConverter}">
-                                                            <Binding
-                                                                Path="SourceFolder" />
-                                                            <Binding
-                                                                RelativeSource="{RelativeSource Self}" />
-                                                            <Binding
-                                                                RelativeSource="{RelativeSource Self}"
-                                                                Path="ActualWidth" />
-                                                        </MultiBinding>
-                                                    </ui:TextBlock.Text>
-                                                </ui:TextBlock>
-                                            </DockPanel>
-                                        </StackPanel>
-                                    </DataTemplate>
-                                </DataGridTemplateColumn.CellTemplate>
-                            </DataGridTemplateColumn>
-                            <DataGridTemplateColumn
-                                CanUserReorder="False"
-                                CanUserResize="False"
-                                CanUserSort="False"
-                                Width="Auto">
-                                <DataGridTemplateColumn.CellTemplate>
-                                    <DataTemplate>
-                                        <ui:Button
-                                            Appearance="Danger"
-                                            Content="{ui:SymbolIcon Symbol=Delete20}"
-                                            Command="{Binding DataContext.RemoveSettingsCommand,
+                                            IsChecked="{Binding DataContext.AllSelected, RelativeSource={RelativeSource AncestorType=ui:ListView}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    </GridViewColumn.Header>
+                                    <GridViewColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <CheckBox
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"
+                                                IsChecked="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                        </DataTemplate>
+                                    </GridViewColumn.CellTemplate>
+                                </GridViewColumn>
+                                <GridViewColumn
+                                    Width="180"
+                                    Header="{StaticResource TargetsHeader}">
+                                    <GridViewColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <StackPanel
+                                                Height="50"
+                                                Margin="4 2">
+                                                <DockPanel
+                                                    Margin="0 0 0 4">
+                                                    <ui:TextBlock
+                                                        Width="55"
+                                                        Margin="0 0 4 0"
+                                                        Foreground="{DynamicResource LabelForeground}"
+                                                        Text="{Binding TargetToLabel}" />
+                                                    <ui:TextBlock
+                                                        Foreground="{DynamicResource LabelForeground}"
+                                                        ToolTip="{Binding TargetFolder}">
+                                                        <i:Interaction.Behaviors>
+                                                            <pluginBehaviors:TextBlockResizeHelper />
+                                                        </i:Interaction.Behaviors>
+                                                        <ui:TextBlock.Text>
+                                                            <MultiBinding
+                                                                Converter="{StaticResource MiddleEllipsisConverter}"
+                                                                ConverterParameter="85">
+                                                                <Binding
+                                                                    Path="TargetFolder" />
+                                                                <Binding
+                                                                    RelativeSource="{RelativeSource Self}" />
+                                                                <Binding
+                                                                    Path="Columns[2].ActualWidth"
+                                                                    RelativeSource="{RelativeSource AncestorType=GridViewRowPresenter}" />
+                                                            </MultiBinding>
+                                                        </ui:TextBlock.Text>
+                                                    </ui:TextBlock>
+                                                </DockPanel>
+                                                <DockPanel>
+                                                    <ui:TextBlock
+                                                        Width="55"
+                                                        Margin="0 0 4 0"
+                                                        Foreground="{DynamicResource LabelForeground}"
+                                                        Text="{Binding TargetFromLabel}" />
+                                                    <ui:TextBlock
+                                                        Foreground="{DynamicResource LabelForeground}"
+                                                        ToolTip="{Binding SourceFolder}">
+                                                        <i:Interaction.Behaviors>
+                                                            <pluginBehaviors:TextBlockResizeHelper />
+                                                        </i:Interaction.Behaviors>
+                                                        <ui:TextBlock.Text>
+                                                            <MultiBinding
+                                                                Converter="{StaticResource MiddleEllipsisConverter}"
+                                                                ConverterParameter="85">
+                                                                <Binding
+                                                                    Path="SourceFolder" />
+                                                                <Binding
+                                                                    RelativeSource="{RelativeSource Self}" />
+                                                                <Binding
+                                                                    Path="Columns[2].ActualWidth"
+                                                                    RelativeSource="{RelativeSource AncestorType=GridViewRowPresenter}" />
+                                                            </MultiBinding>
+                                                        </ui:TextBlock.Text>
+                                                    </ui:TextBlock>
+                                                </DockPanel>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </GridViewColumn.CellTemplate>
+                                </GridViewColumn>
+                                <GridViewColumn
+                                    HeaderContainerStyle="{StaticResource NoResizeColumnHeaderStyle}">
+                                    <GridViewColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <ui:Button
+                                                Appearance="Danger"
+                                                Content="{ui:SymbolIcon Symbol=Delete20}"
+                                                Command="{Binding DataContext.RemoveSettingsCommand,
                         RelativeSource={RelativeSource AncestorType=Window}}"
-                                            CommandParameter="{Binding}" />
-                                    </DataTemplate>
-                                </DataGridTemplateColumn.CellTemplate>
-                            </DataGridTemplateColumn>
-                        </ui:DataGrid.Columns>
-                    </ui:DataGrid>
+                                                CommandParameter="{Binding}" />
+                                        </DataTemplate>
+                                    </GridViewColumn.CellTemplate>
+                                </GridViewColumn>
+                            </GridView>
+                        </ui:ListView.View>
+                    </ui:ListView>
                 </DockPanel>
             </Border>
         </DockPanel>
@@ -383,12 +352,12 @@
             Orientation="Horizontal"
             HorizontalAlignment="Right">
             <ui:TextBlock
-                Margin="10"
+                Margin="8"
                 Style="{StaticResource CustomErrorText}"
                 Text="{Binding ErrorText}" />
 
             <ui:Button
-                Margin="10"
+                Margin="8"
                 Width="80"
                 Appearance="Info"
                 IsDefault="True"
@@ -397,7 +366,7 @@
                 Command="{Binding AcceptViewCommand}" />
 
             <ui:Button
-                Margin="10"
+                Margin="8"
                 Width="80"
                 IsCancel="True"
                 Click="ButtonCancel_Click"

--- a/src/RevitServerFolders/Views/NwcExportViewSettingsDialog.xaml
+++ b/src/RevitServerFolders/Views/NwcExportViewSettingsDialog.xaml
@@ -76,7 +76,7 @@
                     <ui:Button
                         Width="Auto"
                         Height="36"
-                        Margin="10 0"
+                        Margin="8 0"
                         DockPanel.Dock="Right"
                         HorizontalAlignment="Right"
                         ToolTip="{me:LocalizationSource NwcExportViewSettingsDialog.SelectRsRvtTooltip}"
@@ -87,7 +87,7 @@
                         Text="{Binding RvtFilePath, UpdateSourceTrigger=PropertyChanged}" />
                 </DockPanel>
                 <Label
-                    Margin="0 10 0 0"
+                    Margin="0 8 0 0"
                     Content="{me:LocalizationSource NwcExportViewSettingsDialog.ViewTemplateNameLabel}" />
                 <ui:TextBox
                     Text="{Binding ViewTemplateName, UpdateSourceTrigger=PropertyChanged}" />
@@ -96,7 +96,7 @@
 
         <Border
             Grid.Row="1"
-            Margin="0 10 0 0"
+            Margin="0 8 0 0"
             ToolTip="{me:LocalizationSource NwcExportViewSettingsDialog.WorksetsTooltip}"
             Style="{StaticResource CustomBorder}">
             <DockPanel
@@ -122,7 +122,7 @@
                         CommandParameter="{Binding SelectedWorksetHideTemplate}" />
                 </DockPanel>
                 <ui:ListView
-                    Margin="0 5 0 0"
+                    Margin="0 4 0 0"
                     Height="250"
                     ScrollViewer.VerticalScrollBarVisibility="Auto"
                     ItemsSource="{Binding WorksetHideTemplates}"
@@ -132,7 +132,7 @@
                             <DockPanel
                                 LastChildFill="True">
                                 <ui:Button
-                                    Margin="5 0 0 0"
+                                    Margin="4 0 0 0"
                                     Width="Auto"
                                     Height="36"
                                     DockPanel.Dock="Right"

--- a/src/RevitServerFolders/Views/SettingsView.xaml
+++ b/src/RevitServerFolders/Views/SettingsView.xaml
@@ -63,6 +63,9 @@
             <ui:TextBlock
                 x:Key="TargetsHeader"
                 Text="{me:LocalizationSource MainWindow.TargetsHeader}" />
+            <ui:TextBlock
+                x:Key="RemoveExcludedObjectPatternTooltip"
+                Text="{me:LocalizationSource MainWindow.RemoveExcludedObjectPatternTooltip}" />
 
             <Style
                 x:Key="CustomDataGridTextDisabledStyle"
@@ -158,54 +161,152 @@
             Grid.Row="1"
             Style="{StaticResource CustomBorder}">
 
-            <ui:DataGrid
-                Grid.Row="5"
-                Margin="5"
-                RowHeight="33"
-                Style="{StaticResource CustomResizableDataGridStyle}"
-                CellStyle="{StaticResource CustomDataGridCell}"
-                ItemsSource="{Binding ModelObjects}"
-                SelectedItem="{Binding SelectedObject}">
+            <DockPanel
+                LastChildFill="True">
 
-                <ui:DataGrid.Columns>
-                    <DataGridCheckBoxColumn
-                        CanUserReorder="False"
-                        CanUserResize="False"
-                        CanUserSort="False"
+                <DockPanel
+                    DockPanel.Dock="Top"
+                    Margin="5 0 5 5"
+                    LastChildFill="True">
+                    <ui:Button
+                        DockPanel.Dock="Right"
                         Width="Auto"
-                        Binding="{Binding SkipObject, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InverseBooleanConverter}}">
-                        <DataGridCheckBoxColumn.Header>
-                            <CheckBox
-                                IsChecked="{Binding DataContext.SkipAll, RelativeSource={RelativeSource AncestorType=ui:DataGrid}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InverseBooleanConverter}}" />
-                        </DataGridCheckBoxColumn.Header>
-                    </DataGridCheckBoxColumn>
-                    <DataGridTemplateColumn
-                        CanUserReorder="False"
-                        CanUserResize="False"
-                        CanUserSort="False"
-                        Width="Auto">
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate>
-                                <ui:SymbolIcon
-                                    Symbol="{Binding ., Converter={StaticResource CellImageConverter}}" />
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>
-                    <DataGridTextColumn
+                        Height="36"
+                        Margin="5 0 0 0"
+                        ToolTip="{me:LocalizationSource MainWindow.AddExcludedObjectPatternTooltip}"
+                        Content="{ui:SymbolIcon Symbol=Add20}"
+                        Command="{Binding AddExcludedObjectPatternCommand}" />
+                    <ui:TextBox
+                        DockPanel.Dock="Right"
                         Width="250"
-                        IsReadOnly="True"
-                        MinWidth="100"
-                        ElementStyle="{StaticResource CustomDataGridTextDisabledStyle}"
-                        Binding="{Binding Name}"
-                        Header="{StaticResource NameHeader}" />
-                    <DataGridTextColumn
-                        IsReadOnly="True"
-                        MinWidth="100"
-                        ElementStyle="{StaticResource CustomDataGridTextDisabledStyle}"
-                        Binding="{Binding FullName}"
-                        Header="{StaticResource FullNameHeader}" />
-                </ui:DataGrid.Columns>
-            </ui:DataGrid>
+                        Margin="10 0 0 0"
+                        ToolTip="{me:LocalizationSource MainWindow.ExcludedObjectPatternTooltip}"
+                        PlaceholderText="{me:LocalizationSource MainWindow.ExcludedObjectPatternPlaceholder}"
+                        Text="{Binding ExcludedObjectPatternText, UpdateSourceTrigger=PropertyChanged}">
+                        <ui:TextBox.InputBindings>
+                            <KeyBinding
+                                Key="Return"
+                                Command="{Binding AddExcludedObjectPatternCommand}" />
+                        </ui:TextBox.InputBindings>
+                    </ui:TextBox>
+                    <ui:TextBox
+                        Icon="{ui:SymbolIcon Symbol=Search20}"
+                        PlaceholderText="{me:LocalizationSource MainWindow.SearchPlaceholder}"
+                        Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+                </DockPanel>
+
+                <ItemsControl
+                    DockPanel.Dock="Top"
+                    Margin="5 0 5 5"
+                    ItemsSource="{Binding ExcludedObjectPatterns}">
+                    <ItemsControl.Style>
+                        <Style
+                            TargetType="ItemsControl">
+                            <Style.Triggers>
+                                <DataTrigger
+                                    Binding="{Binding ExcludedObjectPatterns.Count}"
+                                    Value="0">
+                                    <Setter
+                                        Property="Visibility"
+                                        Value="Collapsed" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ItemsControl.Style>
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <WrapPanel
+                                FlowDirection="RightToLeft" />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border
+                                Margin="5 2 0 2"
+                                FlowDirection="LeftToRight"
+                                Style="{StaticResource CustomBorder}">
+                                <StackPanel
+                                    Orientation="Horizontal">
+                                    <ui:TextBlock
+                                        VerticalAlignment="Center"
+                                        ToolTip="{Binding Value}"
+                                        Text="{Binding Value}" />
+                                    <ui:Button
+                                        Margin="5 0 0 0"
+                                        Padding="4"
+                                        Width="Auto"
+                                        Appearance="Transparent"
+                                        ToolTip="{StaticResource RemoveExcludedObjectPatternTooltip}"
+                                        Content="{ui:SymbolIcon Symbol=Dismiss12}"
+                                        Command="{Binding DataContext.RemoveExcludedObjectPatternCommand,
+                        RelativeSource={RelativeSource AncestorType=local:SettingsView}}"
+                                        CommandParameter="{Binding}" />
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <ui:DataGrid
+                    Margin="5"
+                    RowHeight="33"
+                    SelectionMode="Extended"
+                    Style="{StaticResource CustomResizableDataGridStyle}"
+                    CellStyle="{StaticResource CustomDataGridCell}"
+                    pluginBehaviors:DataGridSelectedItemsProperty.SelectedItems="{Binding SelectedObjects}"
+                    ItemsSource="{Binding ModelObjectsView.View}"
+                    SelectedItem="{Binding SelectedObject}">
+
+                    <ui:DataGrid.Columns>
+                        <DataGridTemplateColumn
+                            CanUserReorder="False"
+                            CanUserResize="False"
+                            CanUserSort="False"
+                            Width="Auto">
+                            <DataGridTemplateColumn.Header>
+                                <CheckBox
+                                    IsChecked="{Binding DataContext.SkipAll, RelativeSource={RelativeSource AncestorType=ui:DataGrid}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InverseBooleanConverter}}" />
+                            </DataGridTemplateColumn.Header>
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <CheckBox
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        IsChecked="{Binding SkipObject, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InverseBooleanConverter}}"
+                                        Command="{Binding DataContext.ToggleSkipObjectCommand,
+                        RelativeSource={RelativeSource AncestorType=ui:DataGrid}}"
+                                        CommandParameter="{Binding}" />
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTemplateColumn
+                            CanUserReorder="False"
+                            CanUserResize="False"
+                            CanUserSort="False"
+                            Width="Auto">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <ui:SymbolIcon
+                                        Symbol="{Binding ., Converter={StaticResource CellImageConverter}}" />
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTextColumn
+                            Width="250"
+                            IsReadOnly="True"
+                            MinWidth="100"
+                            ElementStyle="{StaticResource CustomDataGridTextDisabledStyle}"
+                            Binding="{Binding Name}"
+                            Header="{StaticResource NameHeader}" />
+                        <DataGridTextColumn
+                            IsReadOnly="True"
+                            MinWidth="100"
+                            ElementStyle="{StaticResource CustomDataGridTextDisabledStyle}"
+                            Binding="{Binding FullName}"
+                            Header="{StaticResource FullNameHeader}" />
+                    </ui:DataGrid.Columns>
+                </ui:DataGrid>
+            </DockPanel>
         </Border>
     </Grid>
 </core:WpfUIPlatformUserControl>

--- a/src/RevitServerFolders/Views/SettingsView.xaml
+++ b/src/RevitServerFolders/Views/SettingsView.xaml
@@ -60,12 +60,6 @@
             <ui:TextBlock
                 x:Key="FullNameHeader"
                 Text="{me:LocalizationSource MainWindow.FullNameHeader}" />
-            <ui:TextBlock
-                x:Key="TargetsHeader"
-                Text="{me:LocalizationSource MainWindow.TargetsHeader}" />
-            <ui:TextBlock
-                x:Key="RemoveExcludedObjectPatternTooltip"
-                Text="{me:LocalizationSource MainWindow.RemoveExcludedObjectPatternTooltip}" />
 
             <Style
                 x:Key="CustomDataGridTextDisabledStyle"
@@ -91,7 +85,7 @@
                 Height="*" />
         </Grid.RowDefinitions>
         <Border
-            Margin="0 0 10 5"
+            Margin="0 0 8 4"
             Grid.Row="0"
             Style="{StaticResource CustomBorder}">
             <StackPanel>
@@ -100,7 +94,7 @@
                         Width="130"
                         Text="{me:LocalizationSource MainWindow.LabelTarget}" />
                     <ui:ToggleSwitch
-                        Margin="5 0"
+                        Margin="8 0"
                         IsChecked="{Binding ClearTargetFolder}"
                         Content="{me:LocalizationSource MainWindow.ClearTarget}" />
                     <ui:ToggleSwitch
@@ -108,36 +102,36 @@
                         Content="{me:LocalizationSource MainWindow.OpenTargetWhenFinish}" />
                 </DockPanel>
                 <DockPanel
-                    Margin="0 5"
+                    Margin="0 4"
                     LastChildFill="True">
                     <ui:Button
                         DockPanel.Dock="Right"
                         Height="36"
-                        Margin="5 0 0 0"
+                        Margin="4 0 0 0"
                         Content="{ui:SymbolIcon Symbol=Folder20}"
                         Command="{Binding OpenFolderDialogCommand}" />
                     <ui:TextBox
                         Text="{Binding TargetFolder, UpdateSourceTrigger=PropertyChanged}" />
                 </DockPanel>
                 <DockPanel
-                    Margin="0 5 0 0">
+                    Margin="0 4 0 0">
                     <ui:TextBlock
                         Width="130"
                         Text="{me:LocalizationSource MainWindow.LabelSource}" />
                     <ui:ToggleSwitch
-                        Margin="5 0"
+                        Margin="4 0"
                         Content="{me:LocalizationSource MainWindow.ExportRooms}"
                         IsChecked="{Binding IsExportRooms}"
                         Visibility="{Binding IsNwcExport, 
             Converter={StaticResource BooleanToVisibilityConverter}}" />
                 </DockPanel>
                 <DockPanel
-                    Margin="0 5 0 0"
+                    Margin="0 4 0 0"
                     LastChildFill="True">
                     <ui:Button
                         DockPanel.Dock="Right"
                         Height="36"
-                        Margin="5 0 0 0"
+                        Margin="4 0 0 0"
                         Content="{ui:SymbolIcon Symbol=Folder20}"
                         IsEnabled="{Binding SourceFolderChangedCommand.IsExecuting,
                 Converter={StaticResource InverseBooleanConverter}}"
@@ -145,7 +139,7 @@
                     <ui:Button
                         DockPanel.Dock="Right"
                         Height="36"
-                        Margin="5 0 0 0"
+                        Margin="4 0 0 0"
                         Visibility="{Binding IsNwcExport, Converter={StaticResource InverseBooleanToVisibilityConverter}}"
                         Content="{ui:SymbolIcon Symbol=ArrowSync20}"
                         Command="{Binding SourceFolderChangedCommand}" />
@@ -157,7 +151,7 @@
         </Border>
 
         <Border
-            Margin="0 5 10 0"
+            Margin="0 4 8 0"
             Grid.Row="1"
             Style="{StaticResource CustomBorder}">
 
@@ -166,20 +160,20 @@
 
                 <DockPanel
                     DockPanel.Dock="Top"
-                    Margin="5 0 5 5"
-                    LastChildFill="True">
-                    <ui:Button
-                        DockPanel.Dock="Right"
-                        Width="Auto"
-                        Height="36"
-                        Margin="5 0 0 0"
-                        ToolTip="{me:LocalizationSource MainWindow.AddExcludedObjectPatternTooltip}"
-                        Content="{ui:SymbolIcon Symbol=Add20}"
-                        Command="{Binding AddExcludedObjectPatternCommand}" />
+                    Margin="4 0 4 4"
+                    LastChildFill="False">
                     <ui:TextBox
                         DockPanel.Dock="Right"
+                        MinWidth="300"
+                        MaxWidth="300"
+                        Margin="8 0 0 0"
+                        HorizontalAlignment="Right"
+                        Icon="{ui:SymbolIcon Symbol=Search20}"
+                        PlaceholderText="{me:LocalizationSource MainWindow.SearchPlaceholder}"
+                        Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+                    <ui:TextBox
+                        DockPanel.Dock="Left"
                         Width="250"
-                        Margin="10 0 0 0"
                         ToolTip="{me:LocalizationSource MainWindow.ExcludedObjectPatternTooltip}"
                         PlaceholderText="{me:LocalizationSource MainWindow.ExcludedObjectPatternPlaceholder}"
                         Text="{Binding ExcludedObjectPatternText, UpdateSourceTrigger=PropertyChanged}">
@@ -189,15 +183,19 @@
                                 Command="{Binding AddExcludedObjectPatternCommand}" />
                         </ui:TextBox.InputBindings>
                     </ui:TextBox>
-                    <ui:TextBox
-                        Icon="{ui:SymbolIcon Symbol=Search20}"
-                        PlaceholderText="{me:LocalizationSource MainWindow.SearchPlaceholder}"
-                        Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+                    <ui:Button
+                        DockPanel.Dock="Left"
+                        Width="Auto"
+                        Height="36"
+                        Margin="4 0 0 0"
+                        ToolTip="{me:LocalizationSource MainWindow.AddExcludedObjectPatternTooltip}"
+                        Content="{ui:SymbolIcon Symbol=Add20}"
+                        Command="{Binding AddExcludedObjectPatternCommand}" />
                 </DockPanel>
 
                 <ItemsControl
                     DockPanel.Dock="Top"
-                    Margin="5 0 5 5"
+                    Margin="4 0 4 4"
                     ItemsSource="{Binding ExcludedObjectPatterns}">
                     <ItemsControl.Style>
                         <Style
@@ -215,15 +213,13 @@
                     </ItemsControl.Style>
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
-                            <WrapPanel
-                                FlowDirection="RightToLeft" />
+                            <WrapPanel />
                         </ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Border
-                                Margin="5 2 0 2"
-                                FlowDirection="LeftToRight"
+                                Margin="0 2 4 2"
                                 Style="{StaticResource CustomBorder}">
                                 <StackPanel
                                     Orientation="Horizontal">
@@ -232,14 +228,14 @@
                                         ToolTip="{Binding Value}"
                                         Text="{Binding Value}" />
                                     <ui:Button
-                                        Margin="5 0 0 0"
+                                        Margin="4 0 0 0"
                                         Padding="4"
                                         Width="Auto"
                                         Appearance="Transparent"
-                                        ToolTip="{StaticResource RemoveExcludedObjectPatternTooltip}"
+                                        ToolTip="{me:LocalizationSource MainWindow.RemoveExcludedObjectPatternTooltip}"
                                         Content="{ui:SymbolIcon Symbol=Dismiss12}"
                                         Command="{Binding DataContext.RemoveExcludedObjectPatternCommand,
-                        RelativeSource={RelativeSource AncestorType=local:SettingsView}}"
+                        RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                         CommandParameter="{Binding}" />
                                 </StackPanel>
                             </Border>
@@ -248,7 +244,7 @@
                 </ItemsControl>
 
                 <ui:DataGrid
-                    Margin="5"
+                    Margin="4"
                     RowHeight="33"
                     SelectionMode="Extended"
                     Style="{StaticResource CustomResizableDataGridStyle}"

--- a/src/RevitServerFolders/assets/Localization/Language.en-US.xaml
+++ b/src/RevitServerFolders/assets/Localization/Language.en-US.xaml
@@ -89,6 +89,16 @@
         x:Key="MainWindow.TargetsFrom">From:</system:String>
     <system:String
         x:Key="MainWindow.TargetsTo">To:</system:String>
+    <system:String
+        x:Key="MainWindow.SearchPlaceholder">Search files</system:String>
+    <system:String
+        x:Key="MainWindow.ExcludedObjectPatternPlaceholder">String for hiding files</system:String>
+    <system:String
+        x:Key="MainWindow.ExcludedObjectPatternTooltip">Files whose full name contains the specified string with ignore case are hidden from the list. Hiding does not affect the export: a file with a checked box will be exported.</system:String>
+    <system:String
+        x:Key="MainWindow.AddExcludedObjectPatternTooltip">Add exclusion</system:String>
+    <system:String
+        x:Key="MainWindow.RemoveExcludedObjectPatternTooltip">Remove exclusion</system:String>
 
     <system:String
         x:Key="NwcExportViewSettingsDialog.Title">View Settings for NWC Export</system:String>

--- a/src/RevitServerFolders/assets/Localization/Language.en-US.xaml
+++ b/src/RevitServerFolders/assets/Localization/Language.en-US.xaml
@@ -94,9 +94,9 @@
     <system:String
         x:Key="MainWindow.ExcludedObjectPatternPlaceholder">String for hiding files</system:String>
     <system:String
-        x:Key="MainWindow.ExcludedObjectPatternTooltip">Files whose full name contains the specified string with ignore case are hidden from the list. Hiding does not affect the export: a file with a checked box will be exported.</system:String>
+        x:Key="MainWindow.ExcludedObjectPatternTooltip">Files whose full name contains the specified string with ignore case are hidden from the list and get unchecked, so that a hidden file does not end up in the export. The list of strings is saved in the setting.</system:String>
     <system:String
-        x:Key="MainWindow.AddExcludedObjectPatternTooltip">Add exclusion</system:String>
+        x:Key="MainWindow.AddExcludedObjectPatternTooltip">Add exclusion and uncheck the files it hides</system:String>
     <system:String
         x:Key="MainWindow.RemoveExcludedObjectPatternTooltip">Remove exclusion</system:String>
 

--- a/src/RevitServerFolders/assets/Localization/Language.ru-RU.xaml
+++ b/src/RevitServerFolders/assets/Localization/Language.ru-RU.xaml
@@ -94,9 +94,9 @@
     <system:String
         x:Key="MainWindow.ExcludedObjectPatternPlaceholder">Подстрока для скрытия файлов</system:String>
     <system:String
-        x:Key="MainWindow.ExcludedObjectPatternTooltip">Файлы, в полном наименовании которых есть заданная подстрока без учета регистра, скрываются из списка. Скрытие не влияет на экспорт: файл со включенной галкой будет выгружен.</system:String>
+        x:Key="MainWindow.ExcludedObjectPatternTooltip">Файлы, в полном наименовании которых есть заданная подстрока без учета регистра, скрываются из списка и отключаются от экспорта. Список подстрок сохраняется в настройках.</system:String>
     <system:String
-        x:Key="MainWindow.AddExcludedObjectPatternTooltip">Добавить исключение</system:String>
+        x:Key="MainWindow.AddExcludedObjectPatternTooltip">Добавить исключение и выключить экспорт файлов</system:String>
     <system:String
         x:Key="MainWindow.RemoveExcludedObjectPatternTooltip">Удалить исключение</system:String>
 

--- a/src/RevitServerFolders/assets/Localization/Language.ru-RU.xaml
+++ b/src/RevitServerFolders/assets/Localization/Language.ru-RU.xaml
@@ -89,6 +89,16 @@
         x:Key="MainWindow.TargetsFrom">Откуда:</system:String>
     <system:String
         x:Key="MainWindow.TargetsTo">Куда:</system:String>
+    <system:String
+        x:Key="MainWindow.SearchPlaceholder">Поиск по файлам</system:String>
+    <system:String
+        x:Key="MainWindow.ExcludedObjectPatternPlaceholder">Подстрока для скрытия файлов</system:String>
+    <system:String
+        x:Key="MainWindow.ExcludedObjectPatternTooltip">Файлы, в полном наименовании которых есть заданная подстрока без учета регистра, скрываются из списка. Скрытие не влияет на экспорт: файл со включенной галкой будет выгружен.</system:String>
+    <system:String
+        x:Key="MainWindow.AddExcludedObjectPatternTooltip">Добавить исключение</system:String>
+    <system:String
+        x:Key="MainWindow.RemoveExcludedObjectPatternTooltip">Удалить исключение</system:String>
 
     <system:String
         x:Key="NwcExportViewSettingsDialog.Title">Настройки вида для экспорта в NWC</system:String>


### PR DESCRIPTION
# Обновления

  1.  Реализовано групповое переключение чекбокса для выделенных экспортируемых файлов
  2. Добавлен поиск по подстроке для списка экспортируемых файлов
  3. Добавлен функционал для скрытия файлов по подстрокам. Отфильтрованные модели также снимаются с экспорта (автоматом снимается `CheckBox`)
  4. При переключении галочки для включения настроек эти настройки экспорта не становятся активными и не начинают загружаться

<img width="1200" src="https://github.com/user-attachments/assets/5e6fca6f-8c83-4610-a76d-ceaa6ee59406" />

