### PR TITLE
RevitMarkAllDocuments: Исправлено получение названия документа

### DIFF
--- a/src/RevitMarkAllDocuments/Services/DocumentService.cs
+++ b/src/RevitMarkAllDocuments/Services/DocumentService.cs
@@ -10,25 +10,7 @@ internal class DocumentService : IDocumentInterface {
     private static readonly string[] _endings = ["_отсоединено", "_detached"];
 
     public string GetDocumentFullName(Document document) {
-        if(document.IsWorkshared) {
-            var modelPath = document.GetWorksharingCentralModelPath();
-            if(modelPath != null) {
-                string path = ModelPathUtils.ConvertModelPathToUserVisiblePath(modelPath);
-                string name = ExtractFileName(path);
-                if(!string.IsNullOrEmpty(name)) {
-                    return name;
-                }
-            }
-        }
-
-        return GetTitleWithoutSuffixes(document);
-    }
-
-    /// <summary>
-    /// Возвращает имя документа без суффикса пользователя и суффикса "отсоединено"
-    /// </summary>
-    private string GetTitleWithoutSuffixes(Document document) {
-        string name = Path.GetFileNameWithoutExtension(document.Title);
+        string name = document.Title;
         string[] endings = [.. _endings, "_" + document.Application.Username];
 
         foreach(string ending in endings) {
@@ -39,17 +21,5 @@ internal class DocumentService : IDocumentInterface {
         }
 
         return name;
-    }
-
-    private string ExtractFileName(string path) {
-        if(string.IsNullOrEmpty(path)) {
-            return string.Empty;
-        }
-
-        path = path.Replace('\\', '/');
-
-        string lastSegment = path.Split('/').LastOrDefault();
-
-        return Path.GetFileNameWithoutExtension(lastSegment);
     }
 }


### PR DESCRIPTION
# Обновления

- Свойство `Document.Title` в 2022 версии и выше не содержит расширение файла в конце, отбрасывать вручную его не нужно.