### PR TITLE
RevitBatchPrint: Заменена сортировка листов

### DIFF
--- a/src/RevitBatchPrint/Comparators/NamingComparator.cs
+++ b/src/RevitBatchPrint/Comparators/NamingComparator.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+using Autodesk.Revit.DB;
+
+namespace RevitBatchPrint.Comparators;
+
+internal sealed class NamingComparator : IComparer<string> {
+    public int Compare(string x, string y) {
+        if(ReferenceEquals(x, y)) {
+            return 0;
+        }
+
+        if(string.IsNullOrEmpty(x)) {
+            return -1;
+        }
+
+        if(string.IsNullOrEmpty(y)) {
+            return 1;
+        }
+
+        return NamingUtils.CompareNames(x, y);
+    }
+}

--- a/src/RevitBatchPrint/ViewModels/MainViewModel.cs
+++ b/src/RevitBatchPrint/ViewModels/MainViewModel.cs
@@ -9,12 +9,11 @@ using System.Windows.Input;
 using Autodesk.Revit.DB;
 
 using dosymep.Bim4Everyone;
-using dosymep.Revit;
-using dosymep.Revit.Comparators;
 using dosymep.SimpleServices;
 using dosymep.WPF.Commands;
 using dosymep.WPF.ViewModels;
 
+using RevitBatchPrint.Comparators;
 using RevitBatchPrint.Extensions;
 using RevitBatchPrint.Models;
 using RevitBatchPrint.Services;
@@ -337,10 +336,9 @@ internal class MainViewModel : BaseViewModel, IPrintContext, IExportContext {
     private SheetViewModel[] CreateSheetCollection(
         AlbumViewModel album,
         IEnumerable<(ViewSheet ViewSheet, FamilyInstance TitleBlock, Viewport[] Viewports)> sheetsInfo) {
-        LogicalStringComparer comparer = new();
         return sheetsInfo
             .Select(item => CreateSheet(album, item))
-            .OrderBy(item => item.SheetNumber, comparer)
+            .OrderBy(item => item.SheetNumber, new NamingComparator())
             .ToArray();
     }
 


### PR DESCRIPTION
- заменил сортировку листов с сортировки как в "Проводнике" на как в "Revit"

<details>
  <summary>Было (как в проводнике)</summary>
  
<img width="356" height="304" alt="image" src="https://github.com/user-attachments/assets/269e758b-a392-4200-a04c-e9966ede1d13" />
  
</details>

<details>
  <summary>Стало (как в Revit)</summary>
  
<img width="356" height="304" alt="image" src="https://github.com/user-attachments/assets/9ea6019d-bd2e-43b7-a795-c1b1fdfd591f" />
  
</details>



