### PR TITLE
RevitAxonometryView: Предупреждение при выборе "Имя системы"

### DIFF
--- a/src/RevitAxonometryViews/ViewModels/MainViewModel.cs
+++ b/src/RevitAxonometryViews/ViewModels/MainViewModel.cs
@@ -104,14 +104,9 @@ internal class MainViewModel : BaseViewModel {
     public string SelectedCriteria {
         get => _selectedCriteria;
         set {
-            bool showSystemNameWarning = _selectedCriteria != value
-                                         && value == _axonometryConfig.SystemName;
+            string previousCriteria = _selectedCriteria;
             RaiseAndSetIfChanged(ref _selectedCriteria, value);
-            UpdateFilteredView();
-
-            if(showSystemNameWarning) {
-                ShowSystemNameWarning();
-            }
+            OnSelectedCriteriaChanged(previousCriteria);
         }
     }
 
@@ -139,10 +134,21 @@ internal class MainViewModel : BaseViewModel {
 
     private void ShowSystemNameWarning() {
         MessageBoxService.Show(
-            _localizationService.GetLocalizedString("MainWindow.SystemNameWarning"),
+            _localizationService.GetLocalizedString(
+                "MainWindow.SystemNameWarning",
+                _axonometryConfig.SharedVisSystemName),
             _localizationService.GetLocalizedString("MainWindow.WarningTitle"),
             MessageBoxButton.OK,
             MessageBoxImage.Warning);
+    }
+
+    private void OnSelectedCriteriaChanged(string previousCriteria) {
+        UpdateFilteredView();
+
+        if(previousCriteria != SelectedCriteria
+           && SelectedCriteria == _axonometryConfig.SystemName) {
+            ShowSystemNameWarning();
+        }
     }
 
     /// <summary>

--- a/src/RevitAxonometryViews/ViewModels/MainViewModel.cs
+++ b/src/RevitAxonometryViews/ViewModels/MainViewModel.cs
@@ -31,6 +31,7 @@ internal class MainViewModel : BaseViewModel {
         RevitRepository revitRepository,
         ViewFactory viewFactory,
         CollectorOperator collectorOperator,
+        IMessageBoxService messageBoxService,
         ILocalizationService localizationService) {
         _revitRepository = revitRepository;
         _viewFactory = viewFactory;
@@ -39,6 +40,7 @@ internal class MainViewModel : BaseViewModel {
         _hvacSystems = GetHvacSystems();
         _selectedCriteria = _axonometryConfig.SystemName;
         _localizationService = localizationService;
+        MessageBoxService = messageBoxService;
 
         _filterValue = string.Empty;
         _selectedCriteria = _axonometryConfig.SharedVisSystemName;
@@ -58,6 +60,7 @@ internal class MainViewModel : BaseViewModel {
 
     public ICommand LoadViewCommand { get; }
     public ICommand AcceptViewCommand { get; }
+    public IMessageBoxService MessageBoxService { get; }
 
     /// <summary>
     /// Отфильтрованный список систем, выводящийся на ГУИ
@@ -101,8 +104,14 @@ internal class MainViewModel : BaseViewModel {
     public string SelectedCriteria {
         get => _selectedCriteria;
         set {
+            bool showSystemNameWarning = _selectedCriteria != value
+                                         && value == _axonometryConfig.SystemName;
             RaiseAndSetIfChanged(ref _selectedCriteria, value);
             UpdateFilteredView();
+
+            if(showSystemNameWarning) {
+                ShowSystemNameWarning();
+            }
         }
     }
 
@@ -126,6 +135,14 @@ internal class MainViewModel : BaseViewModel {
             SelectedCriteria,
             UseOneView,
             _revitRepository));
+    }
+
+    private void ShowSystemNameWarning() {
+        MessageBoxService.Show(
+            _localizationService.GetLocalizedString("MainWindow.SystemNameWarning"),
+            _localizationService.GetLocalizedString("MainWindow.WarningTitle"),
+            MessageBoxButton.OK,
+            MessageBoxImage.Warning);
     }
 
     /// <summary>

--- a/src/RevitAxonometryViews/Views/MainWindow.xaml
+++ b/src/RevitAxonometryViews/Views/MainWindow.xaml
@@ -12,6 +12,7 @@
     xmlns:core="clr-namespace:dosymep.WpfUI.Core"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:me="clr-namespace:dosymep.WpfCore.MarkupExtensions;assembly=dosymep.WpfCore"
+    xmlns:wpfbehaviors="clr-namespace:dosymep.WpfCore.Behaviors;assembly=dosymep.WpfCore"
     
     mc:Ignorable="d"
     WindowStartupLocation="CenterScreen"
@@ -23,6 +24,11 @@
     Width="900"
     
     d:DataContext="{d:DesignInstance vms:MainViewModel, IsDesignTimeCreatable=False}">
+
+    <b:Interaction.Behaviors>
+        <wpfbehaviors:WpfAttachServiceBehavior
+            AttachableService="{Binding MessageBoxService}" />
+    </b:Interaction.Behaviors>
 
     <Window.Resources>
         <ResourceDictionary>

--- a/src/RevitAxonometryViews/assets/localization/Language.en-US.xaml
+++ b/src/RevitAxonometryViews/assets/localization/Language.en-US.xaml
@@ -14,6 +14,6 @@
     <system:String x:Key="MainWindow.WarningTitle">Warning</system:String>
     <system:String x:Key="MainWindow.SystemNameWarning" xml:space="preserve">
 WARNING: Filters based on the system parameter "System Name" will not work with elements nested in families.
-Use "ФОП_ВИС_Имя системы" whenever possible.
+Use "{0}" whenever possible.
     </system:String>
 </ResourceDictionary>

--- a/src/RevitAxonometryViews/assets/localization/Language.en-US.xaml
+++ b/src/RevitAxonometryViews/assets/localization/Language.en-US.xaml
@@ -11,5 +11,9 @@
     <system:String x:Key="MainWindow.FilterParameterTooltip">The name of the parameter by which filtering will be performed</system:String>
     <system:String x:Key="MainWindow.VariantsString">&lt;Variants&gt;</system:String>
     <system:String x:Key="MainWindow.EmptyName">System name empty</system:String>
-   
+    <system:String x:Key="MainWindow.WarningTitle">Warning</system:String>
+    <system:String x:Key="MainWindow.SystemNameWarning" xml:space="preserve">
+WARNING: Filters based on the system parameter "System Name" will not work with elements nested in families.
+Use "ФОП_ВИС_Имя системы" whenever possible.
+    </system:String>
 </ResourceDictionary>

--- a/src/RevitAxonometryViews/assets/localization/Language.ru-RU.xaml
+++ b/src/RevitAxonometryViews/assets/localization/Language.ru-RU.xaml
@@ -14,6 +14,6 @@
     <system:String x:Key="MainWindow.WarningTitle">Предупреждение</system:String>
     <system:String x:Key="MainWindow.SystemNameWarning" xml:space="preserve">
 ВНИМАНИЕ: Фильтры, построенные по системному параметру "Имя системы", не будут работать с вложенными в семейства элементами. 
-Используйте "ФОП_ВИС_Имя системы", если это возможно.
+Используйте "{0}", если это возможно.
     </system:String>
 </ResourceDictionary>

--- a/src/RevitAxonometryViews/assets/localization/Language.ru-RU.xaml
+++ b/src/RevitAxonometryViews/assets/localization/Language.ru-RU.xaml
@@ -11,5 +11,9 @@
     <system:String x:Key="MainWindow.FilterParameterTooltip">Имя параметра, по которому будет выполняться фильтрация.</system:String>
     <system:String x:Key="MainWindow.VariantsString">&lt;Варианты&gt;</system:String>
     <system:String x:Key="MainWindow.EmptyName">Нет системы</system:String>
-
+    <system:String x:Key="MainWindow.WarningTitle">Предупреждение</system:String>
+    <system:String x:Key="MainWindow.SystemNameWarning" xml:space="preserve">
+ВНИМАНИЕ: Фильтры, построенные по системному параметру "Имя системы", не будут работать с вложенными в семейства элементами. 
+Используйте "ФОП_ВИС_Имя системы", если это возможно.
+    </system:String>
 </ResourceDictionary>


### PR DESCRIPTION
По обратной связи было выявлено непонимание проблем связанных с использованием системного параметра. Добавлено предупреждение в явном виде. 