### PR TITLE
RevitUnmodelingMepUpdate: Правила группирования строк

### DIFF
--- a/src/RevitUnmodelingMep/Models/Unmodeling/DraftRowsBuilder.cs
+++ b/src/RevitUnmodelingMep/Models/Unmodeling/DraftRowsBuilder.cs
@@ -95,7 +95,9 @@ internal sealed class DraftRowsBuilder {
                     Unit = unit
                 };
 
-                string key = $"{config.Grouping}_{system}_{economicFunction}_{name}_{mark}_{code}_{maker}";
+                string key = 
+                    $"{smrParams.Block}_{smrParams.Section}_{smrParams.Floor}_{config.Grouping}_{system}"
+                    + $"_{economicFunction}_{name}_{mark}_{code}_{maker}";
                 if(!elementsByGrouping.TryGetValue(key, out List<NewRowElement> groupingElements)) {
                     groupingElements = new List<NewRowElement>();
                     elementsByGrouping[key] = groupingElements;


### PR DESCRIPTION
Обновлено правило группирования строк немоделируемых, теперь идет учет СМР блока-секции-этажа.