### PR TITLE
RevitListOfSchedules: Исправление метода получения имени спецификации

### DIFF
--- a/src/RevitListOfSchedules/Models/InstancesAssembly.cs
+++ b/src/RevitListOfSchedules/Models/InstancesAssembly.cs
@@ -4,22 +4,19 @@ using System.Linq;
 
 using Autodesk.Revit.DB;
 
-using dosymep.Bim4Everyone;
 using dosymep.Revit;
 using dosymep.SimpleServices;
 
 namespace RevitListOfSchedules.Models;
 internal class InstancesAssembly {
-    private readonly ILocalizationService _localizationService;
     private readonly IList<string> _approvedLines;
     private readonly RevitRepository _revitRepository;
 
     public InstancesAssembly(
         ILocalizationService localizationService,
         RevitRepository revitRepository) {
-        _localizationService = localizationService;
         _revitRepository = revitRepository;
-        string localizedApprovedLines = _localizationService.GetLocalizedString("InstancesAssembly.ApprovedLines");
+        string localizedApprovedLines = localizationService.GetLocalizedString("InstancesAssembly.ApprovedLines");
         _approvedLines = localizedApprovedLines
             .Split([','], StringSplitOptions.RemoveEmptyEntries)
             .Select(s => s.Trim())
@@ -39,7 +36,7 @@ internal class InstancesAssembly {
         var headData = tableData.GetSectionData(SectionType.Header);
 
         // Спецификации без шапки не учитываем
-        if(headData == null || headData.HideSection)
+        if(headData is null || headData.HideSection)
             continue;
 
         // Шапка должна содержать хотя бы одну ячейку
@@ -48,26 +45,32 @@ internal class InstancesAssembly {
 
         string resultScheduleName = null;
 
-        // Сначала ищем подходящее имя среди ячеек шапки
-        for(int i = headData.FirstRowNumber; 
-            i < headData.FirstRowNumber + headData.NumberOfRows && resultScheduleName == null; i++) {
-            for(int j = headData.FirstColumnNumber; j < headData.FirstColumnNumber + headData.NumberOfColumns && resultScheduleName == null; j++) {
-                string cellText = headData.GetCellText(i, j);
+        for (int rowIndex = headData.FirstRowNumber; rowIndex <= headData.LastRowNumber; rowIndex++) {
+            for (int columnIndex = headData.FirstColumnNumber; columnIndex <= headData.LastColumnNumber; columnIndex++) {
+                
+                string cellText = schedule.GetCellText(SectionType.Header, rowIndex, columnIndex);
 
-                if(!string.IsNullOrEmpty(cellText) && _approvedLines.Any(x => cellText.ToLower().Contains(x.ToLower()))) {
-                    resultScheduleName = cellText;
+                if(string.IsNullOrEmpty(cellText) || !_approvedLines.Any(x => cellText.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0)) {
+                    continue;
                 }
-            }
-        }
 
-        // Если в шапке ничего подходящего нет,
-        // проверяем название самой спецификации
-        if(resultScheduleName == null && _approvedLines.Any(x => schedule.Name.ToLower().Contains(x.ToLower()))) {
+                resultScheduleName = cellText;
+                break;
+            }
+
+            if (resultScheduleName is not null)
+                break;
+        }
+        
+        System.Windows.MessageBox.Show(resultScheduleName);
+
+        // Если в шапке ничего подходящего нет, проверяем название самой спецификации
+        if(resultScheduleName is null && _approvedLines.Any(x => schedule.Name.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0)) {
             resultScheduleName = schedule.Name;
         }
 
         // Если нашли подходящее имя — размещаем
-        if(resultScheduleName != null) {
+        if(resultScheduleName is not null) {
             PlaceFamilyInstance(sheetNumber, sheetRevNumber, resultScheduleName, familySymbol, viewDrafting, albumName);
         }
     }

--- a/src/RevitListOfSchedules/Models/InstancesAssembly.cs
+++ b/src/RevitListOfSchedules/Models/InstancesAssembly.cs
@@ -36,12 +36,14 @@ internal class InstancesAssembly {
         var headData = tableData.GetSectionData(SectionType.Header);
 
         // Спецификации без шапки не учитываем
-        if(headData is null || headData.HideSection)
+        if(headData is null || headData.HideSection) {
             continue;
+        }
 
         // Шапка должна содержать хотя бы одну ячейку
-        if(headData.NumberOfRows < 1 || headData.NumberOfColumns < 1)
+        if(headData.NumberOfRows < 1 || headData.NumberOfColumns < 1) {
             continue;
+        }
 
         string resultScheduleName = null;
 
@@ -58,8 +60,9 @@ internal class InstancesAssembly {
                 break;
             }
 
-            if (resultScheduleName is not null)
+            if(resultScheduleName is not null) {
                 break;
+            }
         }
 
         // Если в шапке ничего подходящего нет, проверяем название самой спецификации

--- a/src/RevitListOfSchedules/Models/InstancesAssembly.cs
+++ b/src/RevitListOfSchedules/Models/InstancesAssembly.cs
@@ -61,8 +61,6 @@ internal class InstancesAssembly {
             if (resultScheduleName is not null)
                 break;
         }
-        
-        System.Windows.MessageBox.Show(resultScheduleName);
 
         // Если в шапке ничего подходящего нет, проверяем название самой спецификации
         if(resultScheduleName is null && _approvedLines.Any(x => schedule.Name.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0)) {

--- a/src/RevitListOfSchedules/Models/InstancesAssembly.cs
+++ b/src/RevitListOfSchedules/Models/InstancesAssembly.cs
@@ -27,41 +27,51 @@ internal class InstancesAssembly {
     }
 
     public void PlaceFamilyInstances(
-        string sheetNumber,
-        string sheetRevNumber,
-        IList<ViewSchedule> listOfSchedules,
-        FamilySymbol familySymbol,
-        ViewDrafting viewDrafting,
-        string albumName) {
-        foreach(var schedule in listOfSchedules) {
-            var tableData = schedule.GetTableData();
-            var headData = tableData.GetSectionData(SectionType.Header);
+    string sheetNumber,
+    string sheetRevNumber,
+    IList<ViewSchedule> listOfSchedules,
+    FamilySymbol familySymbol,
+    ViewDrafting viewDrafting,
+    string albumName) {
+        
+    foreach(var schedule in listOfSchedules) {
+        var tableData = schedule.GetTableData();
+        var headData = tableData.GetSectionData(SectionType.Header);
 
-            if(headData != null && !headData.HideSection) {
-                string resultScheduleName = null;
-                bool found = false;
+        // Спецификации без шапки не учитываем
+        if(headData == null || headData.HideSection)
+            continue;
 
-                for(int i = headData.FirstRowNumber; i < headData.NumberOfRows && !found; i++) {
-                    for(int j = headData.FirstColumnNumber; j < headData.NumberOfColumns && !found; j++) {
-                        string cellText = headData.GetCellText(i, j);
-                        if(_approvedLines.Any(cellText.ToLower().Contains)) {
-                            resultScheduleName = cellText;
-                            found = true;
-                        }
-                    }
-                }
-                if(found) {
-                    PlaceFamilyInstance(sheetNumber, sheetRevNumber, resultScheduleName, familySymbol, viewDrafting, albumName);
-                } else if(!found
-                    && headData.NumberOfRows == 1
-                    && headData.NumberOfColumns == 1
-                    && string.IsNullOrEmpty(headData.GetCellText(0, 0))) {
+        // Шапка должна содержать хотя бы одну ячейку
+        if(headData.NumberOfRows < 1 || headData.NumberOfColumns < 1)
+            continue;
 
-                    PlaceFamilyInstance(sheetNumber, sheetRevNumber, schedule.Name, familySymbol, viewDrafting, albumName);
+        string resultScheduleName = null;
+
+        // Сначала ищем подходящее имя среди ячеек шапки
+        for(int i = headData.FirstRowNumber; 
+            i < headData.FirstRowNumber + headData.NumberOfRows && resultScheduleName == null; i++) {
+            for(int j = headData.FirstColumnNumber; j < headData.FirstColumnNumber + headData.NumberOfColumns && resultScheduleName == null; j++) {
+                string cellText = headData.GetCellText(i, j);
+
+                if(!string.IsNullOrEmpty(cellText) && _approvedLines.Any(x => cellText.ToLower().Contains(x.ToLower()))) {
+                    resultScheduleName = cellText;
                 }
             }
         }
+
+        // Если в шапке ничего подходящего нет,
+        // проверяем название самой спецификации
+        if(resultScheduleName == null && _approvedLines.Any(x => schedule.Name.ToLower().Contains(x.ToLower()))) {
+            resultScheduleName = schedule.Name;
+        }
+
+        // Если нашли подходящее имя — размещаем
+        if(resultScheduleName != null) {
+            PlaceFamilyInstance(sheetNumber, sheetRevNumber, resultScheduleName, familySymbol, viewDrafting, albumName);
+        }
     }
+}
 
     public void PlaceFamilyInstance(
         string sheetNumber,

--- a/src/RevitListOfSchedules/ViewModels/MainViewModel.cs
+++ b/src/RevitListOfSchedules/ViewModels/MainViewModel.cs
@@ -391,7 +391,7 @@ internal class MainViewModel : BaseViewModel {
             }
             if(_isCreateScheduleChecked) {
                 _revitRepository.CreateSchedule($"{ParamFactory.DefaultScheduleName}_{albumName}");
-                _revitRepository.ActiveUIDocument.GetActiveUIView().Close();
+                //_revitRepository.ActiveUIDocument.GetActiveUIView().Close();
             }
         }
         t.Commit();

--- a/src/RevitListOfSchedules/ViewModels/MainViewModel.cs
+++ b/src/RevitListOfSchedules/ViewModels/MainViewModel.cs
@@ -391,7 +391,6 @@ internal class MainViewModel : BaseViewModel {
             }
             if(_isCreateScheduleChecked) {
                 _revitRepository.CreateSchedule($"{ParamFactory.DefaultScheduleName}_{albumName}");
-                //_revitRepository.ActiveUIDocument.GetActiveUIView().Close();
             }
         }
         t.Commit();


### PR DESCRIPTION
Исправление ошибки получения спецификации. Теперь, если в шапке спецификации нет одобренной строки типа "Спецификация", "Ведомость" и т.д., будет браться системное имя спецификации